### PR TITLE
Update 06 Fill Models.html

### DIFF
--- a/02 Algorithm Reference/15 Reality Modelling/06 Fill Models.html
+++ b/02 Algorithm Reference/15 Reality Modelling/06 Fill Models.html
@@ -8,9 +8,7 @@
 </p>
 <p>
 	The Fill Models implement the $[IFillModel,T:QuantConnect.Orders.Fills.IFillModel] interface. If you wish to implement your own fill model you can start with the $[FillModel,T:QuantConnect.Orders.Fills.FillModel] and override methods you wish to change.
-}</pre>
-</div>
-We provide the $[ImmediateFillModel,T:QuantConnect.Orders.Fills.ImmediateFillModel] which assumes orders and immediately and completely filled.
+	We provide the $[ImmediateFillModel,T:QuantConnect.Orders.Fills.ImmediateFillModel] which assumes orders and immediately and completely filled.
 </p>
 <div class="section-example-container" >
 <pre class="csharp" >


### PR DESCRIPTION
Revome closing tags </div> and </pre>, because they don't have opnening tags.