### PR TITLE
replaced organizations link with local platform

### DIFF
--- a/90 QuantConnect Home/01.html
+++ b/90 QuantConnect Home/01.html
@@ -24,13 +24,24 @@
         </div>
     </div>
 
-    <div class="internal-link" onclick="window.location.href = '/docs/v2/cloud-platform/organizations'">
+    <div class="internal-link" onclick="window.location.href = '/docs/v2/cloud-platform/local-platform'">
         <div class="internal-link-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="29.647" viewBox="0 0 32 29.647"><g transform="translate(-1280 -583.202)"><path d="M3441.141,1628.707H3425.8v-25.2l15.342-4.448Zm-13.342-2h11.342v-24.985l-11.342,3.288Z" transform="translate(-2144.347 -1015.859)" fill="#8f9ca3"/><path d="M3453.294,1628.284h-15.208v-22.546h15.208Zm-13.208-2h11.208v-18.546h-11.208Z" transform="translate(-2143.292 -1015.435)" fill="#8f9ca3"/><path d="M3456.5,1670.5h-32v-2h32Z" transform="translate(-2144.5 -1057.651)" fill="#8f9ca3"/><path d="M3436.148,1650.738h-5.857v-2h5.857Z" transform="translate(-2143.891 -1058.689)" fill="#8f9ca3"/><path d="M3436.148,1650.738h-5.857v-2h5.857Z" transform="translate(-2143.891 -1053.356)" fill="#8f9ca3"/><path d="M3436.148,1650.738h-5.857v-2h5.857Z" transform="translate(-2143.891 -1048.023)" fill="#8f9ca3"/><path d="M3436.148,1650.738h-5.857v-2h5.857Z" transform="translate(-2143.891 -1042.689)" fill="#8f9ca3"/><path d="M3436.148,1650.738h-5.857v-2h5.857Z" transform="translate(-2131.091 -1042.689)" fill="#8f9ca3"/><path d="M3436.148,1650.738h-5.857v-2h5.857Z" transform="translate(-2131.091 -1047.49)" fill="#8f9ca3"/><path d="M3436.148,1650.738h-5.857v-2h5.857Z" transform="translate(-2131.091 -1052.289)" fill="#8f9ca3"/></g></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="34.182" height="28.213" viewBox="0 0 34.182 28.213">
+                <g id="Group_10" data-name="Group 10" transform="translate(-1454.5 -526)">
+                  <g id="Group_8" data-name="Group 8" transform="translate(1464.441 531.097)">
+                    <path id="Path_13" data-name="Path 13" d="M58.412,27.847l-2.919-1.459a.86.86,0,0,0-1.006.178l-9.554,9.043a.628.628,0,0,0-.018.889l.018.018.781.736a.573.573,0,0,0,.754.036l11.5-9.064a.568.568,0,0,1,.613-.06.612.612,0,0,1,.325.545v-.036a.923.923,0,0,0-.5-.825" transform="translate(-44.74 -26.298)" fill="#8f9ca3"/>
+                    <path id="Path_14" data-name="Path 14" d="M58.412,49.962l-2.918,1.457a.859.859,0,0,1-1.006-.177L44.933,42.2a.628.628,0,0,1-.018-.889l.018-.018.78-.735a.574.574,0,0,1,.754-.036l11.506,9.062a.568.568,0,0,0,.613.06.611.611,0,0,0,.325-.545v.036a.922.922,0,0,1-.5.827Z" transform="translate(-44.74 -37.421)" fill="#8f9ca3"/>
+                    <path id="Path_15" data-name="Path 15" d="M94.306,40.3a.709.709,0,0,1-.885-.17.417.417,0,0,0,.5.113.523.523,0,0,0,.281-.479V26.924a.523.523,0,0,0-.281-.479.417.417,0,0,0-.5.112.709.709,0,0,1,.885-.172l2.566,1.4a.9.9,0,0,1,.442.8V38.1a.9.9,0,0,1-.441.8Z" transform="translate(-83.141 -26.299)" fill="#8f9ca3"/>
+                  </g>
+                  <path id="Line_2" data-name="Line 2" d="M14.173-.907H0V-3H14.173Z" transform="translate(1464.615 555.121)" fill="#8f9ca3"/>
+                  <path id="Rectangle_4" data-name="Rectangle 4" d="M1.534-3H26.648a4.539,4.539,0,0,1,4.534,4.534V16.881a4.539,4.539,0,0,1-4.534,4.534H1.534A4.539,4.539,0,0,1-3,16.881V1.534A4.539,4.539,0,0,1,1.534-3ZM26.648,19.323a2.444,2.444,0,0,0,2.442-2.442V1.534A2.444,2.444,0,0,0,26.648-.907H1.534A2.444,2.444,0,0,0-.907,1.534V16.881a2.444,2.444,0,0,0,2.442,2.442Z" transform="translate(1457.5 529)" fill="#8f9ca3"/>
+                </g>
+            </svg>
+              
         </div>
         <div class="internal-link-content">
-            <h4>Organizations on QuantConnect</h4>
-            <p>Build your organization from our foundation</p>
+            <h4>Local Platform</h4>
+            <p>Securely deploy quantitative strategies on-premise with proprietary datasets</p>
         </div>
     </div>
 

--- a/90 QuantConnect Home/01.html
+++ b/90 QuantConnect Home/01.html
@@ -24,7 +24,7 @@
         </div>
     </div>
 
-    <div class="internal-link" onclick="window.location.href = '/docs/v2/cloud-platform/local-platform'">
+    <div class="internal-link" onclick="window.location.href = '/docs/v2/local-platform'">
         <div class="internal-link-icon">
             <svg xmlns="http://www.w3.org/2000/svg" width="34.182" height="28.213" viewBox="0 0 34.182 28.213">
                 <g id="Group_10" data-name="Group 10" transform="translate(-1454.5 -526)">


### PR DESCRIPTION
replaces the organizations link in the docs homepage with the local platform link:

<img width="1474" alt="CleanShot 2023-06-20 at 23 26 13@2x" src="https://github.com/QuantConnect/Documentation/assets/79997186/227e126e-7e0c-45e5-9c49-e2af53b1dca2">
