### PR TITLE
Change jupyter to research

### DIFF
--- a/06 Research/01 Overview/02 Importing Dependencies.html
+++ b/06 Research/01 Overview/02 Importing Dependencies.html
@@ -7,12 +7,12 @@ The foundation class for accessing QuantConnect data through Jupyter is the <cod
 	<pre class="all">from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Common")
-AddReference("QuantConnect.Jupyter")
+AddReference("QuantConnect.Research")
 AddReference("QuantConnect.Indicators")
 from System import *
 from QuantConnect import *
 from QuantConnect.Data.Market import TradeBar, QuoteBar
-from QuantConnect.Jupyter import *
+from QuantConnect.Research import *
 from QuantConnect.Indicators import *
 from datetime import datetime, timedelta
 import matplotlib.pyplot as plt

--- a/06 Research/01 Overview/02 导入引用.cn.html
+++ b/06 Research/01 Overview/02 导入引用.cn.html
@@ -7,12 +7,12 @@
 	<pre class="all">from clr import AddReference
 AddReference("System")
 AddReference("QuantConnect.Common")
-AddReference("QuantConnect.Jupyter")
+AddReference("QuantConnect.Research")
 AddReference("QuantConnect.Indicators")
 from System import *
 from QuantConnect import *
 from QuantConnect.Data.Market import TradeBar, QuoteBar
-from QuantConnect.Jupyter import *
+from QuantConnect.Research import *
 from QuantConnect.Indicators import *
 from datetime import datetime, timedelta
 import matplotlib.pyplot as plt


### PR DESCRIPTION
According to this merged PR https://github.com/QuantConnect/Lean/pull/4449 the following code must be updated.

```python
# change this
AddReference("QuantConnect.Jupyter")
from QuantConnect.Jupyter import *

# to this
AddReference("QuantConnect.Research")
from QuantConnect.Research import *
```