### PR TITLE
Fixing a grammatical error in Setting Indicators

### DIFF
--- a/02 Algorithm Reference/02 Initializing Algorithms/05 Setting Indicators.html
+++ b/02 Algorithm Reference/02 Initializing Algorithms/05 Setting Indicators.html
@@ -1,4 +1,4 @@
 <p>
-	Indicators should be create and warmed up in <code>Initialize()</code> method in most applications.
+	Indicators should be created and warmed up in <code>Initialize()</code> method in most applications.
 	For more details, please see <a class="docs-internal-link" href="/docs/algorithm-reference/indicators">Indicators</a> section.
 </p>


### PR DESCRIPTION
Fixed a grammatical error I noticed while reading through the docs.