### PR TITLE
Update 13 Stop Market Orders.html

### DIFF
--- a/02 Algorithm Reference/07 Trading and Orders/13 Stop Market Orders.html
+++ b/02 Algorithm Reference/07 Trading and Orders/13 Stop Market Orders.html
@@ -1,5 +1,5 @@
 <p>
-A Stop Market Order ("stop-loss") fills as a market order when a specific price is reached. A buy stop market order to purchase assets will trigger when the price is equal or lower than the one configured. Conversely, a sell stop market order will trigger when the price is equal or higher to the one set. Stop market orders are often used to prevent loss. 
+A Stop Market Order ("stop-loss") fills as a market order when a specific price is reached. A buy stop market order to purchase assets will trigger when the price is equal or higher than the one configured. Conversely, a sell stop market order will trigger when the price is equal or lower than to the one set. Stop market orders are often used to prevent loss. 
 </p>
 <p>If the market gaps (jumps in a discontinuous manner) past your stop price it may be filled at a substantially worse price than the stop price you entered. As such a stop-loss order is no guarantee your trade will fill at the price you specify.</p>
 


### PR DESCRIPTION
Reversed direction in the Stop Market Order description. 
A Buy stop is triggered when the market rises through a price.
A sell stop is triggered when a market falls through a price.