### PR TITLE
Adds Mean Reversion Portfolio Construction Model

### DIFF
--- a/02 Writing Algorithms/34 Algorithm Framework/04 Portfolio Construction/02 Supported Models/10 Mean Reversion Model.html
+++ b/02 Writing Algorithms/34 Algorithm Framework/04 Portfolio Construction/02 Supported Models/10 Mean Reversion Model.html
@@ -1,0 +1,77 @@
+<p>The <code>MeanReversionPortfolioConstructionModel</code> implements an on-line portfolio selection technique, named "On-Line Moving Average Reversion" (OLMAR). The basic idea is to represent multi-period mean reversion as "Moving Average Reversion" (MAR), which explicitly predicts next price relatives using moving averages, and then learn portfolios by online learning techniques.</p>
+
+<p>Reference:
+<ul>
+<li> Li, B., Hoi, S. C. (2012). On-line portfolio selection with moving average reversion. arXiv preprint <a target="_blank" rel="nofollow" href="https://arxiv.org/ftp/arxiv/papers/1206/1206.4626.pdf">arXiv:1206.4626</a>.
+</li>
+</ul>
+<p>
+
+<div class="section-example-container">
+	<pre class="csharp">SetPortfolioConstruction(new MeanReversionPortfolioConstructionModel());</pre>
+	<pre class="python">self.SetPortfolioConstruction(MeanReversionPortfolioConstructionModel())</pre>
+</div>
+
+<p>The following table describes the arguments the model accepts:</p>
+
+<table class="qc-table table">
+    <thead>
+        <tr>
+            <th>Argument</th>
+            <th>Data Type</th>
+            <th>Description</th>
+            <th>Default Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code class="python">rebalance</code><code class="csharp">rebalanceFunc</code></td>
+	    <td><code class="csharp">Func&lt;DateTime, DateTime?&gt;</code>
+                 <span class="python">Any of the following types:
+                     <ul>
+                         <li><code>timedelta</code></li>
+                         <li><code>Resolution</code></li>
+                         <li><a href="/docs/v2/writing-algorithms/scheduled-events#04-Date-Rules">DateRules</a></li>
+                         <li><code>None</code></li>
+                         <li>Callable[[datetime], datetime]</li>
+                     </ul>
+                 </span>
+            </td>
+	    <td>
+                 <span class="csharp">A function that receives the algorithm UTC time and returns the next expected rebalance time. If the function returns <code class='python'>None</code><code class='csharp'>null</code>, the portfolio doesn't rebalance.</span>
+
+                 <span class="python">Rebalancing parameter. If it's a <code>timedelta</code>, <code>DateRules</code> or <code>Resolution</code>, it's converted into a function. If it's <code>None</code>, it's ignored. The function returns the next expected rebalance time for a given algorithm UTC DateTime. The function returns </span><span class="python"><span class="python"><code>None </code>if unknown, in which case the function will be called again in the
+                              next loop. If the function returns the current time, the portfolio rebalances.</span>
+            </td>
+            <td><code class="python">None</code><code class="csharp">null</code></td>
+        </tr>
+        <tr>
+            <td><code>portfolioBias</code></td>
+	    <td><code>PortfolioBias</code></td>
+            <td>The bias of the portfolio</td>
+            <td><code>PortfolioBias.LongShort</code></td>
+        </tr>
+        <tr>
+            <td><code>reversionThreshold</code></td>
+	    <td><code class="csharp">decimal</code><code class="python">float</code></td>
+            <td>Reversion threshold</td>
+            <td>1</td>
+        </tr>
+        <tr>
+            <td><code>windowSize</code></td>
+	    <td><code>int</code></td>
+            <td>The window size of mean price</td>
+            <td>20</td>
+        </tr>
+        <tr>
+            <td><code>resolution</code></td>
+	    <td><code>Resolution</code></td>
+            <td>The resolution of the history price</td>
+            <td><code>Resolution.Daily</code></td>
+        </tr>
+    </tbody>
+</table>
+
+<p>This model supports other data types for the rebalancing frequency argument. For more information about the supported types, see <a href='/docs/v2/writing-algorithms/algorithm-framework/portfolio-construction/key-concepts#06-Rebalance-Frequency'>Rebalance Frequency</a>.</p>
+
+<p>To view the implementation of this model, see the <span class="csharp"><a target="_blank" rel="nofollow" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.Framework/Portfolio/MeanReversionPortfolioConstructionModel.cs">LEAN GitHub repository</a></span><span class="python"><a target="_blank" rel="nofollow" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.Framework/Portfolio/MeanReversionPortfolioConstructionModel.py">LEAN GitHub repository</a></span>.</p>


### PR DESCRIPTION
#### Description
Adds documentation for `MeanReversionPortfolioConstructionModel`.

#### Related Issue
Ref.: https://github.com/QuantConnect/Lean/pull/6519

#### Motivation and Context
Updates documentation to reflect new features in Lean.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
