### PR TITLE
Add examples of call/put calendar spread from LEAN

### DIFF
--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/07 Call Calendar Spread/04 Example.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/07 Call Calendar Spread/04 Example.html
@@ -60,3 +60,16 @@ $$
         </div>
     </div>
 </div>
+
+<div class="example-fieldset">
+    <div class="example-legend">Demonstration Algorithm</div>
+    
+    <a class="python example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/IndexOptionCallCalendarSpreadAlgorithm.py" target="_BLANK">
+        IndexOptionCallCalendarSpreadAlgorithm.py  <span class="badge-python pull-right">Python</span>
+    </a>
+    
+    <a class="csharp example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.CSharp/IndexOptionCallCalendarSpreadAlgorithm.cs" target="_BLANK">
+        IndexOptionCallCalendarSpreadAlgorithm.cs  <span class="badge badge-sm badge-csharp pull-right">C#</span>
+    </a>
+
+  </div>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/15 Put Calendar Spread/04 Example.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/15 Put Calendar Spread/04 Example.html
@@ -63,3 +63,16 @@ $$
         </div>
     </div>
 </div>
+
+<div class="example-fieldset">
+    <div class="example-legend">Demonstration Algorithm</div>
+    
+    <a class="python example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/IndexOptionPutCalendarSpreadAlgorithm.py" target="_BLANK">
+        IndexOptionPutCalendarSpreadAlgorithm.py  <span class="badge-python pull-right">Python</span>
+    </a>
+    
+    <a class="csharp example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.CSharp/IndexOptionPutCalendarSpreadAlgorithm.cs" target="_BLANK">
+        IndexOptionPutCalendarSpreadAlgorithm.cs  <span class="badge badge-sm badge-csharp pull-right">C#</span>
+    </a>
+
+  </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Add index weekly option example from LEAN repo to option strategy page of call/put calendar spread. 
Note: The links only works if https://github.com/QuantConnect/Lean/pull/6907 is being merged.

#### Motivation and Context
Better and more example.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->