### PR TITLE
Fix phrasing to indicate that price data beyond the time frontier is not accessible

### DIFF
--- a/01 Key Concepts/05 Understanding Time/03 Batch vs Stream Analysis.html
+++ b/01 Key Concepts/05 Understanding Time/03 Batch vs Stream Analysis.html
@@ -5,5 +5,5 @@ Backtesting platforms come in two general varieties, batch processing or event s
 <p>Batch processing backtesting is much simpler and simply loads all data into an array, and passes it to your algorithm for analysis. Because your algorithm has access to future datapoints it is easy to introduce a look-ahead bias. Most home-grown analysis tools are batch systems.</p>
 
 <p>
-QuantConnect/LEAN is a streaming analysis system. In live trading, data points are generated one after another over time. QuantConnect models this in backtesting, streaming data to your algorithm in fast-forward. Because of this, you do not have access to price data before the Time Frontier. Although streaming analysis is slightly trickier to understand, it allows your algorithm to seamlessly work in backtests and live trading with no code changes. 
+QuantConnect/LEAN is a streaming analysis system. In live trading, data points are generated one after another over time. QuantConnect models this in backtesting, streaming data to your algorithm in fast-forward. Because of this, you do not have access to price data beyond the Time Frontier. Although streaming analysis is slightly trickier to understand, it allows your algorithm to seamlessly work in backtests and live trading with no code changes. 
 </p>


### PR DESCRIPTION
The statement 'you **do not have access** to price data **before** the Time Frontier' is in direct conflict with the previous section which states 'your algorithm **is only permitted** to access values of securities from **before** this Time Frontier'. It seems like 'before' in section 3 should actually be 'beyond' (or perhaps even 'after').