### PR TITLE
Small change to variable name in OnData call from data to slice

### DIFF
--- a/Resources/indicators/using-indicator.php
+++ b/Resources/indicators/using-indicator.php
@@ -88,7 +88,7 @@
         self.<?=strtolower($helperName)?> = <?=$typeName?>(<?=$constructorArguments?>)
 
     def OnData(self, slice: Slice) -> None:
-        bar = data.Bars.get(self.symbol)
+        bar = slice.Bars.get(self.symbol)
         if bar:
             self.<?=strtolower($helperName)?>.Update(<?=$updateParameterValue?>)
 


### PR DESCRIPTION
OnData function argument uses name 'slice' not 'data'. Change in function to match.

Really minor change so I have forgone the standard template
