### PR TITLE
State that history requests for ticks only return the last tick of each timestamp

### DIFF
--- a/Resources/datasets/request-data.php
+++ b/Resources/datasets/request-data.php
@@ -114,6 +114,8 @@ var ticks = {$cVar}History&lt;Tick&gt;(ethSymbol, TimeSpan.FromDays(3), Resoluti
 var tradeBars2 = {$cVar}History(btcSymbol, TimeSpan.FromDays(3), Resolution.Minute);</pre>
 </div>
 
+<p>If you request tick data and there are multiple ticks with the same timestamp, the <code>History</code> method only returns the last tick of the collection.</p>
+
 <h4>Multiple Symbol History Requests</h4>
 <p>To request history for multiple symbols at a time, pass an array of <code>Symbol</code> objects to the same API methods shown in the preceding section. The return type of the method call depends on the history request <code class='python'>[Type]</code><code class='csharp'>&lt;Type&gt;</code>. The following table describes the return type of each request <code class='python'>[Type]</code><code class='csharp'>&lt;Type&gt;</code>:</p>
 
@@ -191,6 +193,8 @@ var quoteBars = {$cVar}History&lt;QuoteBar&gt;(new[] {btcSymbol}, TimeSpan.FromD
 var tradeBars2 = {$cVar}History(new[] {btcSymbol}, TimeSpan.FromDays(3));</pre>	
 
 </div>
+
+<p>If you request tick data and there are multiple ticks with the same timestamp for a single security, the <code>History</code> method only returns the last tick of the collection.</p>
 
 <h4>All Symbol History Requests</h4>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
State that history requests for ticks only return the last tick of each timestamp

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This info was missing from the docs

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
