### PR TITLE
Adds documentation for Benzinga (BenzingaNews)

### DIFF
--- a/08 Alternative Data[]/11 Benzinga/00.html
+++ b/08 Alternative Data[]/11 Benzinga/00.html
@@ -1,0 +1,19 @@
+
+
+<div class="example-fieldset">
+    <div class="example-legend">
+        Demonstration Algorithms
+    </div>
+    <a class="python example-algorithm-link"
+        href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/AltData/BenzingaNewsAlgorithm.py"
+        target="_BLANK"
+        rel="noopener noreferrer">BenzingaNewsAlgorithm.py <span class="badge-python pull-right">Python</span>
+    </a>
+
+    <a class="csharp example-algorithm-link"
+        href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.CSharp/AltData/BenzingaNewsAlgorithm.cs"
+        target="_BLANK"
+        rel="noopener noreferrer">
+        BenzingaNewsAlgorithm.cs <span class="badge-csharp pull-right">C#</span>
+    </a>
+</div>

--- a/08 Alternative Data[]/11 Benzinga/01 Introduction.html
+++ b/08 Alternative Data[]/11 Benzinga/01 Introduction.html
@@ -1,0 +1,4 @@
+<p>
+QuantConnect hosts Benzinga News data for U.S. equities. The data contains the article's headline, body, and any tickers mentioned in the body of the article for each news item. On average, there has been approximately 250 new articles published per day since September 12th, 2017.
+</p>
+<p>Each $[BenzingaNews, T:QuantConnect.Data.Custom.Benzinga.BenzingaNews] object has 7 key properties you can use in your analysis: Title, Teaser, Contents, Author, Symbols, Categories, and Tags.</p>

--- a/08 Alternative Data[]/11 Benzinga/02 Usage.html
+++ b/08 Alternative Data[]/11 Benzinga/02 Usage.html
@@ -1,0 +1,90 @@
+<p>
+    Benzinga data is a <i>linked</i> data source. This means that the data is automatically tied to the
+    underlying equity whenever possible. To add the correct data to your algorithm, you should use
+    the <i>equity</i> asset Symbol in <code>AddData</code>.
+</p>
+
+<h4>Requesting Data</h4>
+
+<p>
+    To add Benzinga data to your algorithm use the <code>AddData()</code> system to request the data. As with all datasets, you should 
+    save a reference to your symbol for easy use later in your algorithm. For detailed documentation on using custom data 
+    see <a class="docs-internal-link" href="/docs/algorithm-reference/importing-custom-data">Importing Custom Data</a>.
+</p>
+<div class="section-example-container">
+<pre class="csharp">
+// Request underlying equity data.
+var aapl = AddEquity("AAPL", Resolution.Daily).Symbol;
+// AAPL news
+var aaplNews = AddData&lt;BenzingaNews&gt;(aapl).Symbol;
+</pre>
+
+<pre class="python">
+# Request underlying equity data.
+aapl = self.AddEquity("AAPL", Resolution.Daily).Symbol
+# AAPL news
+aaplNews = self.AddData(BenzingaNews, aapl).Symbol
+</pre>
+</div>
+
+<h4>Accessing Data</h4>
+<p>
+    Data can be accessed via Slice events. Slice delivers unique events to your algorithm as they happen.
+    We recommend saving the symbol object when you add the data for easy access to slice later.
+    Data is available in daily resolution.
+
+        Since this is a linked data source, it is also available on the underlying 
+        security via the <code class="csharp">Securities[symbol].Data.GetAll&lt;BenzingaNews&gt;()</code>
+        <code class="python">self.Securities[symbol].Data.GetAll(BenzingaNews)</code> helper method. When you 
+        request data via the data cache, it will always return the <em>last</em> article stored.
+
+    You can see an example of both of these accessors in the code below.
+</p>
+<div class="section-example-container">
+<pre class="csharp">using QuantConnect.Data.Custom.Benzinga;
+namespace QuantConnect.Algorithm.CSharp {
+    public class BenzingaAlgorithm : QCAlgorithm {
+        public override void Initialize() {
+            SetStartDate(2019, 1, 1);
+            
+            var aapl = AddEquity("AAPL").Symbol;
+            // AAPL news
+            AddData&lt;BenzingaNews&gt;(aapl);
+        }
+        
+        public override void OnData(Slice data) {
+            // Accessing a linked source from securities collection:
+            //var aaplNews = Securities["AAPL"].Data.GetAll&lt;BenzingaNews&gt;();
+            // Accessing via Slice event
+            var aaplNews = data.Get&lt;BenzingaNews&gt;();
+            
+            foreach (var news in aaplNews.Values)
+            {
+                Log($"Unique ID assigned to the article by Benzinga: {news.Id}, Author of the article: {news.Author}, Date the article was published: {news.CreatedAt}, Date that the article was revised on: {news.UpdatedAt}, Title of the article published: {news.Title}");
+            }
+        }
+    }
+}</pre>
+<pre class="python">from QuantConnect.Data.Custom.Benzinga import *
+
+    class BenzingaAlgorithm(QCAlgorithm):
+        def Initialize(self):
+            self.SetStartDate(2019, 1, 1)
+
+            aapl = self.AddEquity("AAPL").Symbol
+
+            # AAPL news
+            self.AddData(BenzingaNews, aapl)
+
+        def OnData(self, data):
+            # Accessing a linked source from securities collection:
+            #aaplNews = self.Securities["AAPL"].Data.GetAll(BenzingaNews)
+            # Accessing via Slice event
+            aaplNews = data.Get(BenzingaNews)
+            
+            for news in aaplNews.Values:
+                self.Log(f"Unique ID assigned to the article by Benzinga: {news.Id}, Author of the article: {news.Author}, Date the article was published: {news.CreatedAt}, Date that the article was revised on: {news.UpdatedAt}, Title of the article published: {news.Title}")
+</pre>
+</div>
+
+<p>All custom data has the properties <code>Time</code>, <code>Symbol</code>, and <code>Value</code>.</p> 

--- a/08 Alternative Data[]/11 Benzinga/03 Historical Data.html
+++ b/08 Alternative Data[]/11 Benzinga/03 Historical Data.html
@@ -1,0 +1,25 @@
+<p>
+    You can request historical custom data in your algorithm using the custom data Symbol object. To learn more about historical 
+    data requests, please visit 
+    the <a class="docs-internal-link" href="/docs/algorithm-reference/historical-data" target="_blank" ref="noreferrer noopener">Historical Data</a> 
+    documentation. If there is no custom data in the period you request, the history result will be empty. The following example 
+    gets aapl news historical data using the History API.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Add underlying equity 
+var aapl = AddEquity("AAPL", Resolution.Daily).Symbol;
+var aaplNews = AddData&lt;BenzingaNews&gt;(aapl).Symbol;
+
+// Request 60 days of aapl news history with the aaplNews Symbol
+var aaplNewsHistory = History&lt;BenzingaNews&gt;(aaplNews, 60, Resolution.Daily);
+</pre>
+    
+    <pre class="python"># Add underlying equity 
+aapl = self.AddEquity("AAPL", Resolution.Daily).Symbol
+aaplNews = self.AddData(BenzingaNews, aapl).Symbol
+
+# Request 60 days of aapl news history with the aaplNews Symbol
+aaplNewsHistory = self.History(BenzingaNews, aaplNews, 60, Resolution.Daily)
+</pre>
+</div>

--- a/08 Alternative Data[]/11 Benzinga/04 Data Properties.html
+++ b/08 Alternative Data[]/11 Benzinga/04 Data Properties.html
@@ -1,0 +1,9 @@
+<div class="base-tree-container"></div>
+
+<script data-tree="QuantConnect.Data.Custom.Benzinga.BenzingaNews"></script>
+<script type="text/javascript">
+    $(document).ready(function () {
+        var dataTree = $("script[data-tree]").data("tree").split(",");
+        initializeTreeView(dataTree);
+    });
+</script>

--- a/08 Alternative Data[]/11 Benzinga/96 Demonstration.html
+++ b/08 Alternative Data[]/11 Benzinga/96 Demonstration.html
@@ -1,0 +1,5 @@
+<p>
+    Raw text is often analyzed with a technique called Natural Language Processing (NLP). There are many forms of natural language analysis that vary in complexity, but the most simple form is assigning a weighting to individual words and measuring the sum as the sentiment of the text. The demonstration below demonstrates this using Benzinga's News Data.
+</p>
+<iframe class="python" style="border: solid 1px #ebecee; width: 100%; height: 330px" src="/terminal/processCache?request=embedded_backtest_31cde5f9dd7bd275ba23aa31b01d204f.html"></iframe>
+<iframe class="csharp" style="border: solid 1px #ebecee; width: 100%; height: 330px" src="/terminal/processCache?request=embedded_backtest_b13fc99b384ec71ad65d5ac8c86dbb00.html"></iframe>

--- a/08 Alternative Data[]/11 Benzinga/97 Personal Trading.html
+++ b/08 Alternative Data[]/11 Benzinga/97 Personal Trading.html
@@ -1,0 +1,3 @@
+<p>
+QuantConnect provides this data set for personal use. Nothing special is needed for personal live trading.
+</p>

--- a/08 Alternative Data[]/11 Benzinga/97 Personal Trading.html
+++ b/08 Alternative Data[]/11 Benzinga/97 Personal Trading.html
@@ -1,3 +1,3 @@
 <p>
-QuantConnect provides this data set for personal use. Nothing special is needed for personal live trading.
+Benzinga is currently not available for personal trading.
 </p>

--- a/08 Alternative Data[]/11 Benzinga/98 About the Provider.html
+++ b/08 Alternative Data[]/11 Benzinga/98 About the Provider.html
@@ -1,0 +1,10 @@
+<div class="about">
+    <div class="row">
+        <div class="col-md-9">
+<p>Benzinga is a financial news and analysis service providing timely, actionable insights for investors. It is a dynamic and innovative financial media outlet that empowers investors with unique content that is coveted by Wall Street's top traders.</p>
+        </div>
+        <div class="col-md-3">
+            <img style="max-width: 100%" src="https://cdn.quantconnect.com/i/tu/benzinga-logo-rev0.png" />
+        </div>
+    </div>
+</div>

--- a/08 Alternative Data[]/11 Benzinga/99 Pricing.html
+++ b/08 Alternative Data[]/11 Benzinga/99 Pricing.html
@@ -1,0 +1,16 @@
+
+
+<table class="table qc-table">
+    <thead>
+        <tr>
+        <th style="width: 40%;">Application Context</th>
+        <th>Subscription Fee</th>
+        </tr>
+    </thead>
+    <tbody>
+
+        <tr><td>Backtesting</td><td> Free </td></tr>
+        <tr><td>Alpha Streams Use, Competitions</td> <td> Free </td></tr>
+        <tr><td>Personal Paper or Live Trading</td><td> Coming Soon.</td></tr>
+    </tbody>
+</table>


### PR DESCRIPTION
Few things that are left on the TODO list external to these new docs:

* Move vendor image to appropriate location (move image from `/i/tu/` to `/docs/i/`)
* Run backtest with Benzinga data (insufficient data at the moment)