### PR TITLE
Adding authentication step before lean init

### DIFF
--- a/05 Lean CLI/01 Key Concepts/01 Getting Started/03 Installation.php
+++ b/05 Lean CLI/01 Key Concepts/01 Getting Started/03 Installation.php
@@ -1,13 +1,14 @@
 <p>
     Run <code>pip install lean</code> in a terminal to install the latest version of the CLI.
 </p>
-
 <p>
-    After installing the CLI, open a terminal in an empty directory and run <code>lean init</code> to create your first workspace.
+   Open a terminal and run <code> lean login</code>. Enter userId and token.<a href="https://www.quantconnect.com/docs/v2/cloud-platform/community/profile#09-Request-API-Token" target="_blank">Request a token></a>
+</p>
+<p>
+    After authentication, open a terminal in an empty directory and run <code>lean init</code> to create your first workspace.
     The command downloads the latest configuration file and sample data from the <a href="https://github.com/QuantConnect/Lean" target="_blank">QuantConnect/Lean</a> repository.
     We recommend running all Lean CLI commands in your workspace directory.
 </p>
-
 <div class="cli section-example-container">
 <pre>$ lean init
 Downloading latest sample data from the Lean repository...


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding the authentication step between the pip install lean and the lean init
#### Description
<!--- Describe your changes in detail -->
Changed the documentation php file to add an extra step 
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No issue
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Incomplete documentation
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
