### PR TITLE
Users can now specify Docker port forwarding and environment variables

### DIFF
--- a/05 Lean CLI/02 User Guides/02 Configuration/04 Project Configuration.html
+++ b/05 Lean CLI/02 User Guides/02 Configuration/04 Project Configuration.html
@@ -11,4 +11,5 @@
     <li><code>cloud-id</code>: This property is set automatically after the project has been pulled from or pushed to the cloud. It contains the id of the project's counterpart in the cloud and must not be modified or removed manually.</li>
     <li><code>local-id</code>: This property is set automatically when the CLI needs to uniquely identify the current project. It contains a unique id that is specific to the project and must not be modified or removed manually.</li>
     <li><code>algorithm-language</code>: This property contains the language of the project. It is automatically set when the project is created and must not be modified or removed manually.</li>
+    <li><code>docker</code>: This property is a key/value object containing the docker instance's "environment" and "ports" command line run arguments. For example, if you wanted to expose host port 999 to internal port 6006, you would write <code>"docker": { "ports": { "999": "6006"} }</code>.</li>
 </ul>


### PR DESCRIPTION
References [#35](https://github.com/QuantConnect/lean-cli/pull/35)