### PR TITLE
Add index weeklies bull/bear put spread algos to examples

### DIFF
--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/02 Bear Put Spread/04 Example.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/02 Bear Put Spread/04 Example.html
@@ -63,3 +63,18 @@ $$
         </div>
     </div>
 </div>
+
+<br>
+
+<div class="example-fieldset">
+    <div class="example-legend">Demonstration Algorithm</div>
+    
+    <a class="python example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/IndexOptionBearPutSpreadAlgorithm.py" target="_BLANK">
+        IndexOptionBearPutSpreadAlgorithm.py  <span class="badge-python pull-right">Python</span>
+    </a>
+    
+    <a class="csharp example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.CSharp/IndexOptionBearPutSpreadAlgorithm.cs" target="_BLANK">
+        IndexOptionBearPutSpreadAlgorithm.cs  <span class="badge badge-sm badge-csharp pull-right">C#</span>
+    </a>
+
+  </div>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/04 Bull Put Spread/04 Example.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/04 Bull Put Spread/04 Example.html
@@ -61,3 +61,18 @@ $$
         </div>
     </div>
 </div>
+
+<br>
+
+<div class="example-fieldset">
+    <div class="example-legend">Demonstration Algorithm</div>
+    
+    <a class="python example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/IndexOptionBullPutSpreadAlgorithm.py" target="_BLANK">
+        IndexOptionBullPutSpreadAlgorithm.py  <span class="badge-python pull-right">Python</span>
+    </a>
+    
+    <a class="csharp example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.CSharp/IndexOptionBullPutSpreadAlgorithm.cs" target="_BLANK">
+        IndexOptionBullPutSpreadAlgorithm.cs  <span class="badge badge-sm badge-csharp pull-right">C#</span>
+    </a>
+
+  </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Add index weekly option examples from LEAN repo to option strategy page of bear/bull put spread. 
Note: The links only works if https://github.com/QuantConnect/Lean/pull/6914 is being merged.

#### Motivation and Context
Better and more example.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->