### PR TITLE
Add order update workaround

### DIFF
--- a/03 Writing Algorithms/22 Trading and Orders/02 Order Management/01 Order Tickets/05 Cancel Orders.html
+++ b/03 Writing Algorithms/22 Trading and Orders/02 Order Management/01 Order Tickets/05 Cancel Orders.html
@@ -1,5 +1,4 @@
-<p>To cancel an order, call the <code>Cancel</code> method on the <code>OrderTicket</code>. You can't cancel market orders because they transmitted to the brokerage immediately. The method returns an <code>OrderResponse</code> object to signal the success or failure of the cancel request. 
-</p>
+<p>To cancel an order, call the <code>Cancel</code> method on the <code>OrderTicket</code>. The method returns an <code>OrderResponse</code> object to signal the success or failure of the cancel request.</p>
 
 <div class="section-example-container">
 <pre class="csharp">// Create an order and save its ticket
@@ -23,6 +22,8 @@ response = ticket.Cancel("Canceled SPY Trade")
 if response.IsSuccess:
     self.Debug("Order successfully canceled")</pre>
 </div>
+
+<p>You can't cancel market orders because they transmitted to the brokerage immediately. You also can't cancel any orders during <a href='/docs/v2/writing-algorithms/historical-data/warm-up-periods'>warm up</a> and <a href='/docs/v2/writing-algorithms/initialization'>initialization</a>.</p>
 
 <p>When you cancel an order, LEAN creates a <code>CancelOrderRequest</code>, which have the following attributes:</p>
 <div data-tree='QuantConnect.Orders.CancelOrderRequest'></div>

--- a/Resources/brokerages/binance/orders.php
+++ b/Resources/brokerages/binance/orders.php
@@ -119,4 +119,4 @@ def OnData(self, slice: Slice) -&gt; None:
 <?php } ?>
 
 <h4>Updates</h4>
-<p><?= $writingAlgorithms ? "The Binance and Binance US brokerage models don't support" : "We model the Binance and Binance US APIs by not supporting" ?> order updates, but you can cancel an existing order and then create a new order with the desired arguments.</p>
+<p><?= $writingAlgorithms ? "The Binance and Binance US brokerage models don't support" : "We model the Binance and Binance US APIs by not supporting" ?> order updates, but you can cancel an existing order and then create a new order with the desired arguments. For more information about this workaround, see the <a href='/docs/v2/writing-algorithms/trading-and-orders/order-management/order-tickets#workaround-for-brokerages-that-dont-support-updates'>Workaround for Brokerages That Don’t Support Updates</a>.</p>

--- a/Resources/brokerages/coinbase/orders.php
+++ b/Resources/brokerages/coinbase/orders.php
@@ -101,6 +101,6 @@ def OnData(self, slice: Slice) -&gt; None:
 <?php } ?>
 
 <h4>Updates</h4>
-<p><?= $writingAlgorithms ? "The <code>GDAXBrokerageModel</code> doesn't support order updates" : "We model the Coinbase API by not supporting order updates" ?>, but you can cancel an existing order and then create a new order with the desired arguments.</p>
+<p><?= $writingAlgorithms ? "The <code>GDAXBrokerageModel</code> doesn't support order updates" : "We model the Coinbase API by not supporting order updates" ?>, but you can cancel an existing order and then create a new order with the desired arguments. For more information about this workaround, see the <a href='/docs/v2/writing-algorithms/trading-and-orders/order-management/order-tickets#workaround-for-brokerages-that-dont-support-updates'>Workaround for Brokerages That Don’t Support Updates</a>.</p>
 
 

--- a/Resources/brokerages/kraken/orders.php
+++ b/Resources/brokerages/kraken/orders.php
@@ -157,5 +157,5 @@ def OnData(self, slice: Slice) -&gt; None:
 <?php } ?>
 
 <h4>Updates</h4>
-<p><?= $writingAlgorithms ? "The <code>KrakenBrokerageModel</code> doesn't support order updates" : "We model the Kraken API by not supporting order updates" ?>, but you can cancel an existing order and then create a new order with the desired arguments.</p>
+<p><?= $writingAlgorithms ? "The <code>KrakenBrokerageModel</code> doesn't support order updates" : "We model the Kraken API by not supporting order updates" ?>, but you can cancel an existing order and then create a new order with the desired arguments. For more information about this workaround, see the <a href='/docs/v2/writing-algorithms/trading-and-orders/order-management/order-tickets#workaround-for-brokerages-that-dont-support-updates'>Workaround for Brokerages That Don’t Support Updates</a>.</p>
 

--- a/Resources/brokerages/tradier/orders.php
+++ b/Resources/brokerages/tradier/orders.php
@@ -95,7 +95,7 @@ def OnData(self, slice: Slice) -&gt; None:
 <?php } ?>
 
 <h4>Updates</h4>
-<p><?= $writingAlgorithms ? "The <code>TradierBrokerageModel</code> supports" : "We model the Tradier API by supporting" ?> most <a href='/docs/v2/writing-algorithms/trading-and-orders/order-management/order-tickets#04-Update-Orders'>order updates</a>. To update the quantity of an order, cancel the order and then submit a new order with the desired quantity.</p>
+<p><?= $writingAlgorithms ? "The <code>TradierBrokerageModel</code> supports" : "We model the Tradier API by supporting" ?> most <a href='/docs/v2/writing-algorithms/trading-and-orders/order-management/order-tickets#04-Update-Orders'>order updates</a>. To update the quantity of an order, cancel the order and then submit a new order with the desired quantity. For more information about this workaround, see the <a href='/docs/v2/writing-algorithms/trading-and-orders/order-management/order-tickets#workaround-for-brokerages-that-dont-support-updates'>Workaround for Brokerages That Don’t Support Updates</a>.</p>
 
 
 <h4>Extended Market Hours</h4>

--- a/Resources/order-types/update-requests.html
+++ b/Resources/order-types/update-requests.html
@@ -1,7 +1,7 @@
 <p>When you update an order, LEAN creates an <code>UpdateOrderRequest</code> object, which have the following attributes:</p>
 <div data-tree="QuantConnect.Orders.UpdateOrderRequest"></div>
 
-<p>To get a list of <code>UpdateOrderRequest</code> objects for an order, call the <code>UpdateRequests</code> method.</p>
+<p><a id='workaround-for-brokerages-that-dont-support-updates'></a>To get a list of <code>UpdateOrderRequest</code> objects for an order, call the <code>UpdateRequests</code> method.</p>
 
 <div class="section-example-container">
 <pre class="csharp">var updateRequests = orderTicket.UpdateRequests();</pre>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Add order update workaround for brokerages that don't fully support order updates.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Missing content

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
