### PR TITLE
Code generated by Writing-Algorithm-API-Ref-Code-Generator.py

### DIFF
--- a/02 Writing Algorithms/98 API Reference/02.html
+++ b/02 Writing Algorithms/98 API Reference/02.html
@@ -157,7 +157,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L46">line 46 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L46">line 46 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -208,7 +208,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L69">line 69 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L69">line 69 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -267,7 +267,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L93">line 93 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L93">line 93 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -314,7 +314,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2356">line 2356 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2356">line 2356 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -361,7 +361,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2381">line 2381 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2381">line 2381 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -416,7 +416,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L142">line 142 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L142">line 142 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -471,7 +471,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L189">line 189 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L189">line 189 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -538,7 +538,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L218">line 218 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L218">line 218 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -601,7 +601,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L166">line 166 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L166">line 166 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -664,7 +664,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L243">line 243 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L243">line 243 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -719,7 +719,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L330">line 330 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L330">line 330 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -782,7 +782,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L118">line 118 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L118">line 118 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -837,11 +837,10 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L266">line 266 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L266">line 266 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -894,7 +893,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L281">line 281 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L281">line 281 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -945,7 +944,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2298">line 2298 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2298">line 2298 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -1004,7 +1003,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L306">line 306 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L306">line 306 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -1047,11 +1046,10 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L326">line 326 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L326">line 326 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Algorithm Framework')">Algorithm Framework</button>
@@ -1088,7 +1086,7 @@ function openTopTab(event, category) {
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L49">line 49 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L49">line 49 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
         </div>
         
     </div>
@@ -1149,7 +1147,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2094">line 2094 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2094">line 2094 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -1192,7 +1190,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L57">line 57 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L57">line 57 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
@@ -1253,7 +1251,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2125">line 2125 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2125">line 2125 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -1315,11 +1313,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L148">line 148 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L148">line 148 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1375,11 +1372,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L193">line 193 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L193">line 193 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1439,11 +1435,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L213">line 213 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L213">line 213 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1487,11 +1482,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L62">line 62 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L62">line 62 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1535,11 +1529,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L86">line 86 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L86">line 86 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1595,11 +1588,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L104">line 104 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L104">line 104 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1655,11 +1647,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L130">line 130 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L130">line 130 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1699,11 +1690,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2235">line 2235 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2235">line 2235 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1743,11 +1733,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2254">line 2254 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2254">line 2254 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1795,11 +1784,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2276">line 2276 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2276">line 2276 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1847,11 +1835,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2293">line 2293 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2293">line 2293 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1903,11 +1890,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2310">line 2310 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2310">line 2310 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -1959,11 +1945,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2327">line 2327 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2327">line 2327 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -2019,7 +2004,7 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2345">line 2345 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2345">line 2345 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2088,7 +2073,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1765">line 1765 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1765">line 1765 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2149,7 +2134,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2079">line 2079 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2079">line 2079 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2227,7 +2212,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1847">line 1847 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1847">line 1847 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2286,7 +2271,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1883">line 1883 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1883">line 1883 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2333,11 +2318,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L234">line 234 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L234">line 234 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -2378,7 +2362,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1897">line 1897 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1897">line 1897 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2437,7 +2421,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1918">line 1918 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1918">line 1918 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2494,7 +2478,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2109">line 2109 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2109">line 2109 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2549,11 +2533,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1938">line 1938 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1938">line 1938 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -2598,7 +2581,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1954">line 1954 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1954">line 1954 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2649,7 +2632,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1973">line 1973 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1973">line 1973 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2710,11 +2693,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1781">line 1781 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1781">line 1781 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -2769,7 +2751,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1808">line 1808 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1808">line 1808 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2828,7 +2810,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1993">line 1993 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1993">line 1993 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -2872,11 +2854,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L385">line 385 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L385">line 385 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Algorithm Framework')">Algorithm Framework</button>
@@ -2914,7 +2895,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L157">line 157 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L157">line 157 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
         </div>
         
     </div>
@@ -2980,11 +2961,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1584">line 1584 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1584">line 1584 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -3048,11 +3028,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1603">line 1603 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1603">line 1603 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -3120,11 +3099,10 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1622">line 1622 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1622">line 1622 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -3189,7 +3167,7 @@ See also: <code>Market</code>.
             <p>Security - The new Security        </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1677">line 1677 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1677">line 1677 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -3244,7 +3222,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L235">line 235 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L235">line 235 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
@@ -3287,11 +3265,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L204">line 204 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L204">line 204 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3332,11 +3309,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L225">line 225 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L225">line 225 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3377,11 +3353,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L239">line 239 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L239">line 239 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3426,11 +3401,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L254">line 254 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L254">line 254 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3475,11 +3449,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L269">line 269 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L269">line 269 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3524,11 +3497,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L284">line 284 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L284">line 284 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3573,11 +3545,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L299">line 299 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L299">line 299 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3626,11 +3597,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L315">line 315 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L315">line 315 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3679,11 +3649,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L331">line 331 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L331">line 331 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3736,11 +3705,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L347">line 347 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L347">line 347 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3793,11 +3761,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L363">line 363 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L363">line 363 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3854,11 +3821,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L379">line 379 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L379">line 379 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3915,11 +3881,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L400">line 400 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L400">line 400 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -3956,11 +3921,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L418">line 418 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L418">line 418 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4001,11 +3965,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L430">line 430 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L430">line 430 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4046,11 +4009,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L444">line 444 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L444">line 444 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4091,11 +4053,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L456">line 456 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L456">line 456 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4140,11 +4101,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L469">line 469 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L469">line 469 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4201,11 +4161,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L484">line 484 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L484">line 484 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4242,11 +4201,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L287">line 287 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L287">line 287 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4287,11 +4245,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L321">line 321 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L321">line 321 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4336,11 +4293,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L353">line 353 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L353">line 353 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4381,11 +4337,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L366">line 366 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L366">line 366 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4442,11 +4397,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L382">line 382 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L382">line 382 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4491,11 +4445,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L397">line 397 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L397">line 397 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4544,11 +4497,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L412">line 412 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L412">line 412 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4601,11 +4553,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L428">line 428 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L428">line 428 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4654,11 +4605,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L443">line 443 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L443">line 443 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4715,11 +4665,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L459">line 459 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L459">line 459 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4780,11 +4729,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L475">line 475 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L475">line 475 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4845,7 +4793,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L491">line 491 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L491">line 491 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
@@ -4892,11 +4840,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L502">line 502 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L502">line 502 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4937,11 +4884,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L541">line 541 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L541">line 541 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Universes')">Universes</button>
@@ -4982,7 +4928,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L518">line 518 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L518">line 518 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
@@ -5026,11 +4972,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L291">line 291 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L291">line 291 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Algorithm Framework')">Algorithm Framework</button>
@@ -5068,7 +5013,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L122">line 122 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L122">line 122 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
         </div>
         
     </div>
@@ -5104,7 +5049,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2802">line 2802 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2802">line 2802 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -5159,7 +5104,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L379">line 379 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L379">line 379 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -5222,7 +5167,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L355">line 355 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L355">line 355 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -5273,7 +5218,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L404">line 404 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L404">line 404 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -5324,11 +5269,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L618">line 618 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L618">line 618 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -5369,11 +5313,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L47">line 47 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L47">line 47 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -5414,11 +5357,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L60">line 60 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L60">line 60 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -5459,11 +5401,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L73">line 73 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L73">line 73 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -5504,7 +5445,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L86">line 86 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L86">line 86 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -5567,7 +5508,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L429">line 429 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L429">line 429 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -5626,7 +5567,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L455">line 455 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L455">line 455 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -5681,7 +5622,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L478">line 478 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L478">line 478 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -5736,7 +5677,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L501">line 501 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L501">line 501 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -5787,7 +5728,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2854">line 2854 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2854">line 2854 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -5834,11 +5775,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1183">line 1183 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1183">line 1183 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -5881,7 +5821,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1197">line 1197 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1197">line 1197 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -5932,7 +5872,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2838">line 2838 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2838">line 2838 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -5983,11 +5923,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1199">line 1199 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1199">line 1199 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6036,11 +5975,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1213">line 1213 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1213">line 1213 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6085,11 +6023,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1226">line 1226 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1226">line 1226 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6138,11 +6075,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1240">line 1240 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1240">line 1240 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6187,11 +6123,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1266">line 1266 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1266">line 1266 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6236,11 +6171,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2969">line 2969 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2969">line 2969 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6285,11 +6219,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2982">line 2982 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2982">line 2982 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6334,11 +6267,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2995">line 2995 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2995">line 2995 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6383,11 +6315,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3008">line 3008 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3008">line 3008 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6432,11 +6363,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3022">line 3022 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3022">line 3022 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6485,11 +6415,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3042">line 3042 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3042">line 3042 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6538,11 +6467,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3058">line 3058 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3058">line 3058 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6587,11 +6515,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3079">line 3079 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3079">line 3079 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6636,11 +6563,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3092">line 3092 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3092">line 3092 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -6685,7 +6611,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3106">line 3106 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L3106">line 3106 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -6736,7 +6662,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2892">line 2892 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2892">line 2892 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -6795,11 +6721,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L551">line 551 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L551">line 551 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -6848,7 +6773,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L575">line 575 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L575">line 575 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -6907,7 +6832,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L526">line 526 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L526">line 526 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -6962,7 +6887,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L589">line 589 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L589">line 589 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -7017,7 +6942,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L612">line 612 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L612">line 612 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -7060,11 +6985,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1152">line 1152 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1152">line 1152 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -7101,11 +7025,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2365">line 2365 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2365">line 2365 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -7142,11 +7065,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2379">line 2379 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2379">line 2379 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -7183,11 +7105,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2391">line 2391 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2391">line 2391 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -7224,7 +7145,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2403">line 2403 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2403">line 2403 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -7272,11 +7193,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1103">line 1103 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1103">line 1103 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -7326,11 +7246,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1116">line 1116 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1116">line 1116 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -7368,11 +7287,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2642">line 2642 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2642">line 2642 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -7414,11 +7332,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2653">line 2653 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2653">line 2653 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -7468,7 +7385,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2666">line 2666 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2666">line 2666 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -7523,11 +7440,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L636">line 636 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L636">line 636 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -7580,7 +7496,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L652">line 652 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L652">line 652 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -7639,7 +7555,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L677">line 677 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L677">line 677 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -7682,11 +7598,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L412">line 412 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L412">line 412 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Algorithm Framework')">Algorithm Framework</button>
@@ -7723,7 +7638,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L436">line 436 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L436">line 436 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
@@ -7766,11 +7681,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1164">line 1164 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1164">line 1164 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -7807,11 +7721,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2464">line 2464 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2464">line 2464 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -7848,11 +7761,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2478">line 2478 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2478">line 2478 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -7889,11 +7801,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2490">line 2490 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2490">line 2490 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -7930,11 +7841,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2502">line 2502 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2502">line 2502 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -7971,7 +7881,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2514">line 2514 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2514">line 2514 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -8030,7 +7940,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L581">line 581 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L581">line 581 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -8085,7 +7995,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L755">line 755 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L755">line 755 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -8144,7 +8054,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L780">line 780 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L780">line 780 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -8199,11 +8109,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L791">line 791 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L791">line 791 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -8256,11 +8165,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L808">line 808 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L808">line 808 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -8313,11 +8221,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L829">line 829 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L829">line 829 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -8366,11 +8273,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L701">line 701 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L701">line 701 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -8423,11 +8329,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L718">line 718 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L718">line 718 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -8480,7 +8385,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L737">line 737 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L737">line 737 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -8516,7 +8421,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L78">line 78 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L78">line 78 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
@@ -8560,11 +8465,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L527">line 527 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L527">line 527 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -8602,7 +8506,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L539">line 539 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L539">line 539 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
@@ -8638,7 +8542,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L718">line 718 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L718">line 718 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -8693,7 +8597,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L825">line 825 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L825">line 825 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -8744,7 +8648,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L802">line 802 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L802">line 802 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -8795,11 +8699,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L848">line 848 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L848">line 848 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -8844,11 +8747,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L863">line 863 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L863">line 863 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -8918,11 +8820,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L884">line 884 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L884">line 884 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -8971,11 +8872,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L902">line 902 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L902">line 902 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9049,11 +8949,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L924">line 924 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L924">line 924 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9102,11 +9001,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L946">line 946 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L946">line 946 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9155,11 +9053,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L970">line 970 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L970">line 970 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9212,11 +9109,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L985">line 985 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L985">line 985 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9265,11 +9161,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1009">line 1009 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1009">line 1009 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9318,11 +9213,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1032">line 1032 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1032">line 1032 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9363,11 +9257,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L223">line 223 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L223">line 223 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9408,11 +9301,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L237">line 237 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L237">line 237 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9457,11 +9349,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L267">line 267 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L267">line 267 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9506,11 +9397,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L284">line 284 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L284">line 284 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9559,11 +9449,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L316">line 316 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L316">line 316 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9608,11 +9497,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L339">line 339 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L339">line 339 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9657,11 +9545,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L354">line 354 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L354">line 354 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9710,11 +9597,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L397">line 397 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L397">line 397 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9783,11 +9669,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L490">line 490 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L490">line 490 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9824,11 +9709,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L504">line 504 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L504">line 504 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -9865,7 +9749,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L515">line 515 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L515">line 515 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
@@ -9936,7 +9820,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L853">line 853 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L853">line 853 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -9987,7 +9871,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2818">line 2818 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2818">line 2818 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -10038,11 +9922,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L876">line 876 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L876">line 876 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -10091,11 +9974,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L892">line 892 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L892">line 892 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -10144,7 +10026,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L910">line 910 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L910">line 910 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -10181,7 +10063,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L573">line 573 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L573">line 573 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -10225,7 +10107,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1261">line 1261 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1261">line 1261 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -10280,11 +10162,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L927">line 927 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L927">line 927 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -10341,7 +10222,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L943">line 943 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L943">line 943 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -10404,7 +10285,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L991">line 991 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L991">line 991 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -10459,7 +10340,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L966">line 966 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L966">line 966 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -10514,7 +10395,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1014">line 1014 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1014">line 1014 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -10569,7 +10450,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1037">line 1037 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1037">line 1037 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -10624,7 +10505,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1061">line 1061 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1061">line 1061 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -10687,11 +10568,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L531">line 531 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L531">line 531 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -10748,11 +10628,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L547">line 547 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L547">line 547 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -10809,7 +10688,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L563">line 563 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L563">line 563 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -10868,11 +10747,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L383">line 383 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L383">line 383 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -10925,11 +10803,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L398">line 398 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L398">line 398 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -10982,7 +10859,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L413">line 413 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L413">line 413 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -11029,7 +10906,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L959">line 959 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L959">line 959 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -11072,11 +10949,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1176">line 1176 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1176">line 1176 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -11113,11 +10989,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2415">line 2415 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2415">line 2415 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -11154,11 +11029,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2428">line 2428 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2428">line 2428 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -11195,11 +11069,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2440">line 2440 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2440">line 2440 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -11236,7 +11109,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2452">line 2452 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2452">line 2452 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -11303,7 +11176,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1087">line 1087 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1087">line 1087 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -11358,7 +11231,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1110">line 1110 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1110">line 1110 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -11417,7 +11290,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1247">line 1247 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1247">line 1247 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -11473,7 +11346,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1186">line 1186 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1186">line 1186 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -11528,7 +11401,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1222">line 1222 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1222">line 1222 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -11583,7 +11456,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1270">line 1270 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1270">line 1270 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -11638,7 +11511,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1293">line 1293 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1293">line 1293 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -11694,7 +11567,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1317">line 1317 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1317">line 1317 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -11749,7 +11622,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1353">line 1353 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1353">line 1353 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -11808,7 +11681,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1377">line 1377 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1377">line 1377 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -11863,7 +11736,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1401">line 1401 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1401">line 1401 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -11918,11 +11791,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L351">line 351 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L351">line 351 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -11971,11 +11843,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L365">line 365 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L365">line 365 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -12024,7 +11895,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L337">line 337 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L337">line 337 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -12079,11 +11950,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L292">line 292 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L292">line 292 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -12132,11 +12002,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L306">line 306 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L306">line 306 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -12185,7 +12054,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L320">line 320 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L320">line 320 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -12244,11 +12113,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L204">line 204 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L204">line 204 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -12301,11 +12169,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L219">line 219 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L219">line 219 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -12358,11 +12225,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L234">line 234 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L234">line 234 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -12415,7 +12281,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L250">line 250 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L250">line 250 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -12470,7 +12336,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1424">line 1424 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1424">line 1424 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -12521,7 +12387,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1448">line 1448 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1448">line 1448 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -12564,7 +12430,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1033">line 1033 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1033">line 1033 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -12607,7 +12473,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L845">line 845 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L845">line 845 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -12643,7 +12509,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1011">line 1011 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1011">line 1011 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -12679,11 +12545,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L979">line 979 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L979">line 979 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Handling Data')">Handling Data</button>
@@ -12720,11 +12585,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L993">line 993 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L993">line 993 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Handling Data')">Handling Data</button>
@@ -12761,7 +12625,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1002">line 1002 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1002">line 1002 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -12797,7 +12661,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L68">line 68 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Universe.cs#L68">line 68 of file Algorithm/QCAlgorithm.Universe.cs.</a></p>
         </div>
         
     </div>
@@ -12841,7 +12705,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L111">line 111 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L111">line 111 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
@@ -12885,7 +12749,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L261">line 261 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L261">line 261 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
@@ -12929,7 +12793,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L958">line 958 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L958">line 958 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -12966,7 +12830,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L967">line 967 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L967">line 967 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -13009,7 +12873,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1022">line 1022 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1022">line 1022 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -13045,7 +12909,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L656">line 656 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L656">line 656 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -13096,11 +12960,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L644">line 644 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L644">line 644 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -13157,11 +13020,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1221">line 1221 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1221">line 1221 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -13206,11 +13068,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1235">line 1235 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1235">line 1235 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -13255,11 +13116,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1249">line 1249 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1249">line 1249 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -13300,11 +13160,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L149">line 149 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L149">line 149 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -13345,11 +13204,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L161">line 161 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L161">line 161 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -13390,11 +13248,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L173">line 173 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L173">line 173 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -13447,7 +13304,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L189">line 189 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L189">line 189 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -13510,7 +13367,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1473">line 1473 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1473">line 1473 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -13573,7 +13430,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1498">line 1498 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1498">line 1498 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -13636,7 +13493,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1523">line 1523 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1523">line 1523 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -13683,11 +13540,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L690">line 690 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L690">line 690 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -13740,11 +13596,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L724">line 724 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L724">line 724 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -13797,11 +13652,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L739">line 739 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L739">line 739 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -13854,11 +13708,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L754">line 754 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L754">line 754 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -13899,11 +13752,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L69">line 69 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L69">line 69 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -13944,11 +13796,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L114">line 114 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L114">line 114 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -13989,11 +13840,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L123">line 123 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L123">line 123 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -14034,11 +13884,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L133">line 133 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L133">line 133 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -14083,11 +13932,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L143">line 143 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L143">line 143 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -14132,11 +13980,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L153">line 153 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L153">line 153 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -14181,11 +14028,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L163">line 163 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L163">line 163 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -14230,11 +14076,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L175">line 175 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L175">line 175 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -14275,7 +14120,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L253">line 253 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L253">line 253 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
@@ -14335,11 +14180,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L764">line 764 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L764">line 764 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -14397,11 +14241,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L775">line 775 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L775">line 775 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -14443,11 +14286,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L266">line 266 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L266">line 266 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -14493,7 +14335,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L287">line 287 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L287">line 287 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
@@ -14536,11 +14378,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1186">line 1186 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1186">line 1186 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Logging')">Logging</button>
@@ -14577,7 +14418,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2527">line 2527 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2527">line 2527 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -14636,7 +14477,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1547">line 1547 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1547">line 1547 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -14691,7 +14532,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1714">line 1714 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1714">line 1714 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -14746,7 +14587,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1570">line 1570 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1570">line 1570 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -14801,7 +14642,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1595">line 1595 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1595">line 1595 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -14856,7 +14697,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1619">line 1619 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1619">line 1619 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -14911,7 +14752,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1642">line 1642 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1642">line 1642 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -14970,7 +14811,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1667">line 1667 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1667">line 1667 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -15029,7 +14870,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1690">line 1690 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1690">line 1690 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -15076,11 +14917,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L81">line 81 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L81">line 81 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -15121,11 +14961,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L91">line 91 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L91">line 91 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -15166,7 +15005,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L103">line 103 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L103">line 103 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
@@ -15222,11 +15061,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L546">line 546 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L546">line 546 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -15276,11 +15114,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L561">line 561 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L561">line 561 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -15330,11 +15167,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L576">line 576 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L576">line 576 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -15384,11 +15220,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L625">line 625 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L625">line 625 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -15438,11 +15273,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2512">line 2512 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2512">line 2512 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -15492,11 +15326,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2527">line 2527 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2527">line 2527 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -15546,11 +15379,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2542">line 2542 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2542">line 2542 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -15596,11 +15428,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2567">line 2567 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2567">line 2567 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -15650,11 +15481,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2583">line 2583 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2583">line 2583 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -15704,11 +15534,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2599">line 2599 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2599">line 2599 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -15758,7 +15587,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2615">line 2615 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2615">line 2615 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -15801,7 +15630,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2137">line 2137 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2137">line 2137 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -15844,7 +15673,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2148">line 2148 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2148">line 2148 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -15896,11 +15725,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2836">line 2836 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2836">line 2836 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Consolidating Data')">Consolidating Data</button>
@@ -15946,7 +15774,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2855">line 2855 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2855">line 2855 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -15997,7 +15825,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2870">line 2870 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2870">line 2870 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -16048,7 +15876,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2274">line 2274 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2274">line 2274 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -16103,7 +15931,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1810">line 1810 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1810">line 1810 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -16162,7 +15990,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1785">line 1785 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1785">line 1785 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -16221,7 +16049,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1761">line 1761 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1761">line 1761 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -16288,7 +16116,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1836">line 1836 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1836">line 1836 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -16343,7 +16171,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1859">line 1859 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1859">line 1859 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -16402,11 +16230,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1908">line 1908 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1908">line 1908 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -16451,7 +16278,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1930">line 1930 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1930">line 1930 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -16510,7 +16337,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1737">line 1737 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1737">line 1737 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -16565,7 +16392,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1944">line 1944 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1944">line 1944 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -16628,7 +16455,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1970">line 1970 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1970">line 1970 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -16679,11 +16506,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L631">line 631 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L631">line 631 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -16724,11 +16550,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L100">line 100 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L100">line 100 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -16769,11 +16594,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L112">line 112 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L112">line 112 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -16814,11 +16638,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L124">line 124 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L124">line 124 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -16859,7 +16682,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L136">line 136 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L136">line 136 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -16902,7 +16725,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1315">line 1315 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1315">line 1315 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -16945,11 +16768,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L316">line 316 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L316">line 316 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Algorithm Framework')">Algorithm Framework</button>
@@ -16986,7 +16808,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L31">line 31 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L31">line 31 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
         </div>
         
     </div>
@@ -17029,7 +16851,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2728">line 2728 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2728">line 2728 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -17074,11 +16896,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1045">line 1045 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1045">line 1045 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -17121,11 +16942,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1208">line 1208 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1208">line 1208 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -17164,11 +16984,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1236">line 1236 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1236">line 1236 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -17207,11 +17026,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1265">line 1265 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1265">line 1265 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -17250,7 +17068,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1284">line 1284 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1284">line 1284 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -17294,7 +17112,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1191">line 1191 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1191">line 1191 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -17337,11 +17155,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1065">line 1065 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1065">line 1065 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Modeling')">Modeling</button>
@@ -17382,11 +17199,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1145">line 1145 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1145">line 1145 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Modeling')">Modeling</button>
@@ -17423,7 +17239,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1156">line 1156 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1156">line 1156 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -17466,11 +17282,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1347">line 1347 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1347">line 1347 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Securities and Portfolio')">Securities and Portfolio</button>
@@ -17507,11 +17322,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1358">line 1358 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1358">line 1358 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Securities and Portfolio')">Securities and Portfolio</button>
@@ -17556,11 +17370,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1377">line 1377 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1377">line 1377 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Securities and Portfolio')">Securities and Portfolio</button>
@@ -17597,7 +17410,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1335">line 1335 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1335">line 1335 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -17640,7 +17453,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2717">line 2717 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2717">line 2717 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -17691,11 +17504,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1426">line 1426 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1426">line 1426 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Handling Data')">Handling Data</button>
@@ -17732,7 +17544,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1502">line 1502 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1502">line 1502 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -17776,11 +17588,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L363">line 363 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L363">line 363 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Algorithm Framework')">Algorithm Framework</button>
@@ -17818,7 +17629,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L68">line 68 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L68">line 68 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
         </div>
         
     </div>
@@ -17861,7 +17672,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L825">line 825 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L825">line 825 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -17916,11 +17727,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1051">line 1051 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1051">line 1051 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -17973,11 +17783,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1072">line 1072 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1072">line 1072 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -18030,11 +17839,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1087">line 1087 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1087">line 1087 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -18087,11 +17895,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1102">line 1102 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1102">line 1102 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -18144,7 +17951,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1120">line 1120 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L1120">line 1120 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -18188,7 +17995,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2739">line 2739 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2739">line 2739 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -18231,7 +18038,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L815">line 815 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L815">line 815 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -18274,7 +18081,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L728">line 728 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L728">line 728 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -18318,11 +18125,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L352">line 352 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L352">line 352 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Algorithm Framework')">Algorithm Framework</button>
@@ -18360,7 +18166,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L87">line 87 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L87">line 87 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
         </div>
         
     </div>
@@ -18403,7 +18209,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2540">line 2540 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2540">line 2540 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -18447,11 +18253,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L374">line 374 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L374">line 374 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Algorithm Framework')">Algorithm Framework</button>
@@ -18489,7 +18294,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L138">line 138 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L138">line 138 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
         </div>
         
     </div>
@@ -18533,7 +18338,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2614">line 2614 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2614">line 2614 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -18580,11 +18385,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L313">line 313 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L313">line 313 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -18625,11 +18429,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L324">line 324 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L324">line 324 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -18670,11 +18473,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L335">line 335 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L335">line 335 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Charting')">Charting</button>
@@ -18715,7 +18517,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L346">line 346 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Plotting.cs#L346">line 346 of file Algorithm/QCAlgorithm.Plotting.cs.</a></p>
         </div>
         
     </div>
@@ -18759,11 +18561,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1082">line 1082 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1082">line 1082 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -18801,11 +18602,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L767">line 767 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L767">line 767 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -18843,11 +18643,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L793">line 793 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L793">line 793 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Adding Data')">Adding Data</button>
@@ -18885,7 +18684,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L805">line 805 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L805">line 805 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -18936,11 +18735,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1400">line 1400 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1400">line 1400 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Handling Data')">Handling Data</button>
@@ -18977,7 +18775,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1461">line 1461 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1461">line 1461 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -19020,11 +18818,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1087">line 1087 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1087">line 1087 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Handling Data')">Handling Data</button>
@@ -19061,7 +18858,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1107">line 1107 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1107">line 1107 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -19104,7 +18901,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1567">line 1567 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L1567">line 1567 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -19148,11 +18945,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L280">line 280 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.cs#L280">line 280 of file Algorithm/QCAlgorithm.Framework.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Algorithm Framework')">Algorithm Framework</button>
@@ -19190,7 +18986,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L106">line 106 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Framework.Python.cs#L106">line 106 of file Algorithm/QCAlgorithm.Framework.Python.cs.</a></p>
         </div>
         
     </div>
@@ -19233,11 +19029,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L63">line 63 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L63">line 63 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -19278,11 +19073,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L85">line 85 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L85">line 85 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -19319,11 +19113,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L111">line 111 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L111">line 111 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -19364,7 +19157,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L135">line 135 of file Algorithm/QCAlgorithm.History.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L135">line 135 of file Algorithm/QCAlgorithm.History.cs.</a></p>
         </div>
         
     </div>
@@ -19407,11 +19200,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2750">line 2750 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2750">line 2750 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -19452,7 +19244,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2762">line 2762 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2762">line 2762 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -19496,7 +19288,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2791">line 2791 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2791">line 2791 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -19559,11 +19351,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L480">line 480 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L480">line 480 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -19620,11 +19411,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L496">line 496 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L496">line 496 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -19681,7 +19471,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L512">line 512 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L512">line 512 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -19740,11 +19530,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L431">line 431 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L431">line 431 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -19797,11 +19586,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L446">line 446 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L446">line 446 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Trading and Orders')">Trading and Orders</button>
@@ -19854,7 +19642,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L461">line 461 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Trading.cs#L461">line 461 of file Algorithm/QCAlgorithm.Trading.cs.</a></p>
         </div>
         
     </div>
@@ -19899,7 +19687,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2557">line 2557 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2557">line 2557 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -19958,7 +19746,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1994">line 1994 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1994">line 1994 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20017,7 +19805,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1884">line 1884 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1884">line 1884 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20072,7 +19860,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2017">line 2017 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2017">line 2017 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20135,7 +19923,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1162">line 1162 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1162">line 1162 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20186,7 +19974,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2067">line 2067 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2067">line 2067 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20241,7 +20029,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2090">line 2090 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2090">line 2090 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20288,11 +20076,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2319">line 2319 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2319">line 2319 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -20333,7 +20120,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2331">line 2331 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2331">line 2331 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20388,7 +20175,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2113">line 2113 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2113">line 2113 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20455,7 +20242,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2044">line 2044 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2044">line 2044 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20499,11 +20286,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1277">line 1277 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1277">line 1277 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Machine Learning')">Machine Learning</button>
@@ -20549,11 +20335,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1290">line 1290 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L1290">line 1290 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Machine Learning')">Machine Learning</button>
@@ -20591,11 +20376,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2677">line 2677 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2677">line 2677 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Machine Learning')">Machine Learning</button>
@@ -20641,7 +20425,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2690">line 2690 of file Algorithm/QCAlgorithm.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.cs#L2690">line 2690 of file Algorithm/QCAlgorithm.cs.</a></p>
         </div>
         
     </div>
@@ -20704,7 +20488,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2138">line 2138 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2138">line 2138 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20759,7 +20543,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2161">line 2161 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2161">line 2161 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20822,7 +20606,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1136">line 1136 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L1136">line 1136 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20877,11 +20661,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2185">line 2185 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2185">line 2185 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Indicators')">Indicators</button>
@@ -20918,7 +20701,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2206">line 2206 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2206">line 2206 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -20973,7 +20756,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2225">line 2225 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2225">line 2225 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -21028,7 +20811,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2250">line 2250 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2250">line 2250 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
@@ -21084,11 +20867,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L660">line 660 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L660">line 660 of file Algorithm/QCAlgorithm.Python.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -21138,11 +20920,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2659">line 2659 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2659">line 2659 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -21192,11 +20973,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2675">line 2675 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2675">line 2675 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -21246,11 +21026,10 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2701">line 2701 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2701">line 2701 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>
-
 
     <div class="method-header">
         <button class="method-tag" onclick="openTopTab(event, 'Historical Data')">Historical Data</button>
@@ -21300,7 +21079,7 @@ See also: <code>Market</code>.
         </div>
 
         <div class="method-def">
-            <p>Definition at <a href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2718">line 2718 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
+            <p>Definition at <a rel="nofollow" target="_blank" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Indicators.cs#L2718">line 2718 of file Algorithm/QCAlgorithm.Indicators.cs.</a></p>
         </div>
         
     </div>


### PR DESCRIPTION
Adds `rel="nofollow" target="_blank"` to URL pointing to code in QuantConnect/Lean.