### PR TITLE
Add docs for read chart endpoints

### DIFF
--- a/QuantConnect-Platform-2.0.0.yaml
+++ b/QuantConnect-Platform-2.0.0.yaml
@@ -562,7 +562,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ReadBacktestChart'
+              $ref: '#/components/schemas/ReadBacktestChartRequest'
         required: true
       responses:
         "200":
@@ -4286,12 +4286,9 @@ components:
           items:
             $ref: '#/components/schemas/CashAmount'
       description: Settings for using Interactive Brokers as brokerage or data provider.
-    ReadBacktestChart:
+    ReadBacktestChartRequest:
       type: object
       properties:
-        userId:
-          type: integer
-          description: The user ID of the request.
         projectId:
           type: integer
           description: Project ID of the request.
@@ -4335,9 +4332,6 @@ components:
     ReadLiveChartRequest:
       type: object
       properties:
-        userId:
-          type: integer
-          description: The user ID of the request.
         projectId:
           type: integer
           description: Project ID of the request.

--- a/QuantConnect-Platform-2.0.0.yaml
+++ b/QuantConnect-Platform-2.0.0.yaml
@@ -558,7 +558,7 @@ paths:
         - 02 Read Backtest
       summary: Read chart from a backtest.
       requestBody:
-        description: A JSON object containing info about the backtest and new name.
+        description: Request body to obtain a chart from a backtest.
         content:
           application/json:
             schema:
@@ -566,7 +566,7 @@ paths:
         required: true
       responses:
         "200":
-          description: Response with chart requested object.
+          description: Response with the chart requested object.
           content:
             application/json:
               schema:
@@ -690,7 +690,7 @@ paths:
       - 02 Read Live Algorithm
     summary: Read a chart from a live algorithm
       requestBody:
-        description: Request body to get a chart from a live algorithm.
+        description: Request body to obtain a chart from a live algorithm.
         content:
           application/json:
             schema:

--- a/QuantConnect-Platform-2.0.0.yaml
+++ b/QuantConnect-Platform-2.0.0.yaml
@@ -549,6 +549,36 @@ paths:
               explode: false
               schema:
                 type: string
+  /backtests/chart/read:
+    post:
+      tags:
+        - 01 Cloud Platform
+        - 99 API Reference
+        - 05 Backtest Management
+        - 02 Read Backtest
+      summary: Read chart from a backtest.
+      requestBody:
+        description: A JSON object containing info about the backtest and new name.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReadBacktestChart'
+        required: true
+      responses:
+        "200":
+          description: Response with chart requested object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadChartResponse'
+        "401":
+          description: Unauthorized response from the API. Key is missing, invalid, or timestamp is too old for hash.
+          headers:
+            www_authenticate:
+              style: simple
+              explode: false
+              schema:
+                type: string
   /backtests/update:
     post:
       tags:
@@ -652,6 +682,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LeanVersionsResponse'
+  /live/chart/read:
+    tags:
+      - 01 Cloud Platform
+      - 99 API Reference
+      - 07 Live Management
+      - 02 Read Live Algorithm
+    summary: Read a chart from a live algorithm
+      requestBody:
+        description: Request body to get a chart from a live algorithm.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReadLiveChartRequest'
+        required: true
+      responses:
+        "200":
+          description: Response with the requested chart from a live algorithm.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadChartResponse'
+        "401":
+          description: Unauthorized response from the API. Key is missing, invalid, or timestamp is too old for hash.
+          headers:
+            www_authenticate:
+              style: simple
+              explode: false
+              schema:
+                type: string
   /live/create:
     post:
       tags:
@@ -4227,6 +4286,31 @@ components:
           items:
             $ref: '#/components/schemas/CashAmount'
       description: Settings for using Interactive Brokers as brokerage or data provider.
+    ReadBacktestChart:
+      type: object
+      properties:
+        userId:
+          type: integer
+          description: The user ID of the request.
+        projectId:
+          type: integer
+          description: Project ID of the request.
+        name:
+          type: string
+          description: The requested chart name.
+        start:
+          type: integer
+          description: The Utc start seconds timestamp of the request.
+        end:
+          type: integer
+          description: The Utc end seconds timestamp of the request.
+        count:
+          type: integer
+          description: The number of data points to request.
+        backtestId:
+          type: string
+          description: Associated Backtest ID for this chart request.
+      description: Request body to obtain a chart from a backtest.
     ReadBacktestOrdersRequest:
       required:
       - start
@@ -4248,6 +4332,44 @@ components:
           type: string
           description: Id of the backtest from which to read the orders.
       description: Request to read orders from a backtest.
+    ReadLiveChartRequest:
+      type: object
+      properties:
+        userId:
+          type: integer
+          description: The user ID of the request.
+        projectId:
+          type: integer
+          description: Project ID of the request.
+        name:
+          type: string
+          description: The requested chart name.
+        start:
+          type: integer
+          description: The Utc start seconds timestamp of the request.
+        end:
+          type: integer
+          description: The Utc end seconds timestamp of the request.
+        count:
+          type: integer
+          description: The number of data points to request.
+      description: Request to body to obtain a chart from a live algorithm.
+    ReadChartResponse:
+      type: object
+      properties:
+        chart:
+          type: object
+          properties: Chart object requested.
+          $ref: '#/components/schemas/Chart'
+        success:
+          type: boolean
+          description: Indicate if the API request was successful.
+        errors:
+          type: array
+          description: List of errors with the API call.
+          items:
+            type: string
+      description: Response with the requested chart from a live algorithm or backtest.
     ReadOptimizationRequest:
       required:
       - optimizationId
@@ -4405,7 +4527,8 @@ components:
           type: array
           description: Values for the series plot. These values are assumed to be in ascending time order (first points earliest, last points latest)
           items:
-            $ref: '#/components/schemas/ChartPoint'
+            type: object
+            description: The type of the values depends on the series type.
         seriesType:
           type: string
           description: Chart type for the series.


### PR DESCRIPTION
Add request and response bodies for `live/chart/read` and `backtest/chart/read` endpoints