### PR TITLE
Fix URL checker on lean.io links

### DIFF
--- a/05 Lean CLI/05 Datasets/02 Downloading Data/01 Download By Ticker/01 Key Concepts/02 Using the CLI.html
+++ b/05 Lean CLI/05 Datasets/02 Downloading Data/01 Download By Ticker/01 Key Concepts/02 Using the CLI.html
@@ -3,7 +3,7 @@
 <h4>Non-Interactive Mode</h4>
 <p>Follow these steps to download datasets with the non-interactive mode of the CLI:</p>
 <ol>
-    <li>Open the <a href="/docs/v2/cloud-platform/datasets/navigating-the-market#02-View-All-Listings">listing page of the dataset</a> that you want to download.</li>
+    <li>Open the <a href="http://www.quantconnect.com/docs/v2/cloud-platform/datasets/navigating-the-market#02-View-All-Listings">listing page of the dataset</a> that you want to download.</li>
     <li>Click the <span class="tab-name">CLI</span> tab.</li>
     <p>If there is no <span class="tab-name">CLI</span> tab, you can't download the dataset.</p>
     <li>Fill in the Command Line Generator form.</li>

--- a/05 Lean CLI/06 Projects/01 Project Management/04 Rename Projects.php
+++ b/05 Lean CLI/06 Projects/01 Project Management/04 Rename Projects.php
@@ -16,4 +16,4 @@ Renaming project in the cloud from 'My Project' to 'My Renamed Project'
 Successfully updated name and files and libraries for 'My Project'</pre>
 </div>
 
-<p>Alternatively, you can <a href='/docs/v2/cloud-platform/projects/getting-started#07-Rename-Projects'>rename the project</a> in QuantConnect Cloud and then <a href='/docs/v2/lean-cli/projects/cloud-synchronization#02-Pulling-Cloud-Projects'>pull the project</a> to your local machine.</p>
+<p>Alternatively, you can <a href='http://www.quantconnect.com/docs/v2/cloud-platform/projects/getting-started#07-Rename-Projects'>rename the project</a> in QuantConnect Cloud and then <a href='/docs/v2/lean-cli/projects/cloud-synchronization#02-Pulling-Cloud-Projects'>pull the project</a> to your local machine.</p>

--- a/05 Lean CLI/06 Projects/02 Cloud Synchronization/02 Pulling Cloud Projects.php
+++ b/05 Lean CLI/06 Projects/02 Cloud Synchronization/02 Pulling Cloud Projects.php
@@ -1,5 +1,5 @@
 <p>
-    Follow these steps to pull all the cloud projects that you store in an <a href='/docs/v2/cloud-platform/organizations/getting-started'>organization</a> to your local drive:
+    Follow these steps to pull all the cloud projects that you store in an <a href='http://www.quantconnect.com/docs/v2/cloud-platform/organizations/getting-started'>organization</a> to your local drive:
 </p>
 
 <ol>

--- a/05 Lean CLI/09 Live Trading/01 Brokerages/01 QuantConnect Paper Trading/02 Deploy Local Algorithms.php
+++ b/05 Lean CLI/09 Live Trading/01 Brokerages/01 QuantConnect Paper Trading/02 Deploy Local Algorithms.php
@@ -8,7 +8,7 @@ $dataFeedDetails = "
             If your algorithm only uses custom data, you can select the \"Custom data only\" data feed option.
             This data feed doesn't require any brokerage credentials, but only works if your algorithm doesn't subscribe to non-custom data.
             Your algorithm crashes if it attempts to subscribe to non-custom data with this data feed in place, including the benchmark security.
-            To avoid data issues with the benchmark security, either <a href='/docs/v2/writing-algorithms/importing-data/streaming-data/custom-securities/key-concepts#07-Set-the-Benchmark'>set the benchmark to the subscribed custom data</a> or a constant.
+            To avoid data issues with the benchmark security, either <a href='http://www.quantconnect.com/docs/v2/writing-algorithms/importing-data/streaming-data/custom-securities/key-concepts#07-Set-the-Benchmark'>set the benchmark to the subscribed custom data</a> or a constant.
         </p>
         <div class='section-example-container'>
             <pre class='csharp'>SetBenchmark(x => 0);</pre>

--- a/05 Lean CLI/09 Live Trading/01 Brokerages/90 Bloomberg EMSX/04 Orders.php
+++ b/05 Lean CLI/09 Live Trading/01 Brokerages/90 Bloomberg EMSX/04 Orders.php
@@ -15,28 +15,28 @@
    </thead>
    <tbody>
       <tr>
-        <td><a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/market-orders">MarketOrder</a></td>
+        <td><a href="http://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-types/market-orders">MarketOrder</a></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
       </tr>
       <tr>
-        <td><a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/limit-orders">LimitOrder</a></td>
+        <td><a href="http://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-types/limit-orders">LimitOrder</a></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
       </tr>
       <tr>
-        <td><a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/stop-market-orders">StopMarketOrder</a></td>
+        <td><a href="http://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-types/stop-market-orders">StopMarketOrder</a></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
       </tr>
       <tr>
-        <td><a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/stop-limit-orders">StopLimitOrder</a></td>
+        <td><a href="http://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-types/stop-limit-orders">StopLimitOrder</a></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
@@ -54,7 +54,7 @@
 
 
 <h4>Time In Force</h4>
-<p>Terminal Link supports the following <a href='/docs/v2/writing-algorithms/trading-and-orders/order-properties#03-Time-In-Force'>TimeInForce</a> instructions:</p>
+<p>Terminal Link supports the following <a href='http://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-properties#03-Time-In-Force'>TimeInForce</a> instructions:</p>
 <ul>
     <li><code>Day</code></li>
     <li><code>GoodTilCanceled</code></li>
@@ -62,15 +62,15 @@
 </ul>
 
 <h4>Get Open Orders</h4>
-<p>Terminal Link lets you <a href='/docs/v2/writing-algorithms/trading-and-orders/order-management/transaction-manager'>access open orders</a>.</p>
+<p>Terminal Link lets you <a href='http://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-management/transaction-manager'>access open orders</a>.</p>
 
 <h4>Monitor Fills</h4>
-<p>Terminal Link allows you to monitor orders as they fill through <a href='/docs/v2/writing-algorithms/trading-and-orders/order-events'>order events</a>.</p>
+<p>Terminal Link allows you to monitor orders as they fill through <a href='http://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-events'>order events</a>.</p>
 
 <h4>Updates</h4>
-<p>Terminal Link doesn't support <a href='/docs/v2/writing-algorithms/trading-and-orders/order-management/order-tickets#04-Update-Orders'>order updates</a>.</p>
+<p>Terminal Link doesn't support <a href='http://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-management/order-tickets#04-Update-Orders'>order updates</a>.</p>
 
 <h4>Cancellations</h4>
-<p>Terminal Link enables you to <a href='/docs/v2/writing-algorithms/trading-and-orders/order-management/order-tickets#05-Cancel-Orders'>cancel open orders</a>.</p>
+<p>Terminal Link enables you to <a href='http://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-management/order-tickets#05-Cancel-Orders'>cancel open orders</a>.</p>
 
 <? include(DOCS_RESOURCES."/brokerages/handling-splits.html"); ?>

--- a/05 Lean CLI/09 Live Trading/01 Brokerages/90 Bloomberg EMSX/10 Deploy Cloud Algorithms.php
+++ b/05 Lean CLI/09 Live Trading/01 Brokerages/90 Bloomberg EMSX/10 Deploy Cloud Algorithms.php
@@ -1,4 +1,4 @@
-<p>You need to <a href='/docs/v2/cloud-platform/live-trading/brokerages/bloomberg-emsx#14-Set-Up-SAPI'>set up the Bloomberg SAPI</a> before you can deploy cloud algorithms with Terminal Link.</p>
+<p>You need to <a href='http://www.quantconnect.com/docs/v2/cloud-platform/live-trading/brokerages/bloomberg-emsx#14-Set-Up-SAPI'>set up the Bloomberg SAPI</a> before you can deploy cloud algorithms with Terminal Link.</p>
 
 <?php
 $brokerageDetails = "

--- a/06 LEAN Engine/02 Contributions/01 Datasets/02 Defining Data Models/06 Part 3%2F Create Universe Models.php
+++ b/06 LEAN Engine/02 Contributions/01 Datasets/02 Defining Data Models/06 Part 3%2F Create Universe Models.php
@@ -7,7 +7,7 @@
     <li>Skip the rest of this page.</li>
 </ol>
 
-<p>The input to your model should be a <span class="public-file-name">CSV</span> file where the first column is the <a href='/docs/v2/writing-algorithms/key-concepts/security-identifiers'>security identifier</a> and the second column is the point-in-time ticker.</p>
+<p>The input to your model should be a <span class="public-file-name">CSV</span> file where the first column is the <a href='http://www.quantconnect.com/docs/v2/writing-algorithms/key-concepts/security-identifiers'>security identifier</a> and the second column is the point-in-time ticker.</p>
 
 <div class="section-example-container"><pre>
 A R735QTJ8XC9X,A,17.19,109700,1885743,False,0.9904858,1

--- a/URL Test/Program.cs
+++ b/URL Test/Program.cs
@@ -190,6 +190,7 @@ Dictionary<string, List<string>> GetAllUrls()
             foreach (var href in hrefs)
             {
                 var url = href.Split('\"').First();
+                var urlLeanIo = String.Empty;
                 var subUrl = String.Empty;
 
                 if (string.IsNullOrWhiteSpace(url) || url.Contains('{') || url.Contains('}')) continue;
@@ -219,6 +220,11 @@ Dictionary<string, List<string>> GetAllUrls()
                     {
                         url = $"{root}{url.Remove(0, 1)}";
                     }
+
+                    if (leanIoFolder.Any(file.Contains))
+                    {
+                        urlLeanIo = url.Replace(root, leanIo);
+                    }
                 }
 
                 if (url.Contains("sources")) continue;
@@ -230,16 +236,14 @@ Dictionary<string, List<string>> GetAllUrls()
 
                 urlFiles[url].Add(file);
 
-                if (leanIoFolder.Any(file.Contains))
+                if (!string.IsNullOrWhiteSpace(urlLeanIo))
                 {
-                    url = url.Replace(root, leanIo);
-
-                    if (!urlFiles.ContainsKey(url))
+                    if (!urlFiles.ContainsKey(urlLeanIo))
                     {
-                        urlFiles.Add(url, new List<string>());
+                        urlFiles.Add(urlLeanIo, new List<string>());
                     }
 
-                    urlFiles[url].Add(file);
+                    urlFiles[urlLeanIo].Add(file);
                 }
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
The URL checker is wrongly checking links in Lean-CLI & Lean Engine sections with full link (http://www.quantconnect.com/...) by lean.io/...
This PR fixes the checker only checks the shortened links. And fixes broken hrefs.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
Bug

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
