### PR TITLE
Add Payoff Curve to Option Strategies

### DIFF
--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/14 Covered Put/03 Strategy Payoff.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/14 Covered Put/03 Strategy Payoff.html
@@ -25,7 +25,8 @@ $$
 $$
 <br>
 <p>The following chart shows the payoff at expiration:</p>
-<!--img class="docs-image" src="https://cdn.quantconnect.com/tutorials/i/Tutorial01-covered-call.png" alt="covered put strategy payoff"-->
+<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/covered-put.png" alt="Strategy payoff decomposition and analysis of covered put">
+
 <p>The maximum profit is $S_T - K + P^{K}_0$. It occurs when the underlying price is at or below the strike price of the put at expiration.</p>
 <p>If the underlying price increase, the maximum loss is unlimited.</p>
 <p>If the Option is American Option, there is risk of early assignment on the sold contract.</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/17 Naked Call/03 Strategy Payoff.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/17 Naked Call/03 Strategy Payoff.html
@@ -24,7 +24,7 @@ $$
 $$
 <br>
 <p>The following chart shows the payoff at expiration:</p>
-<!--img class="docs-image" src="https://cdn.quantconnect.com/tutorials/i/Tutorial01-naked-call.png" alt="naked call strategy payoff"-->
+<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/naked-call.png" alt="Strategy payoff decomposition and analysis of naked call">
 <p>The maximum profit is $C^{K}_0$, which occurs when the underlying price is at or below the strike price of the call at expiration.</p>
 <p>The maximum loss is unlimited because there is no limit to how high the underlying asset's price can rise.</p>
 <p>If the Option is American Option, there is risk of early assignment on the sold contract.</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/18 Naked Put/03 Strategy Payoff.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/18 Naked Put/03 Strategy Payoff.html
@@ -24,7 +24,7 @@ $$
 $$
 <br>
 <p>The following chart shows the payoff at expiration:</p>
-<!--img class="docs-image" src="https://cdn.quantconnect.com/tutorials/i/Tutorial01-naked-put.png" alt="naked put strategy payoff"-->
+<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/naked-put.png" alt="Strategy payoff decomposition and analysis of naked put">
 <p>The maximum profit is $P^{K}_0$, which occurs when the underlying price is at or above the strike price of the put at expiration.</p>
 <p>The maximum loss is $K - P^{K}_0$, which ocurrs when the underlying price drops to zero.</p>
 <p>If the Option is American Option, there is risk of early assignment on the sold contract.</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/19 Protective Call/03 Strategy Payoff.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/19 Protective Call/03 Strategy Payoff.html
@@ -25,6 +25,6 @@ $$
 $$
 <br>
 <p>The following chart shows the payoff at expiration:</p>
-<!--img class="docs-image" src="https://cdn.quantconnect.com/tutorials/i/Tutorial01-protective-call.png" alt="protective call strategy payoff"-->
+<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/protective-call.png" alt="Strategy payoff decomposition and analysis of protective call">
 <p>The maximum profit is $S_0 - C^{K}_0$, which occurs when the underlying price is $0$.</p>
 <p>The maximum loss is $S_0 - K - C^{K}_0$, which occurs when the underlying price is above the strike price.</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/20 Protective Put/03 Strategy Payoff.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/20 Protective Put/03 Strategy Payoff.html
@@ -25,6 +25,6 @@ $$
 $$
 <br>
 <p>The following chart shows the payoff at expiration:</p>
-<!--img class="docs-image" src="https://cdn.quantconnect.com/tutorials/i/Tutorial01-protective-put.png" alt="protective put strategy payoff"-->
+<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/protective-put.png" alt="Strategy payoff decomposition and analysis of protective put">
 <p>The maximum profit is $S_T - S_0 - P^{K}_0$, which occurs when the underlying price is above the $S_0 + P^{K}_0$.</p>
 <p>The maximum loss is $P^{K}_0$, which occurs when the underlying price drops.</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/23 Short Straddle/03 Strategy Payoff.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/23 Short Straddle/03 Strategy Payoff.html
@@ -28,6 +28,6 @@ $$
 $$
 <br>
 <p>The following chart shows the payoff at expiration:</p>
-<!--img class="docs-image" src="https://cdn.quantconnect.com/tutorials/i/Tutorial03-short-straddle.png" alt="Strategy payoff decomposition and analysis of short straddle"-->
+<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/short-straddle.png" alt="Strategy payoff decomposition and analysis of short straddle">
 <p>The maximum profit is $C^{ATM}_0 + P^{ATM}_0$. It occurs when the price of the underlying asset remains exactly at the strike price upon expiration.</p>
 <p>The maximum loss is unlimited if the underlying price rises to infinity or drops to zero at expiration.</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/25 Short Strangle/03 Strategy Payoff.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/25 Short Strangle/03 Strategy Payoff.html
@@ -28,7 +28,7 @@ $$
 $$
 <br>
 <p>The following chart shows the payoff at expiration:</p>
-<!--img class="docs-image" src="https://cdn.quantconnect.com/tutorials/i/Tutorial04-short-strangle.png" alt="short strangle strategy payoff"-->
+<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/short-strangle.png" alt="Strategy payoff decomposition and analysis of short strangle">
 
 <p>The maximum profit $C^{OTM}_0 + P^{OTM}_0$. It occurs when the underlying price at expiration remains within the range of the strike prices. In this case, both Options expire worthless.</p>
 <p>The maximum loss is unlimited if the underlying price rises to infinity or substantial, $C^{OTM}_0 + P^{OTM}_0 - K^{P}$, if it drops to zero at expiration.</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Add Payoff Curve to Option Strategies if missing
- Covered Put
- Naked Call
- Naked Put
- Protective Call
- Protective Put
- Short Straddle
- Short Strangle

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
Missing feature

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
