### PR TITLE
Fix python Callable type helpers

### DIFF
--- a/03 Writing Algorithms/12 Universes/05 Crypto/02 Crypto Universes.html
+++ b/03 Writing Algorithms/12 Universes/05 Crypto/02 Crypto Universes.html
@@ -44,7 +44,7 @@
         </tr>
         <tr>
             <td><code>universeFilterFunc</code></td>
-	        <td><code class="csharp">Func&lt;IEnumerable&lt;CryptoCoarseFundamental&gt;, IEnumerable&lt;Symbol&gt;&gt;</code><code class="python">callable[List[CryptoCoarseFundamental], List[Symbol]]</code></td>
+	        <td><code class="csharp">Func&lt;IEnumerable&lt;CryptoCoarseFundamental&gt;, IEnumerable&lt;Symbol&gt;&gt;</code><code class="python">Callable[[List[CryptoCoarseFundamental]], List[Symbol]]</code></td>
             <td>A function to select some of the Cryptocurrencies for the universe.<br></td>
             <td></td>
         </tr>

--- a/03 Writing Algorithms/12 Universes/06 Futures/13 Filter Contracts.php
+++ b/03 Writing Algorithms/12 Universes/06 Futures/13 Filter Contracts.php
@@ -13,7 +13,7 @@
 	        <td>Selects the contracts that expire within the range you set.<br></td>
         </tr>
         <tr>
-            <td><code class="csharp">SetFilter(Func&lt;FutureFilterUniverse, FutureFilterUniverse&gt; universeFunc)</code><code class="python">SetFilter(universeFunc: callable[FutureFilterUniverse, FutureFilterUniverse])</code></td>
+            <td><code class="csharp">SetFilter(Func&lt;FutureFilterUniverse, FutureFilterUniverse&gt; universeFunc)</code><code class="python">SetFilter(universeFunc: Callable[[FutureFilterUniverse], FutureFilterUniverse])</code></td>
 	        <td>Selects the contracts that a function selects.</td>
         </tr>
     </tbody>

--- a/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/05 ETF Constituents Universes/02 Add ETF Constituents Universe Selection.html
+++ b/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/05 ETF Constituents Universes/02 Add ETF Constituents Universe Selection.html
@@ -31,7 +31,7 @@
         </tr>
         <tr>
             <td><code>universeFilterFunc</code></td>
-	    <td><code class="csharp">Func&lt;IEnumerable&lt;ETFConstituentData&gt;, IEnumerable&lt;Symbol&gt;&gt;</code><code class="python">Callable[List[ETFConstituentData], List[Symbol]]</code></td>
+	    <td><code class="csharp">Func&lt;IEnumerable&lt;ETFConstituentData&gt;, IEnumerable&lt;Symbol&gt;&gt;</code><code class="python">Callable[[List[ETFConstituentData]], List[Symbol]]</code></td>
             <td>Function to filter ETF constituents. If you don't provide an argument, the model selects all of the ETF constituents by default.</td>
             <td><code class="csharp">null</code><code class="python">None</code></td>
         </tr>

--- a/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/07 Futures Universes/50 Future Universe Selection.php
+++ b/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/07 Futures Universes/50 Future Universe Selection.php
@@ -27,7 +27,7 @@ self.AddUniverseSelection(FutureUniverseSelectionModel(refreshInterval, futureCh
         </tr>
         <tr>
             <td><code>futureChainSymbolSelector</code></td>
-	    <td><code class="csharp">Func&lt;DateTime, IEnumerable&lt;Symbol&gt;&gt;</code><code class="python">Callable[datetime, List[Symbol]]</code></td>
+	    <td><code class="csharp">Func&lt;DateTime, IEnumerable&lt;Symbol&gt;&gt;</code><code class="python">Callable[[datetime], List[Symbol]]</code></td>
             <td>A function that selects the Future symbols<br></td>
             <td></td>
         </tr>

--- a/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/08 Options Universes/60 Options Universe Selection.php
+++ b/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/08 Options Universes/60 Options Universe Selection.php
@@ -27,7 +27,7 @@ self.AddUniverseSelection(OptionUniverseSelectionModel(refreshInterval, optionCh
         </tr>
         <tr>
             <td><code>optionChainSymbolSelector</code></td>
-	    <td><code class="csharp">Func&lt;DateTime, IEnumerable&lt;Symbol&gt;&gt;</code><code class="python">Callable[datetime, List[Symbol]]</code></td>
+	    <td><code class="csharp">Func&lt;DateTime, IEnumerable&lt;Symbol&gt;&gt;</code><code class="python">Callable[[datetime], List[Symbol]]</code></td>
             <td>A function that selects the Option symbols<br></td>
             <td></td>
         </tr>

--- a/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/08 Options Universes/61 Option Chained Universe Selection.php
+++ b/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/08 Options Universes/61 Option Chained Universe Selection.php
@@ -27,7 +27,7 @@
         </tr>
         <tr>
             <td><code>optionFilter</code></td>
-	    <td><code class="csharp">Func&lt;OptionFilterUniverse, OptionFilterUniverse&gt;</code><code class="python">Callable[OptionFilterUniverse, OptionFilterUniverse]</code></td>
+	    <td><code class="csharp">Func&lt;OptionFilterUniverse, OptionFilterUniverse&gt;</code><code class="python">Callable[[OptionFilterUniverse], OptionFilterUniverse]</code></td>
             <td>The Option filter universe to use</td>
             <td></td>
         </tr>

--- a/Resources/universes/future/future-filter-universe.html
+++ b/Resources/universes/future/future-filter-universe.html
@@ -43,7 +43,7 @@
             <td>Selects a list of contracts</td>
         </tr>
         <tr>
-            <td><code class="csharp">Contracts(Func&lt;IEnumerable&lt;Symbol&gt;, IEnumerable&lt; Symbol&gt;&gt; contractSelector)</code><code class="python">Contracts(contractSelector: callable[List[Symbol], List[Symbol]])</code></td>
+            <td><code class="csharp">Contracts(Func&lt;IEnumerable&lt;Symbol&gt;, IEnumerable&lt; Symbol&gt;&gt; contractSelector)</code><code class="python">Contracts(contractSelector: Callable[[List[Symbol]], List[Symbol]])</code></td>
             <td>Selects contracts that a selector function selects</td>
         </tr>
         <tr>

--- a/Resources/universes/option/option-filter-universe.html
+++ b/Resources/universes/option/option-filter-universe.html
@@ -55,7 +55,7 @@
             <td>Selects a list of contracts</td>
         </tr>
         <tr>
-            <td><code class="csharp">Contracts(Func&lt;IEnumerable&lt;Symbol&gt;, IEnumerable&lt; Symbol&gt;&gt; contractSelector)</code><code class="python">Contracts(contractSelector: callable[List[Symbol], List[Symbol]])</code></td>
+            <td><code class="csharp">Contracts(Func&lt;IEnumerable&lt;Symbol&gt;, IEnumerable&lt; Symbol&gt;&gt; contractSelector)</code><code class="python">Contracts(contractSelector: Callable[[List[Symbol]], List[Symbol]])</code></td>
             <td>Selects contracts that a selector function selects</td>
         </tr>
         <tr>

--- a/Resources/universes/option/set-filter.php
+++ b/Resources/universes/option/set-filter.php
@@ -26,7 +26,7 @@
 	        <td>Selects the contracts that expire and have a strike within the range you set.</td>
         </tr>
         <tr>
-            <td><code class="csharp">SetFilter(Func&lt;OptionFilterUniverse, OptionFilterUniverse&gt; universeFunc)</code><code class="python">SetFilter(universeFunc: callable[OptionFilterUniverse, OptionFilterUniverse])</code></td>
+            <td><code class="csharp">SetFilter(Func&lt;OptionFilterUniverse, OptionFilterUniverse&gt; universeFunc)</code><code class="python">SetFilter(universeFunc: Callable[[OptionFilterUniverse], OptionFilterUniverse])</code></td>
 	        <td>Selects the contracts that a function selects.</td>
         </tr>
     </tbody>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Update some of the Python code snippets so the type helpers are correct.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The correct syntax is `Callable[[Arg1Type, Arg2Type], ReturnType]`
See https://docs.python.org/3/library/typing.html#callable

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
