### PR TITLE
Add download pdf links

### DIFF
--- a/01 Cloud Platform/00.html
+++ b/01 Cloud Platform/00.html
@@ -19,6 +19,8 @@
 				Join the leading cloud platform for quant research and trading. Easily scale your team on our cloud, and focus on what matters, alpha.
 				</p>
                 <a href="/docs/v2/cloud-platform/getting-started">Get Started</a>
+                <a href="#" class="section-pdf python">Dowload PDF</a>
+                <a href="#" class="section-pdf csharp">Dowload PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/01 Cloud Platform/00.html
+++ b/01 Cloud Platform/00.html
@@ -19,8 +19,8 @@
 				Join the leading cloud platform for quant research and trading. Easily scale your team on our cloud, and focus on what matters, alpha.
 				</p>
                 <a href="/docs/v2/cloud-platform/getting-started">Get Started</a>
-                <a href="#" class="section-pdf python">Dowload PDF</a>
-                <a href="#" class="section-pdf csharp">Dowload PDF</a>
+                <a href="#" class="section-pdf python">Download PDF</a>
+                <a href="#" class="section-pdf csharp">Download PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/01 Cloud Platform/00.html
+++ b/01 Cloud Platform/00.html
@@ -19,8 +19,8 @@
 				Join the leading cloud platform for quant research and trading. Easily scale your team on our cloud, and focus on what matters, alpha.
 				</p>
                 <a href="/docs/v2/cloud-platform/getting-started">Get Started</a>
-                <a href="#" class="section-pdf python">Download PDF</a>
-                <a href="#" class="section-pdf csharp">Download PDF</a>
+                <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Cloud-Platform-Python.pdf" class="section-pdf python">Download PDF</a>
+                <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Cloud-Platform-CSharp.pdf" class="section-pdf csharp">Download PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/02 Local Platform/00.html
+++ b/02 Local Platform/00.html
@@ -17,8 +17,8 @@
                 <p class="description">Same cutting edge quant technology, locally hosted for full
                     flexibility and power. Evolve faster.</p>
                 <a href="/docs/v2/local-platform/key-concepts/getting-started">Get Started</a>
-                <a href="#" class="section-pdf python">Dowload PDF</a>
-                <a href="#" class="section-pdf csharp">Dowload PDF</a>
+                <a href="#" class="section-pdf python">Download PDF</a>
+                <a href="#" class="section-pdf csharp">Download PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/02 Local Platform/00.html
+++ b/02 Local Platform/00.html
@@ -17,8 +17,8 @@
                 <p class="description">Same cutting edge quant technology, locally hosted for full
                     flexibility and power. Evolve faster.</p>
                 <a href="/docs/v2/local-platform/key-concepts/getting-started">Get Started</a>
-                <a href="#" class="section-pdf python">Download PDF</a>
-                <a href="#" class="section-pdf csharp">Download PDF</a>
+                <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Local-Platform-Python.pdf" class="section-pdf python">Download PDF</a>
+                <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Local-Platform-CSharp.pdf" class="section-pdf csharp">Download PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/02 Local Platform/00.html
+++ b/02 Local Platform/00.html
@@ -17,6 +17,8 @@
                 <p class="description">Same cutting edge quant technology, locally hosted for full
                     flexibility and power. Evolve faster.</p>
                 <a href="/docs/v2/local-platform/key-concepts/getting-started">Get Started</a>
+                <a href="#" class="section-pdf python">Dowload PDF</a>
+                <a href="#" class="section-pdf csharp">Dowload PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/03 Writing Algorithms/00.html
+++ b/03 Writing Algorithms/00.html
@@ -15,8 +15,8 @@
             <h3>Feature Complete Algorithmic Trading API</h3>
             <p class="description">Build on a mature, flexible, feature-complete API managing billions of dollars capital, and used by 5,000+ investors every month.</p>
             <a href="/docs/v2/writing-algorithms/key-concepts/getting-started">Get Started</a>
-            <a href="#" class="section-pdf python">Dowload PDF</a>
-            <a href="#" class="section-pdf csharp">Dowload PDF</a>
+            <a href="#" class="section-pdf python">Download PDF</a>
+            <a href="#" class="section-pdf csharp">Download PDF</a>
         </div>
     </div>
     <div class="super-section-image">

--- a/03 Writing Algorithms/00.html
+++ b/03 Writing Algorithms/00.html
@@ -15,8 +15,8 @@
             <h3>Feature Complete Algorithmic Trading API</h3>
             <p class="description">Build on a mature, flexible, feature-complete API managing billions of dollars capital, and used by 5,000+ investors every month.</p>
             <a href="/docs/v2/writing-algorithms/key-concepts/getting-started">Get Started</a>
-            <a href="#" class="section-pdf python">Download PDF</a>
-            <a href="#" class="section-pdf csharp">Download PDF</a>
+            <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Writing-Algorithms-Python.pdf" class="section-pdf python">Download PDF</a>
+            <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Writing-Algorithms-CSharp.pdf" class="section-pdf csharp">Download PDF</a>
         </div>
     </div>
     <div class="super-section-image">

--- a/03 Writing Algorithms/00.html
+++ b/03 Writing Algorithms/00.html
@@ -15,6 +15,8 @@
             <h3>Feature Complete Algorithmic Trading API</h3>
             <p class="description">Build on a mature, flexible, feature-complete API managing billions of dollars capital, and used by 5,000+ investors every month.</p>
             <a href="/docs/v2/writing-algorithms/key-concepts/getting-started">Get Started</a>
+            <a href="#" class="section-pdf python">Dowload PDF</a>
+            <a href="#" class="section-pdf csharp">Dowload PDF</a>
         </div>
     </div>
     <div class="super-section-image">

--- a/04 Research Environment/00.html
+++ b/04 Research Environment/00.html
@@ -17,8 +17,8 @@
                 <p class="description">Our data repository is preformatted and ready to go.
                     Skip expensive and tedious data processing and get to work.</p>
                 <a href="/docs/v2/research-environment/key-concepts/getting-started">Get Started</a>
-                <a href="#" class="section-pdf python">Dowload PDF</a>
-                <a href="#" class="section-pdf csharp">Dowload PDF</a>
+                <a href="#" class="section-pdf python">Download PDF</a>
+                <a href="#" class="section-pdf csharp">Download PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/04 Research Environment/00.html
+++ b/04 Research Environment/00.html
@@ -17,6 +17,8 @@
                 <p class="description">Our data repository is preformatted and ready to go.
                     Skip expensive and tedious data processing and get to work.</p>
                 <a href="/docs/v2/research-environment/key-concepts/getting-started">Get Started</a>
+                <a href="#" class="section-pdf python">Dowload PDF</a>
+                <a href="#" class="section-pdf csharp">Dowload PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/04 Research Environment/00.html
+++ b/04 Research Environment/00.html
@@ -17,8 +17,8 @@
                 <p class="description">Our data repository is preformatted and ready to go.
                     Skip expensive and tedious data processing and get to work.</p>
                 <a href="/docs/v2/research-environment/key-concepts/getting-started">Get Started</a>
-                <a href="#" class="section-pdf python">Download PDF</a>
-                <a href="#" class="section-pdf csharp">Download PDF</a>
+                <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Research-Environment-Python.pdf" class="section-pdf python">Download PDF</a>
+                <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Research-Environment-CSharp.pdf" class="section-pdf csharp">Download PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/05 Lean CLI/00.html
+++ b/05 Lean CLI/00.html
@@ -18,8 +18,8 @@
                 <h3>Automate, Scale, and Systemize</h3>
                 <p class="description">LEAN CLI provides notebooks, backtesting, optimization and live trading with a simple to use API, deploying to the cloud or on premise.</p>
                 <a href="/docs/v2/lean-cli/key-concepts/getting-started">Get Started</a>
-                <a href="#" class="section-pdf python">Dowload PDF</a>
-                <a href="#" class="section-pdf csharp">Dowload PDF</a>
+                <a href="#" class="section-pdf python">Download PDF</a>
+                <a href="#" class="section-pdf csharp">Download PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/05 Lean CLI/00.html
+++ b/05 Lean CLI/00.html
@@ -18,6 +18,8 @@
                 <h3>Automate, Scale, and Systemize</h3>
                 <p class="description">LEAN CLI provides notebooks, backtesting, optimization and live trading with a simple to use API, deploying to the cloud or on premise.</p>
                 <a href="/docs/v2/lean-cli/key-concepts/getting-started">Get Started</a>
+                <a href="#" class="section-pdf python">Dowload PDF</a>
+                <a href="#" class="section-pdf csharp">Dowload PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/05 Lean CLI/00.html
+++ b/05 Lean CLI/00.html
@@ -18,8 +18,8 @@
                 <h3>Automate, Scale, and Systemize</h3>
                 <p class="description">LEAN CLI provides notebooks, backtesting, optimization and live trading with a simple to use API, deploying to the cloud or on premise.</p>
                 <a href="/docs/v2/lean-cli/key-concepts/getting-started">Get Started</a>
-                <a href="#" class="section-pdf python">Download PDF</a>
-                <a href="#" class="section-pdf csharp">Download PDF</a>
+                <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Lean-Cli-Python.pdf" class="section-pdf python">Download PDF</a>
+                <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Lean-Cli-CSharp.pdf" class="section-pdf csharp">Download PDF</a>
             </div>
         </div>
         <div class="super-section-image">

--- a/06 LEAN Engine/00.html
+++ b/06 LEAN Engine/00.html
@@ -17,6 +17,8 @@
             <p class="description">Multi-asset with full portfolio modeling, LEAN is data agnostic,
                 empowering you to explore faster than ever before.</p>
             <a href="/docs/v2/lean-engine/getting-started">Get Started</a>
+            <a href="#" class="section-pdf python">Dowload PDF</a>
+            <a href="#" class="section-pdf csharp">Dowload PDF</a>
         </div>
     </div>
     <div class="super-section-image">

--- a/06 LEAN Engine/00.html
+++ b/06 LEAN Engine/00.html
@@ -17,8 +17,8 @@
             <p class="description">Multi-asset with full portfolio modeling, LEAN is data agnostic,
                 empowering you to explore faster than ever before.</p>
             <a href="/docs/v2/lean-engine/getting-started">Get Started</a>
-            <a href="#" class="section-pdf python">Download PDF</a>
-            <a href="#" class="section-pdf csharp">Download PDF</a>
+            <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Lean-Engine-Python.pdf" class="section-pdf python">Download PDF</a>
+            <a href="https://raw.githubusercontent.com/QuantConnect/Documentation/master/single-page/Quantconnect-Lean-Engine-CSharp.pdf" class="section-pdf csharp">Download PDF</a>
         </div>
     </div>
     <div class="super-section-image">

--- a/06 LEAN Engine/00.html
+++ b/06 LEAN Engine/00.html
@@ -17,8 +17,8 @@
             <p class="description">Multi-asset with full portfolio modeling, LEAN is data agnostic,
                 empowering you to explore faster than ever before.</p>
             <a href="/docs/v2/lean-engine/getting-started">Get Started</a>
-            <a href="#" class="section-pdf python">Dowload PDF</a>
-            <a href="#" class="section-pdf csharp">Dowload PDF</a>
+            <a href="#" class="section-pdf python">Download PDF</a>
+            <a href="#" class="section-pdf csharp">Download PDF</a>
         </div>
     </div>
     <div class="super-section-image">


### PR DESCRIPTION
@gaviles added links to download docs pdf for py and csharp and styling in www repo

needs merging the www PR before mergin this

<img width="1212" alt="CleanShot 2023-09-08 at 19 44 03@2x" src="https://github.com/QuantConnect/Documentation/assets/79997186/7fd7f9fc-c6ae-451a-9105-914c08bd8594">
