### PR TITLE
Update 04 QuantBook.html

### DIFF
--- a/07 Research/01 Overview/04 QuantBook.html
+++ b/07 Research/01 Overview/04 QuantBook.html
@@ -6,6 +6,7 @@ QuantBook is a wrapper on QCAlgorithm which allows you to access QCAlgorithm met
 <div class="section-example-container">
 	<pre class="all">from clr import AddReference
 AddReference("System")
+AddReference('System.Memory')
 AddReference("QuantConnect.Common")
 AddReference("QuantConnect.Research")
 AddReference("QuantConnect.Indicators")


### PR DESCRIPTION
If we input the code writing as-is in a local Lean/Jupyter, a bunch of issues and warning appear and in particular this one:
```
/opt/miniconda3/lib/python3.6/site-packages/ipykernel_launcher.py:6: DeprecationWarning: The module was found, but not in a referenced namespace.
Implicit loading is deprecated. Please use clr.AddReference('System.Memory').
```

By adding `AddReference('System.Memory')`, The warning disapear