### PR TITLE
Update 04 New C# Projects.html

### DIFF
--- a/05 Lean CLI/02 User Guides/01 Directory Structure/04 New C# Projects.html
+++ b/05 Lean CLI/02 User Guides/01 Directory Structure/04 New C# Projects.html
@@ -1,5 +1,5 @@
 <p>
-    After creating a new Python project directory with <code>lean create-project -l csharp &lt;project name&gt;</code> or by pulling a C# project with <code>lean cloud pull</code>, the following structure is created:
+    After creating a new C# project directory with <code>lean create-project -l csharp &lt;project name&gt;</code> or by pulling a C# project with <code>lean cloud pull</code>, the following structure is created:
 </p>
 
 <div class="section-example-container">


### PR DESCRIPTION
Fix docs typo: replace Python with C# when creating new C# projects.