### PR TITLE
Remove --open option from lean cloud optimize

### DIFF
--- a/05 Lean CLI/03 Tutorials/09 Optimization/03 Cloud optimizations/02 Running cloud optimizations.html
+++ b/05 Lean CLI/03 Tutorials/09 Optimization/03 Cloud optimizations/02 Running cloud optimizations.html
@@ -6,9 +6,9 @@
     <li><a href="/docs/v2/lean-cli/tutorials/authentication#02-Logging-in">Log in</a> to the CLI if you haven't done so already.</li>
     <li><a href="/docs/v2/lean-cli/tutorials/optimization/project-parameters">Convert your project to use project parameters</a> instead of constants for all values that must be optimized.</li>
     <li>Open a terminal in the directory you ran <code>lean init</code> in.</li>
-    <li>Run <code>lean cloud optimize "My Project" --push --open</code> to push <code>./My Project</code> to the cloud, start optimizing the project in the cloud, and open the results in the browser.
+    <li>Run <code>lean cloud optimize "My Project" --push</code> to push <code>./My Project</code> to the cloud, start optimizing the project in the cloud.
 <div class="section-example-container">
-<pre>$ lean cloud optimize "My Project" --push --open
+<pre>$ lean cloud optimize "My Project" --push
 [1/1] Pushing 'My Project'
 Successfully updated cloud file 'My Project/main.py'
 Started compiling project 'My Project'
@@ -27,7 +27,7 @@ Enter a number:</pre>
     </li>
     <li>Enter the number of the optimization target to use. The target specifies what statistic you want to optimize and whether you want to minimize or maximize it.
 <div class="section-example-container">
-<pre>$ lean cloud optimize "My Project" --push --open
+<pre>$ lean cloud optimize "My Project" --push
 Select an optimization target:
 1) Sharpe Ratio (min)
 2) Sharpe Ratio (max)
@@ -42,7 +42,7 @@ Enter a number: 2</pre>
     </li>
     <li>For each parameter, enter whether you want to optimize it and what its values can be.
 <div class="section-example-container">
-<pre>$ lean cloud optimize "My Project" --push --open
+<pre>$ lean cloud optimize "My Project" --push
 Should the 'ema-fast' parameter be optimized? [Y/n]: y
 Minimum value for 'ema-fast': 1
 Maximum value for 'ema-fast': 10
@@ -51,7 +51,7 @@ Step size for 'ema-fast' [1.0]: 1</pre>
     </li>
     <li>Enter the constraints of the optimization. An example optimization is "Drawdown &lt;= 0.25", which discards all parameter combinations resulting in a drawdown higher than 25%.
 <div class="section-example-container">
-<pre>$ lean cloud optimize "My Project" --push --open
+<pre>$ lean cloud optimize "My Project" --push
 Current constraints: None
 Do you want to add a constraint? [y/N]: y
 Select a constraint target:


### PR DESCRIPTION
Since there is no more `--open` option for `lean cloud optimize`, it should be removed from the documentation in order to avoid confusion.