### PR TITLE
Remove extra 'the' in the 'what is a symbol' section

### DIFF
--- a/01 Key Concepts/06 Security Identifiers/02 What Is A Symbol%3F.html
+++ b/01 Key Concepts/06 Security Identifiers/02 What Is A Symbol%3F.html
@@ -1,5 +1,5 @@
 <p>
-Symbols have several public properties you can use to identify the asset uniquely. The when serialized together this class allows unique identification of millions of different security objects, all within a self-contained reference. 
+Symbols have several public properties you can use to identify the asset uniquely. When serialized together this class allows unique identification of millions of different security objects, all within a self-contained reference. 
 </p>
 <img src="https://cdn.quantconnect.com/alpha/docs/i/what-is-symbol_rev0.png" class="img-responsive"/>
 <div class="section-example-container">


### PR DESCRIPTION
Seems like a typo.