### PR TITLE
Fixing a grammatical error in Setting Time Zone

### DIFF
--- a/02 Algorithm Reference/02 Initializing Algorithms/09 Setting Time Zone.html
+++ b/02 Algorithm Reference/02 Initializing Algorithms/09 Setting Time Zone.html
@@ -23,7 +23,7 @@ self.SetTimeZone(TimeZones.Chicago)
 </pre>
 </div>
 <p>
-    The algorithm $[TimeZone, P:QuantConnect.Algorithm.QCAlgorithm.TimeZone] that may be different from the data timezone (e.g.: Forex trading). In this case it might appear like there is a lag between the algorithm time and the first bar of a history request, however this is just the difference in time zone. All the data is internally synchronized in UTC time and arrives in the same "time slice" or $[Slice,T:QuantConnect.Data.Slice] object. A slice is a sliver of time with all the data available for this moment.
+    The algorithm $[TimeZone, P:QuantConnect.Algorithm.QCAlgorithm.TimeZone] may be different from the data timezone (e.g.: Forex trading). In this case it might appear like there is a lag between the algorithm time and the first bar of a history request, however this is just the difference in time zone. All the data is internally synchronized in UTC time and arrives in the same "time slice" or $[Slice,T:QuantConnect.Data.Slice] object. A slice is a sliver of time with all the data available for this moment.
 </p>
 <p>
     To keep trades easy to compare between asset classes we mark all orders in $[UtcTime, P:QuantConnect.Algorithm.QCAlgorithm.UtcTime].


### PR DESCRIPTION
Fixed a grammatical error I noticed while reading through the docs.