### PR TITLE
Fixes Bug on CustomFeeModel

### DIFF
--- a/02 Algorithm Reference/15 Reality Modelling/04 Fee Models.html
+++ b/02 Algorithm Reference/15 Reality Modelling/04 Fee Models.html
@@ -36,7 +36,7 @@ public class CustomFeeModel : FeeModel {
         var fee = Math.Max(1m, parameters.Security.Price 
                            * parameters.Order.AbsoluteQuantity 
                            * 0.00001m);
-        return new OrderFee(new CashAmount(fee, parameters.AccountCurrency));
+        return new OrderFee(new CashAmount(fee, "USD"));
     }
 }
 
@@ -57,8 +57,8 @@ class CustomFeeModel:
     def GetOrderFee(self, parameters):
         fee = max(1, parameters.Security.Price
                   * parameters.Order.AbsoluteQuantity
-                  * d.Decimal(0.00001))
-        return OrderFee(CashAmount(fee, parameters.AccountCurrency))
+                  * 0.00001)
+        return OrderFee(CashAmount(fee, 'USD'))
 
 # Non accountCurrency custom fee model to pay order fees in a desired currency
 class NonAccountCurrencyCustomFeeModel:


### PR DESCRIPTION
The example was using `parameter.AccountCurrency` that doesn't exist. Replaced by `"USD"`.