### PR TITLE
Adds talib example algorithm

### DIFF
--- a/02 Algorithm Reference/09 Indicators/00.html
+++ b/02 Algorithm Reference/09 Indicators/00.html
@@ -14,6 +14,9 @@
     <a class="python example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/RegressionChannelAlgorithm.py" target="_BLANK">
         RegressionChannelAlgorithm.py  <span class="badge-python pull-right">Python</span>
     </a>
+    <a class="python example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/TalibIndicatorsAlgorithm.py" target="_BLANK">
+        TalibIndicatorsAlgorithm.py  <span class="badge-python pull-right">Python</span>
+    </a>
     
     
     <a class="csharp example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.CSharp/IndicatorSuiteAlgorithm.cs" target="_BLANK">


### PR DESCRIPTION
Adds a link to the talib example algorithm, which was added in https://github.com/QuantConnect/Lean/pull/4389