### PR TITLE
Refactors logging-statements

### DIFF
--- a/01 Cloud Platform/06 Projects/06 Debugging/04 Logging Statements.php
+++ b/01 Cloud Platform/06 Projects/06 Debugging/04 Logging Statements.php
@@ -1,10 +1,7 @@
 <? include(DOCS_RESOURCES."/logging-statements/introduction.php"); ?>
 
 <h4>Log</h4>
-<?
-$isOnOurPlatform = true;
-include(DOCS_RESOURCES."/logging-statements/log.php");
-?>
+<? include(DOCS_RESOURCES."/logging-statements/log.php"); ?>
 
 <h4>Debug</h4>
 <? include(DOCS_RESOURCES."/logging-statements/debug.php"); ?>

--- a/01 Cloud Platform/06 Projects/06 Debugging/04 Logging Statements.php
+++ b/01 Cloud Platform/06 Projects/06 Debugging/04 Logging Statements.php
@@ -1,20 +1,16 @@
-<?php 
-include(DOCS_RESOURCES."/logging-statements/introduction.php"); 
-$terminalLink = "/docs/v2/cloud-platform/projects/ide#06-Cloud-Terminal";
-$getLogIntroText($terminalLink);
-?>
+<? include(DOCS_RESOURCES."/logging-statements/introduction.php"); ?>
 
 <h4>Log</h4>
-<?php
+<?
+$isOnOurPlatform = true;
 include(DOCS_RESOURCES."/logging-statements/log.php");
-$getLogText(true);
 ?>
 
 <h4>Debug</h4>
-<?php echo file_get_contents(DOCS_RESOURCES."/logging-statements/debug.php"); ?>
+<? include(DOCS_RESOURCES."/logging-statements/debug.php"); ?>
 
 <h4>Error</h4>
-<?php echo file_get_contents(DOCS_RESOURCES."/logging-statements/error.php"); ?>
+<? include(DOCS_RESOURCES."/logging-statements/error.php"); ?>
 
 <h4>Quit</h4>
-<?php echo file_get_contents(DOCS_RESOURCES."/logging-statements/quit.php"); ?>
+<? include(DOCS_RESOURCES."/logging-statements/quit.php"); ?>

--- a/03 Writing Algorithms/38 Logging/01 Introduction.php
+++ b/03 Writing Algorithms/38 Logging/01 Introduction.php
@@ -1,4 +1,1 @@
-<?php 
-include(DOCS_RESOURCES."/logging-statements/introduction.php"); 
-$getLogIntroText("");
-?>
+<? include(DOCS_RESOURCES."/logging-statements/introduction.php"); ?>

--- a/03 Writing Algorithms/38 Logging/02 Log Messages.php
+++ b/03 Writing Algorithms/38 Logging/02 Log Messages.php
@@ -1,4 +1,4 @@
-<?php
+<?
+$isOnOurPlatform = false;
 include(DOCS_RESOURCES."/logging-statements/log.php");
-$getLogText(false);
 ?>

--- a/03 Writing Algorithms/38 Logging/02 Log Messages.php
+++ b/03 Writing Algorithms/38 Logging/02 Log Messages.php
@@ -1,4 +1,1 @@
-<?
-$isOnOurPlatform = false;
-include(DOCS_RESOURCES."/logging-statements/log.php");
-?>
+<? include(DOCS_RESOURCES."/logging-statements/log.php"); ?>

--- a/03 Writing Algorithms/38 Logging/03 Debug Messages.php
+++ b/03 Writing Algorithms/38 Logging/03 Debug Messages.php
@@ -1,1 +1,1 @@
-<?php echo file_get_contents(DOCS_RESOURCES."/logging-statements/debug.php"); ?>
+<? include(DOCS_RESOURCES."/logging-statements/debug.php"); ?>

--- a/03 Writing Algorithms/38 Logging/04 Error Messages.php
+++ b/03 Writing Algorithms/38 Logging/04 Error Messages.php
@@ -1,1 +1,1 @@
-<?php echo file_get_contents(DOCS_RESOURCES."/logging-statements/error.php"); ?>
+<? include(DOCS_RESOURCES."/logging-statements/error.php"); ?>

--- a/03 Writing Algorithms/38 Logging/05 Quit Messages.php
+++ b/03 Writing Algorithms/38 Logging/05 Quit Messages.php
@@ -1,1 +1,1 @@
-<?php echo file_get_contents(DOCS_RESOURCES."/logging-statements/quit.php"); ?>
+<? include(DOCS_RESOURCES."/logging-statements/quit.php"); ?>

--- a/03 Writing Algorithms/40 Live Trading/41 Charting and Logging/03 Logging.php
+++ b/03 Writing Algorithms/40 Live Trading/41 Charting and Logging/03 Logging.php
@@ -1,7 +1,4 @@
-<?php 
-include(DOCS_RESOURCES."/logging-statements/introduction.php"); 
-$getLogIntroText("");
-?>
+<? include(DOCS_RESOURCES."/logging-statements/introduction.php"); ?>
 
 <p>If you run algorithms on QuantConnect, you must stay within the <a href="/docs/v2/cloud-platform/organizations/resources#09-Log-Quotas">log quota</a>. To only log when your algorithm is live, use the <code>LiveMode</code> property.</p>
 

--- a/Resources/logging-statements/introduction.php
+++ b/Resources/logging-statements/introduction.php
@@ -1,10 +1,2 @@
-<?php
-$getLogIntroText = function($terminalLink)
-{
-    echo "
 <p>Algorithms can record string messages ('log statements') to a file for analysis after a backtest is complete, or as a live algorithm is running. These records can assist in debugging logical flow errors in the project code. Consider adding them in the code block of an <code>if</code> statement to signify an error has been caught.</p>
-
 <p>It's good practice to add logging statements to live algorithms so you can understand its behavior and keep records to compare against backtest results. If you don't add logging statements to a live algorithm and the algorithm doesn't trade as you expect, it's difficult to evaluate the underlying problem.</p>
-    ";
-}
-?>

--- a/Resources/logging-statements/log.php
+++ b/Resources/logging-statements/log.php
@@ -1,28 +1,6 @@
-<?php
-
-$getLogText = function($isOnOurPlatform) {
-    $result = "<p>Log statements are added to the log file while your algorithm continues executing. Logging dataset information is not permitted. Use <code>Log</code> statements to debug your backtests and live trading algorithms.</p><p>";
-    
-    if ($isOnOurPlatform) {
-        $result .= "L";
-    }
-    else
-    {
-        $result .= "If you execute algorithms in QuantConnect Cloud, l";
-    }
-    $result .= "og length is <a href='/docs/v2/cloud-platform/organizations/resources#09-Log-Quotas'>capped by organization tier</a>. If your organization hits the daily limit, <a href='/contact'>contact us</a>.</p><p>If you log the same content multiple times, only the first instance is added to the log file. To bypass this rate-limit, add a timestamp to your log messages.</p><p>For live trading, the log files of each cloud project can store up to 100,000 lines for up to one year. If you log more than 100,000 lines or some lines become older than one year, we remove the oldest lines in the files so your project stays within the quota.</p> <p>To record the algorithm state when the algorithm stops executing, add log statements to the <code>OnEndOfAlgorithm</code> event handler.</p>";
-     
-    $result .= "<div class='section-example-container'>
-                    <pre class='csharp'>Log(\"My log message\");</pre>
-                    <pre class='python'>self.Log(\"My log message\")</pre>
-                </div>";
-    
-    echo $result;
-}
-
-?>
-
-
-
-
-
+<p>Log statements are added to the log file while your algorithm continues executing. Logging dataset information is not permitted. Use <code>Log</code> statements to debug your backtests and live trading algorithms.</p>
+<p><? if ($isOnOurPlatform) { ?>L<?} else {?>If you execute algorithms in QuantConnect Cloud, l<? } ?>og length is <a href='/docs/v2/cloud-platform/organizations/resources#09-Log-Quotas'>capped by organization tier</a>. If your organization hits the daily limit, <a href='/contact'>contact us</a>.</p><p>If you log the same content multiple times, only the first instance is added to the log file. To bypass this rate-limit, add a timestamp to your log messages.</p><p>For live trading, the log files of each cloud project can store up to 100,000 lines for up to one year. If you log more than 100,000 lines or some lines become older than one year, we remove the oldest lines in the files so your project stays within the quota.</p> <p>To record the algorithm state when the algorithm stops executing, add log statements to the <code>OnEndOfAlgorithm</code> event handler.</p>
+<div class='section-example-container'>
+    <pre class='csharp'>Log(\"My log message\");</pre>
+    <pre class='python'>self.Log(\"My log message\")</pre>
+</div>

--- a/Resources/logging-statements/log.php
+++ b/Resources/logging-statements/log.php
@@ -1,6 +1,14 @@
 <p>Log statements are added to the log file while your algorithm continues executing. Logging dataset information is not permitted. Use <code>Log</code> statements to debug your backtests and live trading algorithms.</p>
-<p><? if ($isOnOurPlatform) { ?>L<?} else {?>If you execute algorithms in QuantConnect Cloud, l<? } ?>og length is <a href='/docs/v2/cloud-platform/organizations/resources#09-Log-Quotas'>capped by organization tier</a>. If your organization hits the daily limit, <a href='/contact'>contact us</a>.</p><p>If you log the same content multiple times, only the first instance is added to the log file. To bypass this rate-limit, add a timestamp to your log messages.</p><p>For live trading, the log files of each cloud project can store up to 100,000 lines for up to one year. If you log more than 100,000 lines or some lines become older than one year, we remove the oldest lines in the files so your project stays within the quota.</p> <p>To record the algorithm state when the algorithm stops executing, add log statements to the <code>OnEndOfAlgorithm</code> event handler.</p>
+
+<p><?=$cloudPlatform ? "Log length " : "If you execute algorithms in QuantConnect Cloud, log length " ?> is <a href='/docs/v2/cloud-platform/organizations/resources#09-Log-Quotas'>capped by organization tier</a>. If your organization hits the daily limit, <a href='/contact'>contact us</a>.</p>
+
+<p>If you log the same content multiple times, only the first instance is added to the log file. To bypass this rate-limit, add a timestamp to your log messages.</p>
+
+<p>For live trading, the log files of each cloud project can store up to 100,000 lines for up to one year. If you log more than 100,000 lines or some lines become older than one year, we remove the oldest lines in the files so your project stays within the quota.</p>
+
+<p>To record the algorithm state when the algorithm stops executing, add log statements to the <code>OnEndOfAlgorithm</code> event handler.</p>
+
 <div class='section-example-container'>
-    <pre class='csharp'>Log(\"My log message\");</pre>
-    <pre class='python'>self.Log(\"My log message\")</pre>
+    <pre class='csharp'>Log("My log message");</pre>
+    <pre class='python'>self.Log("My log message")</pre>
 </div>


### PR DESCRIPTION
Note:  `$terminalLink` was removed since it was not being used:
https://github.com/QuantConnect/Documentation/compare/logging-statements?expand=1#diff-8e253ad2298292b3347b5e79e12b03739d9d8a5d744d60ade53fe86c7b72d70aL2