### PR TITLE
Write Trading Economics Documentation

### DIFF
--- a/07 Data Library/07 Trading Economics/00.html
+++ b/07 Data Library/07 Trading Economics/00.html
@@ -1,0 +1,4 @@
+<style>.work-in-progress{width:100%;border:1px solid #f5ae29;border-radius:5px;padding:15px;color:#f5ae29}.tip{width:100%;border:1px solid #f5ae29;border-radius:5px;padding:15px;margin-bottom:20px;margin-top:20px}.tip i{color:#f5ae29}.tip-title{font-weight:bold;color:#f5ae29;margin-left:5px;margin-right:5px}.tip p{display:inline}table th i{color:#f5ae29}th.summary{font-family:"Courier New";font-weight:normal}.table.qc-table tbody tr td{text-align:left}.implementation{font-family:"Courier New"}</style>
+<div class="work-in-progress"> 
+    <i class="fa fa-warning"></i> Updated August 28th, 2019: This data source is only supported in backtesting
+</div></div>

--- a/07 Data Library/07 Trading Economics/01 Introduction.html
+++ b/07 Data Library/07 Trading Economics/01 Introduction.html
@@ -1,0 +1,42 @@
+<meta name="tag" content="using data">
+<meta name="tag" content="using custom data">
+<meta name="tag" content="custom data">
+<meta name="tag" content="adddata">
+<meta name="tag" content="trading economics">
+<meta name="tag" content="fed interest rates">
+<meta name="tag" content="economic indicators">
+<meta name="tag" content="tradingeconomics">
+<p>
+    QuantConnect provides Trading Economics calendar and indicator data for use in your algorithms. 
+    Trading Economics is a provider of economic event announcements and economic report data. 
+    An example use of the data is using it to factor in interest rate changes or unemployment report announcements
+    to rebalance your portfolio. 
+</p>
+<p>
+    QuantConnect hosts Trading Economics data dating back to around 2013. Trading Economics supports various countries, but only the USA interest rate symbol is defined for now.
+</p>
+<p>
+    To subscribe to Trading Economics data, use the <code>AddData</code> method with the data source you'd like information about.
+</p>
+<p>
+    Valid values for the type parameter in <code>AddData</code> are:
+<ul>
+    <li><code>TradingEconomicsCalendar</code></li>
+    <li><code>TradingEconomicsIndicator</code></li>
+</ul>
+</p>
+<p>
+    Here's an example on adding TradingEconomicsCalendar data to your algorithm:
+    <div class="section-example-container">
+    	<pre class="csharp">
+            // Adding TradingEconomicsCalendar interest rate data to the algorithm
+            AddData&lt;TradingEconomicsCalendar&gt;(TradingEconomics.Calendar.UnitedStates.InterestRate);
+        </pre>
+    	<pre class="python">
+            # Adding TradingEconomicsCalendar interest rate data to the algorithm
+            self.AddData(TradingEconomicsCalendar, TradingEconomics.Calendar.UnitedStates.InterestRate);
+        </pre>
+    </div>
+
+    Note: Due to the nature of this data, you'll have to add the data sources manually in order to use the data.
+</p>

--- a/07 Data Library/07 Trading Economics/02 Handling Data.html
+++ b/07 Data Library/07 Trading Economics/02 Handling Data.html
@@ -1,0 +1,64 @@
+<p>
+    We recommend that you store the Symbol object that is accessible from the <code>Security</code> type
+    returned from the <code>AddData</code> call. Reasons for doing so are:
+
+    <ol>
+        <li>You can reference the custom data symbol directly for use in other methods</li>
+        <li>It makes accessing data from <code>Slice</code> easier</li>
+        <li>Allows you to remove the custom data subscription later if you're not using it anymore</li>
+    </ol>
+
+    <span>Note:</span> special care must be taken with adding TradingEconomics data. The AddData method currently assumes
+    that the data timezone (i.e. the timezone the data is stored in) is America/New_York. We need to make sure
+    that we use UTC because the data is stored in UTC.
+</p>
+<p>
+    In order to store your custom data symbol, you can do the following:
+
+    <div class="section-example-container">
+    	<pre class="csharp">
+            // Storing a symbol object to a List&lt;Symbol&gt; defined as a class member variable
+            public class TradingEconomicsCalendarAlgorithm : QCAlgorithm 
+            {
+                // Can be private or public
+                private List&lt;Symbol&gt; _customDataSymbols = new List&lt;Symbol&gt;();
+
+                public void Initialize() 
+                {
+                    var calendars = new List&lt;string&gt; 
+                    {
+                        TradingEconomics.Calendar.UnitedStates.InterestRate,
+                        // ...
+                    };
+
+                    foreach (var calendar in calendars) 
+                    {
+                        var tickerSymbol = AddData&lt;TradingEconomicsCalendar&gt;(calendar, Resolution.Daily, TimeZones.Utc).Symbol;
+                        _customDataSymbols.Add(tickerSymbol);
+                    }
+                }
+
+                public void OnData(Slice slice) 
+                {
+                    // ...
+                }
+            }
+        </pre>
+    	<pre class="python">
+            # Storing a symbol object to a list defined as a class member variable
+            class TradingEconomicsCalendarAlgorithm(QCAlgorithm):
+                def Initialize():
+                    calendars = [TradingEconomics.Calendar.UnitedStates.InterestRate]
+
+                    self.customDataSymbols = [self.AddData(TradingEconomicsCalendar, calendar, Resolution.Daily, TimeZones.Utc).Symbol for calendar in calendars]
+
+                def OnData(slice):
+                    # ...
+                    pass
+        </pre>
+    </div>
+</p>
+<p>
+    After you've stored your symbol object, you can access data from the <code>Slice</code> object using the stored symbol object, similar to how you would load equity data.
+    Please see the <a href="/docs/algorithm-reference/handling-data">Handling Data</a> documentation section for more information on how to access your data using a symbol object.
+</p>

--- a/07 Data Library/07 Trading Economics/03 Data Shape and Properties.html
+++ b/07 Data Library/07 Trading Economics/03 Data Shape and Properties.html
@@ -1,0 +1,59 @@
+<p>
+    Trading Economics data is stored as a flat, single-line JSON file on disk. Data can be accessed using either one of the types using AddData:
+    
+    <ul>
+        <li>$[TradingEconomicsCalendar,T:QuantConnect.Data.Custom.TradingEconomics]</li>
+        <li>$[TradingEconomicsIndicator,T:QuantConnect.Data.Custom.TradingEconomics]</li>
+    </ul>
+
+    You can see the available fields for both Calendar and Indicator data by clicking the type name in the list above.
+</p>
+<p>
+    Trading Economics data is separated into two distinct categories: Calendar, and Indicator. The calendar category contains the announcements and results
+    of economic events, whereas Indicators only contain the most recent value parsable as a decimal. An example of Calendar data is U.S. fed interest rate announcements.
+    Calendar data will contain the announced actual value, the predicted value (by Wall St. and Trading Economics), and the previous value. Indicator data is similar to calendar
+    data, but contains numeric values instead of hard to parse values.
+</p>
+<p>
+    Accessible ticker values for Calendar and Indicator data for <code>AddData</code> can be seen on <a href="https://github.com/QuantConnect/Lean/blob/master/Common/Data/Custom/TradingEconomics/TradingEconomics.cs">GitHub</a>
+</p>
+<p>
+    Because calendar data sometimes has unclean values for the fields: <code>"Actual", "Previous", "Forecast", "TEForecast"</code>,
+    you'll have to clean the string and then parse as decimal/float. To do this, we recommend doing the following:
+
+    <div class="section-example-container">
+    	<pre class="csharp">
+            var inBillions = calendarData.Forecast.Contains("B");
+            var inMillions = calendarData.Forecast.Contains("M");
+
+            var formattedForecast = calendarData.Forecast.Replace("%", "").Replace("$", "");
+            var forecast = 0;
+
+            if (inBillions) 
+            {
+                forecast = Convert.ToDeicmal(formattedForecast.Replace("B", ""), CultureInfo.InvariantCulture) * 1000000000;
+            }
+            else if (inMillions) 
+            {
+                forecast = Convert.ToDecimal(formattedForecast.Replace("M", ""), CultureInfo.InvariantCulture) * 1000000;
+            }
+            else 
+            {
+                forecast = Convert.ToDecimal(formattedForecast, CultureInfo.InvariantCulture);
+            }
+        </pre>
+    	<pre class="python">
+            inBillions = "B" in calendarData.Forecast
+            inMillions = "M" in calendarData.Forecast
+
+            if inBillions:
+                forecast = float(calendarData.Forecast.replace("%", "").replace("B", "").replace("$", ""))
+                forecast = forecast * 1000000000
+            elif inMillions
+                forecast = float(calendarData.Forecast.replace("%", "").replace("M", "").replace("$", ""))
+                forecast = forecast * 1000000
+            else:
+                forecast = float(calendarData.Forecast.replace("%", "").replace("$", ""))
+        </pre>
+    </div>
+</p>

--- a/07 Data Library/07 Trading Economics/04 About the Provider.html
+++ b/07 Data Library/07 Trading Economics/04 About the Provider.html
@@ -1,0 +1,11 @@
+<p>
+    <a href="https://tradingeconomics.com/">
+        <span style="font-size: 18px; color: #dddddd; line-height: 17px; font-weight: bold; text-decoration: none; padding-top: 2px; vertical-align: bottom;">TRADING</span>
+        <br />
+        <span style="font-size: 20px; padding-left: 2px; line-height: 14px; font-weight: bold; text-decoration: none; color: #858585; text-shadow: 0 1px 0 #FFFFFF; padding-top: 0px; vertical-align: bottom;">ECONOMICS</span>
+    </a>
+
+    Trading Economics provides indicator, calendar, government bonds, equities, and commodity data for 196 countries.
+    Data is sourced from official, non-third party sources. They provide more than 20 million indicators, which are manually
+    checked for any errors and inconsistencies. You can find out more about Trading Economics at <a href="https://tradingeconomics.com/about-te.aspx">https://tradingeconomics.com/about-te.aspx</a>
+</p>


### PR DESCRIPTION
This is a rough draft for Trading Economics documentation. Any suggestions/criticisms are welcome. If you have any doubts about Trading Economics data, or have any additional questions about it, let me know and I'll address it by adding it to the documentation 👍 

That being said, I have a few notes about the documentation:

* In the about the provider section, the styling for the TE logo is sourced from their website
* Fairly limited in scope. I believe we need a "handling custom data" section separate from this branch
* Did not add in the table for all Trading Economics values, since it's super massive and would cause the page to be super massive. Instead, I linked to the relevant source code file.