### PR TITLE
Fix display bug on C# dataframe wrangling data

### DIFF
--- a/Resources/datasets/wrangle-data.php
+++ b/Resources/datasets/wrangle-data.php
@@ -125,7 +125,7 @@
 <? } ?>
 
 <p class="csharp">You may construct a <code>Microsoft.Data.Analysis.DataFrame</code> object from the historical data for efficient vectorized data wrangling.</p>
-<div class='section-example-container'>
+<div class='csharp section-example-container'>
 <pre class='csharp'>var columns = new DataFrameColumn[] {
     new PrimitiveDataFrameColumn<DateTime>("Time", history.Select(x => x[<?=$primarySymbolC?>].EndTime)),
     new DecimalDataFrameColumn("<?=$primaryTicker?> Open", history.Select(x => x[<?=$primarySymbolC?>].Open)),
@@ -146,7 +146,7 @@ df</pre>
 
 <h4>Slice Objects</h4>
 <p>If the <code>History</code> method returns <code>Slice</code> objects, iterate through the <code>Slice</code> objects to get each one. The <code>Slice</code> objects may not have data for all of your <?=$assetClass?> subscriptions. To avoid issues, check if the <code>Slice</code> contains data for your <?=$singularAssetClass?> before you index it with the <?=$assetClass?> <code>Symbol</code>.</p>
-<div class='section-example-container'>
+<div class='csharp section-example-container'>
 <pre class='csharp'>foreach (var slice in allHistorySlice) {
 <? if ($supportsAltData) {?>
     if (slice.ContainsKey(<?=$primarySymbolC?>))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Fixing the display bug on `Research Environment/Datasets/**#Wrangling data` that C# snippet was presented when using python.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
