### PR TITLE
Fix lean.io dead links

### DIFF
--- a/Resources/algorithm-results/report/rolling-statistics.php
+++ b/Resources/algorithm-results/report/rolling-statistics.php
@@ -1,4 +1,4 @@
-<p>The backtest report displays time series for your portfolio's rolling <a href='/docs/v2/writing-algorithms/key-concepts/glossary#07-beta'>beta</a> and <a href='/docs/v2/writing-algorithms/key-concepts/glossary#19-Sharpe-ratio'>Sharpe ratio</a>.<br></p>
+<p>The backtest report displays time series for your portfolio's rolling <a href='https://www.quantconnect.com/docs/v2/writing-algorithms/key-concepts/glossary#07-beta'>beta</a> and <a href='https://www.quantconnect.com/docs/v2/writing-algorithms/key-concepts/glossary#19-Sharpe-ratio'>Sharpe ratio</a>.<br></p>
 
 <h4>Rolling Portfolio Beta<br></h4>
 <img src="https://cdn.quantconnect.com/i/tu/rolling-portfolio-beta-chart.png" class='img-responsive'>


### PR DESCRIPTION
#### Description
Fix dead links on lean.io 

#### Related Issue
Closes #652

#### Motivation and Context
These links worked fine on quantconnect.com, but not on [lean.io](https://www.lean.io/docs/v2/lean-cli/reports#07-Rolling-Statistics) because there is no `lean.io/docs/v2/writing-algorithms` path

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`