### PR TITLE
Remove ObjectStore.Save in ML pages

### DIFF
--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/01 GPlearn/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/01 GPlearn/07 Save Models.html
@@ -19,10 +19,4 @@ regressor_file_name = self.ObjectStore.GetFilePath(regressor_model_key)</pre>
 joblib.dump(self.model, regressor_file_name)</pre>
     </div>
     <p>If you dump the models using the <code>joblib</code> module before you save the models, you don't need to retrain the models.</p>
-
-    <li>Call the <code>Save</code> method with the keys.</li>
-    <div class="section-example-container">
-        <pre class="python">self.ObjectStore.Save(transformer_model_key)
-self.ObjectStore.Save(regressor_model_key)</pre>
-    </div>
 </ol>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/05 PyTorch/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/05 PyTorch/07 Save Models.html
@@ -16,9 +16,4 @@
         <pre class="python">joblib.dump(self.model, file_name)</pre>
     </div>
     <p>If you dump the model using the <code>joblib</code> module before you save the model, you don't need to retrain the model.</p>
-
-    <li>Call the <code>Save</code> method with the key.</li>
-    <div class="section-example-container">
-        <pre class="python">self.ObjectStore.Save(model_key)</pre>
-    </div>
 </ol>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/06 Scikit-Learn/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/06 Scikit-Learn/07 Save Models.html
@@ -17,9 +17,4 @@
         <pre class="python">joblib.dump(self.model, file_name)</pre>
     </div>
     <p>If you dump the model using the <code>joblib</code> module before you save the model, you don't need to retrain the model.</p>
-
-    <li>Call the <code>Save</code> method with the key.</li>
-    <div class="section-example-container">
-        <pre class="python">self.ObjectStore.Save(model_key)</pre>
-    </div>
 </ol>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/10 XGBoost/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/10 XGBoost/07 Save Models.html
@@ -16,9 +16,4 @@
         <pre class="python">joblib.dump(self.model, file_name)</pre>
     </div>
     <p>If you dump the model using the <code>joblib</code> module before you save the model, you don't need to retrain the model.</p>
-
-    <li>Call the <code>Save</code> method with the key.</li>
-    <div class="section-example-container">
-        <pre class="python">self.ObjectStore.Save(model_key)</pre>
-    </div>
 </ol>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/11 Aesera/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/11 Aesera/07 Save Models.html
@@ -17,9 +17,4 @@
         <pre class="python">joblib.dump(self.predict, file_name)</pre>
     </div>
     <p>If you dump the model using the <code>joblib</code> module before you save the model, you don't need to retrain the model.</p>
-
-    <li>Call the <code>Save</code> method with the key.</li>
-    <div class="section-example-container">
-        <pre class="python">self.ObjectStore.Save(model_key)</pre>
-    </div>
 </ol>

--- a/04 Research Environment/08 Machine Learning/02 Keras/07 Store Models.html
+++ b/04 Research Environment/08 Machine Learning/02 Keras/07 Store Models.html
@@ -18,11 +18,6 @@
     <div class="section-example-container">
         <pre class="python">model.save(file_name)</pre>
     </div>
-
-    <li>Call the <code>Save</code> method with the key.</li>
-    <div class="section-example-container">
-        <pre class="python">qb.ObjectStore.Save(model_key)</pre>
-    </div>
 </ol>
 
 <h4>Load Models</h4>

--- a/04 Research Environment/08 Machine Learning/04 Scikit-Learn/07 Store Models.html
+++ b/04 Research Environment/08 Machine Learning/04 Scikit-Learn/07 Store Models.html
@@ -19,11 +19,6 @@
         <pre class="python">joblib.dump(model, file_name)</pre>
     </div>
     <p>If you dump the model using the <code>joblib</code> module before you save the model, you don't need to retrain the model.</p>
-
-    <li>Call the <code>Save</code> method with the key.</li>
-    <div class="section-example-container">
-        <pre class="python">qb.ObjectStore.Save(model_key)</pre>
-    </div>
 </ol>
 
 <h4>Load Models</h4>

--- a/04 Research Environment/08 Machine Learning/05 Hmmlearn/07 Store Models.html
+++ b/04 Research Environment/08 Machine Learning/05 Hmmlearn/07 Store Models.html
@@ -20,11 +20,6 @@
         <pre class="python">joblib.dump(model, file_name)</pre>
     </div>
     <p>If you dump the model using the <code>joblib</code> module before you save the model, you don't need to retrain the model.</p>
-
-    <li>Call the <code>Save</code> method with the key.</li>
-    <div class="section-example-container">
-        <pre class="python">qb.ObjectStore.Save(model_key)</pre>
-    </div>
 </ol>
 
 

--- a/04 Research Environment/08 Machine Learning/06 Gplearn/07 Store Models.html
+++ b/04 Research Environment/08 Machine Learning/06 Gplearn/07 Store Models.html
@@ -22,12 +22,6 @@ regressor_file = qb.ObjectStore.GetFilePath(regressor_key)</pre>
 joblib.dump(gp_regressor, regressor_file)</pre>
     </div>
     <p>If you dump the model using the <code>joblib</code> module before you save the model, you don't need to retrain the model.</p>
-
-    <li>Call the <code>Save</code> method with the key names.</li>
-    <div class="section-example-container">
-        <pre class="python">qb.ObjectStore.Save(transformer_key)
-qb.ObjectStore.Save(regressor_key)</pre>
-    </div>
 </ol>
 
 <h4>Load Models</h4>

--- a/04 Research Environment/08 Machine Learning/07 PyTorch/07 Store Models.html
+++ b/04 Research Environment/08 Machine Learning/07 PyTorch/07 Store Models.html
@@ -20,11 +20,6 @@
         <pre class="python">joblib.dump(model, file_name)</pre>
     </div>
     <p>If you dump the model using the <code>joblib</code> module before you save the model, you don't need to retrain the model.</p>
-
-    <li>Call the <code>Save</code> method with the key.</li>
-    <div class="section-example-container">
-        <pre class="python">qb.ObjectStore.Save(model_key)</pre>
-    </div>
 </ol>
 
 <h4>Load Models</h4>

--- a/04 Research Environment/08 Machine Learning/09 Tslearn/07 Store Models.html
+++ b/04 Research Environment/08 Machine Learning/09 Tslearn/07 Store Models.html
@@ -19,11 +19,6 @@
     <div class="section-example-container">
         <pre class="python">km.to_hdf5(file_name + ".hdf5")</pre>
     </div>
-
-    <li>Call the <code>Save</code> method with the key.</li>
-    <div class="section-example-container">
-        <pre class="python">qb.ObjectStore.Save(model_key)</pre>
-    </div>
 </ol>
 
 <h4>Load Models</h4>

--- a/04 Research Environment/08 Machine Learning/10 XGBoost/07 Store Models.html
+++ b/04 Research Environment/08 Machine Learning/10 XGBoost/07 Store Models.html
@@ -15,11 +15,6 @@
     <div class="section-example-container">
         <pre class="python">joblib.dump(model, file_name)</pre>
     </div>
-
-    <li>Call <code>Save</code> with the key's name to save the model into ObjectStore.</li>
-    <div class="section-example-container">
-        <pre class="python">qb.ObjectStore.Save(model_key)</pre>
-    </div>
 </ol>
 
 <h4>Loading the Model</h4>

--- a/04 Research Environment/08 Machine Learning/11 Aesera/07 Store Models.html
+++ b/04 Research Environment/08 Machine Learning/11 Aesera/07 Store Models.html
@@ -19,11 +19,6 @@
         <pre class="python">joblib.dump(predict, file_name)</pre>
     </div>
     <p>If you dump the model using the <code>joblib</code> module before you save the model, you don't need to retrain the model.</p>
-
-    <li>Call the <code>Save</code> method with the key.</li>
-    <div class="section-example-container">
-        <pre class="python">qb.ObjectStore.Save(model_key)</pre>
-    </div>
 </ol>
 
 <h4>Load Models</h4>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Remove redundant, buggy `ObjectStore.Save()` calls in ML model tutorial pages in Writing Algorithm and Research Environment.

#### Related Issue
N/A

#### Motivation and Context
The call is not needed, ObjectStore.Save() also does not have overload on `Save(name)`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
