### PR TITLE
Add Backspread Option Strategy

### DIFF
--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/38 Long Call Backspread/01 Introduction.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/38 Long Call Backspread/01 Introduction.html
@@ -1,0 +1,7 @@
+<p>
+  <span class="new-term">Long Call Backspread</span>, consists of short 1 lower-strike call and long 2 higher strike calls.
+  It is a combination of a <a href="/docs/v2/writing-algorithms/trading-and-orders/option-strategies/bear-call-spread">bear call spread</a> and a long call with the same strike price as the higher-strike leg the call spread. 
+  All calls have the same underlying Equity and expiration date. 
+  This strategy profits from increasing volatility of the underlying asset. 
+  For instance, the underlying price moves away from its current price.
+</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/38 Long Call Backspread/02 Implementation.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/38 Long Call Backspread/02 Implementation.html
@@ -1,0 +1,110 @@
+<p>Follow these steps to implement the long call backspread strategy:</p>
+
+<ol>
+    <li>In the <code class="csharp">Initialize</code><code class="python">initialize</code> method, set the start date, end date, cash, and <a href="/docs/v2/writing-algorithms/universes/equity-options">Option universe</a>. You can use the <code class="csharp">CallSpread</code><code class="csharp">call_spread</code> helper method in option universe filtering, since a call backspread consists of the same contracts as a call spread.</li>
+    <div class="section-example-container">
+        <pre class="csharp">private Symbol _symbol;
+
+public override void Initialize()
+{
+    SetStartDate(2017, 4, 1);
+    SetEndDate(2017, 4, 22);
+    SetCash(1000000);
+
+    UniverseSettings.Asynchronous = true;
+    var option = AddOption("GOOG", Resolution.Minute);
+    _symbol = option.Symbol;
+    option.SetFilter(universe =&gt; universe.IncludeWeeklys().CallSpread(20, 5));
+}</pre>
+        <pre class="python">def initialize(self) -&gt; None:
+    self.set_start_date(2017, 4, 1)
+    self.set_end_date(2017, 4, 22)
+    self.set_cash(1000000)
+
+    self.universe_settings.asynchronous = True
+    option = self.add_option("GOOG", Resolution.MINUTE)
+    self._symbol = option.symbol
+    option.set_filter(lambda universe: universe.include_weeklys().call_spread(20, 5))</pre>
+    </div>
+
+    <li>In the <code class="csharp">OnData</code><code class="python">on_data</code> method, select the expiration and strikes of the contracts in the strategy legs.</li>
+    <div class="section-example-container">
+        <pre class="csharp">public override void OnData(Slice slice)
+{
+    if (Portfolio.Invested ||
+        !slice.OptionChains.TryGetValue(_symbol, out var chain))
+    {
+        return;
+    }
+
+    // Select the call Option contracts with the furthest expiry
+    var expiry = chain.Max(x =&gt; x.Expiry);    
+    var calls = chain.Where(x =&gt; x.Expiry == expiry &amp;&amp; x.Right == OptionRight.Call);
+    if (calls.Count() == 0) return;
+
+    // Select the strike prices from the remaining contracts
+    var strikes = calls.Select(x =&gt; x.Strike).Distinct().OrderBy(x =&gt; x).ToList();
+    if (strikes.Count &lt; 2)
+    {
+        return;
+    }
+    
+    var lowStrike = strikes[0];
+    var highStrike = strikes[1];</pre>
+        <pre class="python">def on_data(self, slice: Slice) -&gt; None:
+    if self.portfolio.invested:
+        return
+
+    # Get the OptionChain
+    chain = slice.option_chains.get(self._symbol, None)
+    if not chain:
+        return
+    
+    # Select the call Option contracts with the furthest expiry
+    expiry = max([x.expiry for x in chain])
+    calls = [i for i in chain if i.expiry == expiry and i.right == OptionRight.CALL]
+    if not calls:
+        return
+
+    # Select the strike prices from the remaining contracts
+    strikes = sorted(set(x.strike for x in calls))
+    if len(strikes) &lt; 2:
+        return
+    
+    low_strike = strikes[0]
+    high_strike = strikes[1]</pre>
+    </div>
+
+    <li>In the <code class="csharp">OnData</code><code class="python">on_data</code> method, select the contracts and place the orders.</li>
+
+    <p><b>Approach A:</b> Call the <code class="csharp">OptionStrategies.CallBackspread</code><code class="python">OptionStrategies.call_backspread</code> method with the details of each leg and then pass the result to the <code class="csharp">Buy</code><code class="python">buy</code> method.</p>
+    <div class="section-example-container">
+        <pre class="csharp">var optionStrategy = OptionStrategies.CallBackspread(_symbol, lowStrike, highStrike, expiry);
+Buy(optionStrategy, 1);<br></pre>
+        <pre class="python">option_strategy = OptionStrategies.call_backspread(self._symbol, low_strike, high_strike, expiry)
+self.buy(option_strategy, 1)</pre>
+    </div>
+
+    <p><b>Approach B:</b> Create a list of <code>Leg</code> objects and then call the <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-market-orders"><span class='csharp'>Combo Market Order</span><span class='python'>combo_market_order</span></a>, <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-limit-orders"><span class='csharp'>Combo Limit Order</span><span class='python'>combo_limit_order</span></a>, or <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-leg-limit-orders"><span class='csharp'>Combo Leg Limit Order</span><span class='python'>combo_leg_limit_order</span></a> method.</p>
+    
+    <div class="section-example-container">
+        <pre class="csharp">var lowStrikeCall = calls.Single(x =&gt; x.Strike == lowStrike);
+var highStrikeCall = calls.Single(x =&gt; x.Strike == highStrike);
+
+var legs = new List&lt;Leg&gt;()
+{
+    Leg.Create(lowStrikeCall.Symbol, -1),
+    Leg.Create(highStrikeCall.Symbol, 2)
+};
+ComboMarketOrder(legs, 1, true);</pre>
+        <pre class="python">low_strike_call = next(filter(lambda x: x.strike == low_strike, calls))
+high_strike_call = next(filter(lambda x: x.strike == high_strike, calls))
+
+legs = [
+    Leg.create(low_strike_call.symbol, -1),
+    Leg.create(high_strike_call.symbol, 2)
+]
+self.combo_market_order(legs, 1)</pre>
+    </div>
+</ol>
+

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/38 Long Call Backspread/03 Strategy Payoff.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/38 Long Call Backspread/03 Strategy Payoff.html
@@ -1,0 +1,34 @@
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+</script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+
+<p>The long call backspread is an unlimited-profit-limited-risk strategy. The payoff is</p>
+$$
+\begin{array}{rcll}
+C^{low}_T &amp; = &amp; (S_T - K^{low})^{+}\\
+C^{high}_T &amp; = &amp; (S_T - K^{high})^{+}\\
+Payoff_T &amp; = &amp; (C^{low}_0 - C^{low}_T + C^{high}_T \times 2 - C^{high}_0 \times 2)\times m - fee\\
+\end{array}
+$$
+$$
+\begin{array}{rcll}
+\textrm{where} &amp; C^{low}_T &amp; = &amp; \textrm{Lower-strike call value at time T}\\
+&amp; C^{high}_T &amp; = &amp; \textrm{Higher-strike call value at time T}\\
+&amp; S_T &amp; = &amp; \textrm{Underlying asset price at time T}\\
+&amp; K^{low} &amp; = &amp; \textrm{Lower-strike call strike price}\\
+&amp; K^{high} &amp; = &amp; \textrm{Higher-strike call strike price}\\
+&amp; C^{low}_0 &amp; = &amp; \textrm{Lower-strike call value at position opening (credit received)}\\
+&amp; C^{high}_0 &amp; = &amp; \textrm{Higher-strike call value at position opening (debit paid)}\\
+&amp; m &amp; = &amp; \textrm{Contract multiplier}\\
+&amp; T &amp; = &amp; \textrm{Time of expiration}
+\end{array}
+$$
+<br>
+<p>The following chart shows the payoff at expiration:</p>
+<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/long-call-backspread-payoff.png" alt="Strategy payoff decomposition and analysis of long call backspread">
+
+<p>The maximum profit is unlimited, which occurs when the underlying price increases indefinitely.</p>
+<p>The maximum loss is $K^{low} - K^{high} + C^{low}_0 - C^{high}_0 \times 2$, which occurs when the underlying price is exactly at the lower strike at expiry.</p>
+<p>If the Option is American Option, there is a risk of <a href='/docs/v2/writing-algorithms/reality-modeling/options-models/assignment'>early assignment</a> on the contract you sell.</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/38 Long Call Backspread/04 Example.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/38 Long Call Backspread/04 Example.html
@@ -1,0 +1,64 @@
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+</script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+
+<p>The following table shows the price details of the assets in the algorithm:</p>
+
+<table class="table qc-table" id="payoff-table">
+<thead>
+<tr><th>Asset</th><th>Price ($)</th><th>Strike ($)</th></tr>
+</thead>
+<tbody>
+<tr><td>Lower-Strike call</td><td>12.00</td><td>825.00</td></tr>
+<tr><td>Higher-strike call</td><td>8.80</td><td>835.00</td></tr>
+<tr><td>Underlying Equity at expiration</td><td>843.19</td><td>-</td></tr>
+</tbody>
+</table>
+
+<style>
+#payoff-table td:nth-child(2), 
+#payoff-table th:nth-child(2), 
+#payoff-table td:nth-child(3), 
+#payoff-table th:nth-child(3) {
+    text-align: right;
+}
+</style>
+
+<p>Therefore, the payoff is</p>
+$$
+\begin{array}{rcll}
+C^{low}_T & = & (S_T - K^{low})^{+}\\
+& = & (843.19-825.00)^{+}\\
+& = & 18.19\\
+C^{high}_T & = & (S_T - K^{high})^{+}\\
+& = & (843.19-835.00)^{+}\\
+& = & 8.19\\
+Payoff_T & = & (C^{low}_0 - C^{low}_T + C^{high}_T \times 2 - C^{high}_0 \times 2)\times m - fee\\
+& = & (12.00 - 18.19 + 8.19\times2 - 8.80\times2)\times100-2.30\\
+& = & -743.30\\
+\end{array}
+$$
+<br>
+<p>So, the strategy loses $743.30.</p>
+
+<p>The following algorithm implements a long call backspread Option strategy:</p>
+
+<div class="python">
+    <div class="qc-embed-frame" style="display: inline-block; position: relative; width: 100%; min-height: 100px; min-width: 300px;">
+        <div class="qc-embed-dummy" style="padding-top: 56.25%;"></div>
+        <div class="qc-embed-element" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;">
+            <iframe class="qc-embed-backtest" height="100%" width="100%" style="border: 1px solid #ccc; padding: 0; margin: 0;" src="https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_6bc9a61961d09998dc9e0954fc8790d6.html"></iframe>
+        </div>
+    </div>
+</div>
+
+<div class="csharp">
+    <div class="qc-embed-frame" style="display: inline-block; position: relative; width: 100%; min-height: 100px; min-width: 300px;">
+        <div class="qc-embed-dummy" style="padding-top: 56.25%;"></div>
+        <div class="qc-embed-element" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;">
+            <iframe class="qc-embed-backtest" height="100%" width="100%" style="border: 1px solid #ccc; padding: 0; margin: 0;" src="https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_20cda6e717dd732b203425fe372d9b1f.html"></iframe>
+        </div>
+    </div>
+</div>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/38 Long Call Backspread/metadata.json
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/38 Long Call Backspread/metadata.json
@@ -1,0 +1,12 @@
+{
+    "type": "metadata",
+    "values": {
+        "description": "Long call backspread, a combination of bear call spread and long call, consists of selling a lower-strike call and buying two higher-srtike calls with the same expiry.",
+        "keywords": "call backspread, bear call spread, unlimited-reward-limited-risk strategy, strategy payoff, early assignment",
+        "og:description": "Long call backspread, a combination of bear call spread and long call, consists of selling a lower-strike call and buying two higher-srtike calls with the same expiry.",
+        "og:title": "Long Call Backspread - Documentation QuantConnect.com",
+        "og:type": "website",
+        "og:site_name": "Long Call Backspread - QuantConnect.com",
+        "og:image": "https://cdn.quantconnect.com/docs/i/writing-algorithms/trading-and-orders/option-strategies/long-call-backspread.png"
+    }
+}

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/39 Short Call Backspread/01 Introduction.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/39 Short Call Backspread/01 Introduction.html
@@ -1,0 +1,7 @@
+<p>
+  <span class="new-term">Short Call Backspread</span>, consists of long 1 lower-strike call and short 2 higher strike calls.
+  It is a combination of a <a href="/docs/v2/writing-algorithms/trading-and-orders/option-strategies/bull-call-spread">bull call spread</a> and a short call with the same strike price as the higher-strike leg the call spread. 
+  All calls have the same underlying Equity and expiration date. 
+  This strategy profits from stable, consistent price of the underlying asset. 
+  For instance, the underlying price stays at its current price.
+</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/39 Short Call Backspread/02 Implementation.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/39 Short Call Backspread/02 Implementation.html
@@ -1,0 +1,110 @@
+<p>Follow these steps to implement the short call backspread strategy:</p>
+
+<ol>
+    <li>In the <code class="csharp">Initialize</code><code class="python">initialize</code> method, set the start date, end date, cash, and <a href="/docs/v2/writing-algorithms/universes/equity-options">Option universe</a>. You can use the <code class="csharp">CallSpread</code><code class="csharp">call_spread</code> helper method in option universe filtering, since a call backspread consists of the same contracts as a call spread.</li>
+    <div class="section-example-container">
+        <pre class="csharp">private Symbol _symbol;
+
+public override void Initialize()
+{
+    SetStartDate(2017, 4, 1);
+    SetEndDate(2017, 4, 22);
+    SetCash(1000000);
+
+    UniverseSettings.Asynchronous = true;
+    var option = AddOption("GOOG", Resolution.Minute);
+    _symbol = option.Symbol;
+    option.SetFilter(universe =&gt; universe.IncludeWeeklys().CallSpread(20, 5));
+}</pre>
+        <pre class="python">def initialize(self) -&gt; None:
+    self.set_start_date(2017, 4, 1)
+    self.set_end_date(2017, 4, 22)
+    self.set_cash(1000000)
+
+    self.universe_settings.asynchronous = True
+    option = self.add_option("GOOG", Resolution.MINUTE)
+    self._symbol = option.symbol
+    option.set_filter(lambda universe: universe.include_weeklys().call_spread(20, 5))</pre>
+    </div>
+
+    <li>In the <code class="csharp">OnData</code><code class="python">on_data</code> method, select the expiration and strikes of the contracts in the strategy legs.</li>
+    <div class="section-example-container">
+        <pre class="csharp">public override void OnData(Slice slice)
+{
+    if (Portfolio.Invested ||
+        !slice.OptionChains.TryGetValue(_symbol, out var chain))
+    {
+        return;
+    }
+
+    // Select the call Option contracts with the furthest expiry
+    var expiry = chain.Max(x =&gt; x.Expiry);    
+    var calls = chain.Where(x =&gt; x.Expiry == expiry &amp;&amp; x.Right == OptionRight.Call);
+    if (calls.Count() == 0) return;
+
+    // Select the strike prices from the remaining contracts
+    var strikes = calls.Select(x =&gt; x.Strike).Distinct().OrderBy(x =&gt; x).ToList();
+    if (strikes.Count &lt; 2)
+    {
+        return;
+    }
+    
+    var lowStrike = strikes[0];
+    var highStrike = strikes[1];</pre>
+        <pre class="python">def on_data(self, slice: Slice) -&gt; None:
+    if self.portfolio.invested:
+        return
+
+    # Get the OptionChain
+    chain = slice.option_chains.get(self._symbol, None)
+    if not chain:
+        return
+    
+    # Select the call Option contracts with the furthest expiry
+    expiry = max([x.expiry for x in chain])
+    calls = [i for i in chain if i.expiry == expiry and i.right == OptionRight.CALL]
+    if not calls:
+        return
+
+    # Select the strike prices from the remaining contracts
+    strikes = sorted(set(x.strike for x in calls))
+    if len(strikes) &lt; 2:
+        return
+    
+    low_strike = strikes[0]
+    high_strike = strikes[1]</pre>
+    </div>
+
+    <li>In the <code class="csharp">OnData</code><code class="python">on_data</code> method, select the contracts and place the orders.</li>
+
+    <p><b>Approach A:</b> Call the <code class="csharp">OptionStrategies.ShortCallBackspread</code><code class="python">OptionStrategies.short_call_backspread</code> method with the details of each leg and then pass the result to the <code class="csharp">Buy</code><code class="python">buy</code> method.</p>
+    <div class="section-example-container">
+        <pre class="csharp">var optionStrategy = OptionStrategies.ShortCallBackspread(_symbol, lowStrike, highStrike, expiry);
+Buy(optionStrategy, 1);<br></pre>
+        <pre class="python">option_strategy = OptionStrategies.short_call_backspread(self._symbol, low_strike, high_strike, expiry)
+self.buy(option_strategy, 1)</pre>
+    </div>
+
+    <p><b>Approach B:</b> Create a list of <code>Leg</code> objects and then call the <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-market-orders"><span class='csharp'>Combo Market Order</span><span class='python'>combo_market_order</span></a>, <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-limit-orders"><span class='csharp'>Combo Limit Order</span><span class='python'>combo_limit_order</span></a>, or <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-leg-limit-orders"><span class='csharp'>Combo Leg Limit Order</span><span class='python'>combo_leg_limit_order</span></a> method.</p>
+    
+    <div class="section-example-container">
+        <pre class="csharp">var lowStrikeCall = calls.Single(x =&gt; x.Strike == lowStrike);
+var highStrikeCall = calls.Single(x =&gt; x.Strike == highStrike);
+
+var legs = new List&lt;Leg&gt;()
+{
+    Leg.Create(lowStrikeCall.Symbol, 1),
+    Leg.Create(highStrikeCall.Symbol, -2)
+};
+ComboMarketOrder(legs, 1, true);</pre>
+        <pre class="python">low_strike_call = next(filter(lambda x: x.strike == low_strike, calls))
+high_strike_call = next(filter(lambda x: x.strike == high_strike, calls))
+
+legs = [
+    Leg.create(low_strike_call.symbol, 1),
+    Leg.create(high_strike_call.symbol, -2)
+]
+self.combo_market_order(legs, 1)</pre>
+    </div>
+</ol>
+

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/39 Short Call Backspread/03 Strategy Payoff.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/39 Short Call Backspread/03 Strategy Payoff.html
@@ -4,12 +4,12 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 
-<p>The long call backspread is an unlimited-profit-limited-risk strategy. The payoff is</p>
+<p>The short call backspread is an limited-profit-unlimited-risk strategy. The payoff is</p>
 $$
 \begin{array}{rcll}
 C^{low}_T &amp; = &amp; (S_T - K^{low})^{+}\\
 C^{high}_T &amp; = &amp; (S_T - K^{high})^{+}\\
-Payoff_T &amp; = &amp; (C^{low}_0 - C^{low}_T + C^{high}_T \times 2 - C^{high}_0 \times 2)\times m - fee\\
+Payoff_T &amp; = &amp; (C^{low}_T - C^{low}_0 + C^{high}_0 \times 2 - C^{high}_T \times 2)\times m - fee\\
 \end{array}
 $$
 $$
@@ -27,8 +27,8 @@ $$
 $$
 <br>
 <p>The following chart shows the payoff at expiration:</p>
-<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/long-call-backspread-payoff.png" alt="Strategy payoff decomposition and analysis of long call backspread">
+<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/short-call-backspread-payoff.png" alt="Strategy payoff decomposition and analysis of short call backspread">
 
-<p>The maximum profit is unlimited, which occurs when the underlying price increases indefinitely.</p>
-<p>The maximum loss is $K^{low} - K^{high} + C^{low}_0 - C^{high}_0 \times 2$, which occurs when the underlying price is exactly at the higher strike at expiry.</p>
+<p>The maximum profit is $K^{high} - K^{low} - C^{low}_0 + C^{high}_0 \times 2$, which occurs when the underlying price is exactly at the higher strike at expiry.</p>
+<p>The maximum loss is unlimited, which occurs when the underlying price increases indefinitely.</p>
 <p>If the Option is American Option, there is a risk of <a href='/docs/v2/writing-algorithms/reality-modeling/options-models/assignment'>early assignment</a> on the contract you sell.</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/39 Short Call Backspread/04 Example.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/39 Short Call Backspread/04 Example.html
@@ -1,0 +1,64 @@
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+</script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+
+<p>The following table shows the price details of the assets in the algorithm:</p>
+
+<table class="table qc-table" id="payoff-table">
+<thead>
+<tr><th>Asset</th><th>Price ($)</th><th>Strike ($)</th></tr>
+</thead>
+<tbody>
+<tr><td>Lower-Strike call</td><td>15.10</td><td>825.00</td></tr>
+<tr><td>Higher-strike call</td><td>8.00</td><td>835.00</td></tr>
+<tr><td>Underlying Equity at expiration</td><td>843.19</td><td>-</td></tr>
+</tbody>
+</table>
+
+<style>
+#payoff-table td:nth-child(2), 
+#payoff-table th:nth-child(2), 
+#payoff-table td:nth-child(3), 
+#payoff-table th:nth-child(3) {
+    text-align: right;
+}
+</style>
+
+<p>Therefore, the payoff is</p>
+$$
+\begin{array}{rcll}
+C^{low}_T & = & (S_T - K^{low})^{+}\\
+& = & (843.19-825.00)^{+}\\
+& = & 18.19\\
+C^{high}_T & = & (S_T - K^{high})^{+}\\
+& = & (843.19-835.00)^{+}\\
+& = & 8.19\\
+Payoff_T & = & (C^{low}_T - C^{low}_0 - C^{high}_T \times 2 + C^{high}_0 \times 2)\times m - fee\\
+& = & (18.19 - 15.10 - 8.19\times2 + 8.00\times2)\times100-2.30\\
+& = & 268.70\\
+\end{array}
+$$
+<br>
+<p>So, the strategy gains $268.70.</p>
+
+<p>The following algorithm implements a short call backspread Option strategy:</p>
+
+<div class="python">
+    <div class="qc-embed-frame" style="display: inline-block; position: relative; width: 100%; min-height: 100px; min-width: 300px;">
+        <div class="qc-embed-dummy" style="padding-top: 56.25%;"></div>
+        <div class="qc-embed-element" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;">
+            <iframe class="qc-embed-backtest" height="100%" width="100%" style="border: 1px solid #ccc; padding: 0; margin: 0;" src="https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_955977bc7f78cae16c4778f858dac82e.html"></iframe>
+        </div>
+    </div>
+</div>
+
+<div class="csharp">
+    <div class="qc-embed-frame" style="display: inline-block; position: relative; width: 100%; min-height: 100px; min-width: 300px;">
+        <div class="qc-embed-dummy" style="padding-top: 56.25%;"></div>
+        <div class="qc-embed-element" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;">
+            <iframe class="qc-embed-backtest" height="100%" width="100%" style="border: 1px solid #ccc; padding: 0; margin: 0;" src="https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_21e9cf5999731d32f51a2c1a76a0221b.html"></iframe>
+        </div>
+    </div>
+</div>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/39 Short Call Backspread/metadata.json
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/39 Short Call Backspread/metadata.json
@@ -1,0 +1,12 @@
+{
+    "type": "metadata",
+    "values": {
+        "description": "Short call backspread, a combination of bull call spread and short call, consists of buying a lower-strike call and selling two higher-srtike calls with the same expiry.",
+        "keywords": "short call backspread, bull call spread, limited-reward-unlimited-risk strategy, strategy payoff, early assignment",
+        "og:description": "Short call backspread, a combination of bull call spread and short call, consists of buying a lower-strike call and selling two higher-srtike calls with the same expiry.",
+        "og:title": "Short Call Backspread - Documentation QuantConnect.com",
+        "og:type": "website",
+        "og:site_name": "Short Call Backspread - QuantConnect.com",
+        "og:image": "https://cdn.quantconnect.com/docs/i/writing-algorithms/trading-and-orders/option-strategies/short-call-backspread.png"
+    }
+}

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/40 Long Put Backspread/01 Introduction.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/40 Long Put Backspread/01 Introduction.html
@@ -1,0 +1,7 @@
+<p>
+  <span class="new-term">Long Put Backspread</span>, consists of short 1 higher-strike put and long 2 lower-strike puts.
+  It is a combination of a <a href="/docs/v2/writing-algorithms/trading-and-orders/option-strategies/bull-put-spread">bull put spread</a> and a long put with the same strike price as the lower-strike leg the put spread. 
+  All puts have the same underlying Equity and expiration date. 
+  This strategy profits from increasing volatility of the underlying asset. 
+  For instance, the underlying price moves away from its current price.
+</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/40 Long Put Backspread/02 Implementation.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/40 Long Put Backspread/02 Implementation.html
@@ -1,0 +1,110 @@
+<p>Follow these steps to implement the long put backspread strategy:</p>
+
+<ol>
+    <li>In the <code class="csharp">Initialize</code><code class="python">initialize</code> method, set the start date, end date, cash, and <a href="/docs/v2/writing-algorithms/universes/equity-options">Option universe</a>. You can use the <code class="csharp">PutSpread</code><code class="csharp">put_spread</code> helper method in option universe filtering, since a put backspread consists of the same contracts as a put spread.</li>
+    <div class="section-example-container">
+        <pre class="csharp">private Symbol _symbol;
+
+public override void Initialize()
+{
+    SetStartDate(2017, 4, 1);
+    SetEndDate(2017, 4, 22);
+    SetCash(1000000);
+
+    UniverseSettings.Asynchronous = true;
+    var option = AddOption("GOOG", Resolution.Minute);
+    _symbol = option.Symbol;
+    option.SetFilter(universe =&gt; universe.IncludeWeeklys().PutSpread(20, 5));
+}</pre>
+        <pre class="python">def initialize(self) -&gt; None:
+    self.set_start_date(2017, 4, 1)
+    self.set_end_date(2017, 4, 22)
+    self.set_cash(1000000)
+
+    self.universe_settings.asynchronous = True
+    option = self.add_option("GOOG", Resolution.MINUTE)
+    self._symbol = option.symbol
+    option.set_filter(lambda universe: universe.include_weeklys().put_spread(20, 5))</pre>
+    </div>
+
+    <li>In the <code class="csharp">OnData</code><code class="python">on_data</code> method, select the expiration and strikes of the contracts in the strategy legs.</li>
+    <div class="section-example-container">
+        <pre class="csharp">public override void OnData(Slice slice)
+{
+    if (Portfolio.Invested ||
+        !slice.OptionChains.TryGetValue(_symbol, out var chain))
+    {
+        return;
+    }
+
+    // Select the put Option contracts with the furthest expiry
+    var expiry = chain.Max(x =&gt; x.Expiry);    
+    var puts = chain.Where(x =&gt; x.Expiry == expiry);
+    if (puts.Count() == 0) return;
+
+    // Select the strike prices from the remaining contracts
+    var strikes = puts.Select(x =&gt; x.Strike).Distinct().OrderBy(x =&gt; x).ToList();
+    if (strikes.Count &lt; 2)
+    {
+        return;
+    }
+    
+    var lowStrike = strikes[0];
+    var highStrike = strikes[1];</pre>
+        <pre class="python">def on_data(self, slice: Slice) -&gt; None:
+    if self.portfolio.invested:
+        return
+
+    # Get the OptionChain
+    chain = slice.option_chains.get(self._symbol, None)
+    if not chain:
+        return
+    
+    # Select the put Option contracts with the furthest expiry
+    expiry = max([x.expiry for x in chain])
+    puts = [i for i in chain if i.expiry == expiry]
+    if not puts:
+        return
+
+    # Select the strike prices from the remaining contracts
+    strikes = sorted(set(x.strike for x in puts))
+    if len(strikes) &lt; 2:
+        return
+    
+    low_strike = strikes[0]
+    high_strike = strikes[1]</pre>
+    </div>
+
+    <li>In the <code class="csharp">OnData</code><code class="python">on_data</code> method, select the contracts and place the orders.</li>
+
+    <p><b>Approach A:</b> Call the <code class="csharp">OptionStrategies.PutBackspread</code><code class="python">OptionStrategies.put_backspread</code> method with the details of each leg and then pass the result to the <code class="csharp">Buy</code><code class="python">buy</code> method.</p>
+    <div class="section-example-container">
+        <pre class="csharp">var optionStrategy = OptionStrategies.PutBackspread(_symbol, highStrike, lowStrike, expiry);
+Buy(optionStrategy, 1);<br></pre>
+        <pre class="python">option_strategy = OptionStrategies.put_backspread(self._symbol, high_strike, low_strike, expiry)
+self.buy(option_strategy, 1)</pre>
+    </div>
+
+    <p><b>Approach B:</b> Create a list of <code>Leg</code> objects and then call the <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-market-orders"><span class='csharp'>Combo Market Order</span><span class='python'>combo_market_order</span></a>, <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-limit-orders"><span class='csharp'>Combo Limit Order</span><span class='python'>combo_limit_order</span></a>, or <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-leg-limit-orders"><span class='csharp'>Combo Leg Limit Order</span><span class='python'>combo_leg_limit_order</span></a> method.</p>
+    
+    <div class="section-example-container">
+        <pre class="csharp">var lowStrikePut = puts.Single(x =&gt; x.Strike == lowStrike);
+var highStrikePut = puts.Single(x =&gt; x.Strike == highStrike);
+
+var legs = new List&lt;Leg&gt;()
+{
+    Leg.Create(lowStrikePut.Symbol, 2),
+    Leg.Create(highStrikePut.Symbol, -1)
+};
+ComboMarketOrder(legs, 1, true);</pre>
+        <pre class="python">low_strike_put = next(filter(lambda x: x.strike == low_strike, puts))
+high_strike_put = next(filter(lambda x: x.strike == high_strike, puts))
+
+legs = [
+    Leg.create(low_strike_put.symbol, 2),
+    Leg.create(high_strike_put.symbol, -1)
+]
+self.combo_market_order(legs, 1)</pre>
+    </div>
+</ol>
+

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/40 Long Put Backspread/03 Strategy Payoff.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/40 Long Put Backspread/03 Strategy Payoff.html
@@ -1,0 +1,34 @@
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+</script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+
+<p>The long put backspread is an unlimited-profit-limited-risk strategy. The payoff is</p>
+$$
+\begin{array}{rcll}
+P^{low}_T &amp; = &amp; (K^{low} - S_T)^{+}\\
+P^{high}_T &amp; = &amp; (K^{high} - S_T)^{+}\\
+Payoff_T &amp; = &amp; (P^{high}_0 - P^{high}_T + P^{low}_T \times 2 - P^{low}_0 \times 2)\times m - fee\\
+\end{array}
+$$
+$$
+\begin{array}{rcll}
+\textrm{where} &amp; P^{low}_T &amp; = &amp; \textrm{Lower-strike put value at time T}\\
+&amp; P^{high}_T &amp; = &amp; \textrm{Higher-strike put value at time T}\\
+&amp; S_T &amp; = &amp; \textrm{Underlying asset price at time T}\\
+&amp; K^{low} &amp; = &amp; \textrm{Lower-strike put strike price}\\
+&amp; K^{high} &amp; = &amp; \textrm{Higher-strike put strike price}\\
+&amp; P^{low}_0 &amp; = &amp; \textrm{Lower-strike put value at position opening (credit received)}\\
+&amp; P^{high}_0 &amp; = &amp; \textrm{Higher-strike put value at position opening (debit paid)}\\
+&amp; m &amp; = &amp; \textrm{Contract multiplier}\\
+&amp; T &amp; = &amp; \textrm{Time of expiration}
+\end{array}
+$$
+<br>
+<p>The following chart shows the payoff at expiration:</p>
+<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/long-put-backspread-payoff.png" alt="Strategy payoff decomposition and analysis of long put backspread">
+
+<p>The maximum profit is unlimited, which occurs when the underlying price increases indefinitely.</p>
+<p>The maximum loss is $K^{low} - K^{high} + P^{high}_0 - P^{low}_0 \times 2$, which occurs when the underlying price is exactly at the lower strike at expiry.</p>
+<p>If the Option is American Option, there is a risk of <a href='/docs/v2/writing-algorithms/reality-modeling/options-models/assignment'>early assignment</a> on the contract you sell.</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/40 Long Put Backspread/04 Example.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/40 Long Put Backspread/04 Example.html
@@ -1,0 +1,64 @@
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+</script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+
+<p>The following table shows the price details of the assets in the algorithm:</p>
+
+<table class="table qc-table" id="payoff-table">
+<thead>
+<tr><th>Asset</th><th>Price ($)</th><th>Strike ($)</th></tr>
+</thead>
+<tbody>
+<tr><td>Lower-Strike put</td><td>6.90</td><td>825.00</td></tr>
+<tr><td>Higher-strike put</td><td>8.50</td><td>835.00</td></tr>
+<tr><td>Underlying Equity at expiration</td><td>843.19</td><td>-</td></tr>
+</tbody>
+</table>
+
+<style>
+#payoff-table td:nth-child(2), 
+#payoff-table th:nth-child(2), 
+#payoff-table td:nth-child(3), 
+#payoff-table th:nth-child(3) {
+    text-align: right;
+}
+</style>
+
+<p>Therefore, the payoff is</p>
+$$
+\begin{array}{rcll}
+P^{low}_T & = & (K^{low} - S_T)^{+}\\
+& = & (825.00-843.19)^{+}\\
+& = & 0.00\\
+P^{high}_T & = & (K^{high} - S_T)^{+}\\
+& = & (835.00-843.19)^{+}\\
+& = & 0.00\\
+Payoff_T & = & (P^{high}_0 - P^{high}_T + P^{low}_T \times 2 - P^{low}_0 \times 2)\times m - fee\\
+& = & (8.50 - 0.00 + 0.00\times2 - 6.90\times2)\times100-2.30\\
+& = & -532.30\\
+\end{array}
+$$
+<br>
+<p>So, the strategy loses $532.30.</p>
+
+<p>The following algorithm implements a long put backspread Option strategy:</p>
+
+<div class="python">
+    <div class="qc-embed-frame" style="display: inline-block; position: relative; width: 100%; min-height: 100px; min-width: 300px;">
+        <div class="qc-embed-dummy" style="padding-top: 56.25%;"></div>
+        <div class="qc-embed-element" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;">
+            <iframe class="qc-embed-backtest" height="100%" width="100%" style="border: 1px solid #ccc; padding: 0; margin: 0;" src="https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_2aa9a3547f28656758e14e5bf7f9b5a9.html"></iframe>
+        </div>
+    </div>
+</div>
+
+<div class="csharp">
+    <div class="qc-embed-frame" style="display: inline-block; position: relative; width: 100%; min-height: 100px; min-width: 300px;">
+        <div class="qc-embed-dummy" style="padding-top: 56.25%;"></div>
+        <div class="qc-embed-element" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;">
+            <iframe class="qc-embed-backtest" height="100%" width="100%" style="border: 1px solid #ccc; padding: 0; margin: 0;" src="https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_6208f8309df1eb5a229c7b043c717cde.html"></iframe>
+        </div>
+    </div>
+</div>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/40 Long Put Backspread/metadata.json
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/40 Long Put Backspread/metadata.json
@@ -1,0 +1,12 @@
+{
+    "type": "metadata",
+    "values": {
+        "description": "Long put backspread, a combination of bull put spread and long put, consists of selling a higher-strike put and buying two lower-srtike puts with the same expiry.",
+        "keywords": "put backspread, bull put spread, unlimited-reward-limited-risk strategy, strategy payoff, early assignment",
+        "og:description": "Long put backspread, a combination of bull put spread and long put, consists of selling a higher-strike put and buying two lower-srtike puts with the same expiry.",
+        "og:title": "Long Put Backspread - Documentation QuantConnect.com",
+        "og:type": "website",
+        "og:site_name": "Long Put Backspread - QuantConnect.com",
+        "og:image": "https://cdn.quantconnect.com/docs/i/writing-algorithms/trading-and-orders/option-strategies/long-put-backspread.png"
+    }
+}

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/41 Short Put Backspread/01 Introduction.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/41 Short Put Backspread/01 Introduction.html
@@ -1,0 +1,7 @@
+<p>
+  <span class="new-term">Short Put Backspread</span>, consists of short 1 higher-strike put and short 2 lower-strike puts.
+  It is a combination of a <a href="/docs/v2/writing-algorithms/trading-and-orders/option-strategies/bear-put-spread">bear put spread</a> and a short put with the same strike price as the lower-strike leg the put spread. 
+  All puts have the same underlying Equity and expiration date. 
+  This strategy profits from stable, consistent price of the underlying asset. 
+  For instance, the underlying price stays at its current price.
+</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/41 Short Put Backspread/02 Implementation.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/41 Short Put Backspread/02 Implementation.html
@@ -1,0 +1,110 @@
+<p>Follow these steps to implement the short put backspread strategy:</p>
+
+<ol>
+    <li>In the <code class="csharp">Initialize</code><code class="python">initialize</code> method, set the start date, end date, cash, and <a href="/docs/v2/writing-algorithms/universes/equity-options">Option universe</a>. You can use the <code class="csharp">PutSpread</code><code class="csharp">put_spread</code> helper method in option universe filtering, since a put backspread consists of the same contracts as a put spread.</li>
+    <div class="section-example-container">
+        <pre class="csharp">private Symbol _symbol;
+
+public override void Initialize()
+{
+    SetStartDate(2017, 4, 1);
+    SetEndDate(2017, 4, 22);
+    SetCash(1000000);
+
+    UniverseSettings.Asynchronous = true;
+    var option = AddOption("GOOG", Resolution.Minute);
+    _symbol = option.Symbol;
+    option.SetFilter(universe =&gt; universe.IncludeWeeklys().PutSpread(20, 5));
+}</pre>
+        <pre class="python">def initialize(self) -&gt; None:
+    self.set_start_date(2017, 4, 1)
+    self.set_end_date(2017, 4, 22)
+    self.set_cash(1000000)
+
+    self.universe_settings.asynchronous = True
+    option = self.add_option("GOOG", Resolution.MINUTE)
+    self._symbol = option.symbol
+    option.set_filter(lambda universe: universe.include_weeklys().put_spread(20, 5))</pre>
+    </div>
+
+    <li>In the <code class="csharp">OnData</code><code class="python">on_data</code> method, select the expiration and strikes of the contracts in the strategy legs.</li>
+    <div class="section-example-container">
+        <pre class="csharp">public override void OnData(Slice slice)
+{
+    if (Portfolio.Invested ||
+        !slice.OptionChains.TryGetValue(_symbol, out var chain))
+    {
+        return;
+    }
+
+    // Select the put Option contracts with the furthest expiry
+    var expiry = chain.Max(x =&gt; x.Expiry);    
+    var puts = chain.Where(x =&gt; x.Expiry == expiry);
+    if (puts.Count() == 0) return;
+
+    // Select the strike prices from the remaining contracts
+    var strikes = puts.Select(x =&gt; x.Strike).Distinct().OrderBy(x =&gt; x).ToList();
+    if (strikes.Count &lt; 2)
+    {
+        return;
+    }
+    
+    var lowStrike = strikes[0];
+    var highStrike = strikes[1];</pre>
+        <pre class="python">def on_data(self, slice: Slice) -&gt; None:
+    if self.portfolio.invested:
+        return
+
+    # Get the OptionChain
+    chain = slice.option_chains.get(self._symbol, None)
+    if not chain:
+        return
+    
+    # Select the put Option contracts with the furthest expiry
+    expiry = max([x.expiry for x in chain])
+    puts = [i for i in chain if i.expiry == expiry]
+    if not puts:
+        return
+
+    # Select the strike prices from the remaining contracts
+    strikes = sorted(set(x.strike for x in puts))
+    if len(strikes) &lt; 2:
+        return
+    
+    low_strike = strikes[0]
+    high_strike = strikes[1]</pre>
+    </div>
+
+    <li>In the <code class="csharp">OnData</code><code class="python">on_data</code> method, select the contracts and place the orders.</li>
+
+    <p><b>Approach A:</b> Call the <code class="csharp">OptionStrategies.ShortPutBackspread</code><code class="python">OptionStrategies.short_put_backspread</code> method with the details of each leg and then pass the result to the <code class="csharp">Buy</code><code class="python">buy</code> method.</p>
+    <div class="section-example-container">
+        <pre class="csharp">var optionStrategy = OptionStrategies.ShortPutBackspread(_symbol, highStrike, lowStrike, expiry);
+Buy(optionStrategy, 1);<br></pre>
+        <pre class="python">option_strategy = OptionStrategies.short_put_backspread(self._symbol, high_strike, low_strike, expiry)
+self.buy(option_strategy, 1)</pre>
+    </div>
+
+    <p><b>Approach B:</b> Create a list of <code>Leg</code> objects and then call the <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-market-orders"><span class='csharp'>Combo Market Order</span><span class='python'>combo_market_order</span></a>, <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-limit-orders"><span class='csharp'>Combo Limit Order</span><span class='python'>combo_limit_order</span></a>, or <a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/combo-leg-limit-orders"><span class='csharp'>Combo Leg Limit Order</span><span class='python'>combo_leg_limit_order</span></a> method.</p>
+    
+    <div class="section-example-container">
+        <pre class="csharp">var lowStrikePut = puts.Single(x =&gt; x.Strike == lowStrike);
+var highStrikePut = puts.Single(x =&gt; x.Strike == highStrike);
+
+var legs = new List&lt;Leg&gt;()
+{
+    Leg.Create(lowStrikePut.Symbol, -2),
+    Leg.Create(highStrikePut.Symbol, 1)
+};
+ComboMarketOrder(legs, 1, true);</pre>
+        <pre class="python">low_strike_put = next(filter(lambda x: x.strike == low_strike, puts))
+high_strike_put = next(filter(lambda x: x.strike == high_strike, puts))
+
+legs = [
+    Leg.create(low_strike_put.symbol, -2),
+    Leg.create(high_strike_put.symbol, 1)
+]
+self.combo_market_order(legs, 1)</pre>
+    </div>
+</ol>
+

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/41 Short Put Backspread/03 Strategy Payoff.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/41 Short Put Backspread/03 Strategy Payoff.html
@@ -1,0 +1,34 @@
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+</script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+
+<p>The short put backspread is an unlimited-profit-limited-risk strategy. The payoff is</p>
+$$
+\begin{array}{rcll}
+P^{low}_T &amp; = &amp; (K^{low} - S_T)^{+}\\
+P^{high}_T &amp; = &amp; (K^{high} - S_T)^{+}\\
+Payoff_T &amp; = &amp; (P^{high}_T - P^{high}_0 - P^{low}_T \times 2 + P^{low}_0 \times 2)\times m - fee\\
+\end{array}
+$$
+$$
+\begin{array}{rcll}
+\textrm{where} &amp; P^{low}_T &amp; = &amp; \textrm{Lower-strike put value at time T}\\
+&amp; P^{high}_T &amp; = &amp; \textrm{Higher-strike put value at time T}\\
+&amp; S_T &amp; = &amp; \textrm{Underlying asset price at time T}\\
+&amp; K^{low} &amp; = &amp; \textrm{Lower-strike put strike price}\\
+&amp; K^{high} &amp; = &amp; \textrm{Higher-strike put strike price}\\
+&amp; P^{low}_0 &amp; = &amp; \textrm{Lower-strike put value at position opening (credit received)}\\
+&amp; P^{high}_0 &amp; = &amp; \textrm{Higher-strike put value at position opening (debit paid)}\\
+&amp; m &amp; = &amp; \textrm{Contract multiplier}\\
+&amp; T &amp; = &amp; \textrm{Time of expiration}
+\end{array}
+$$
+<br>
+<p>The following chart shows the payoff at expiration:</p>
+<img class="docs-image" src="https://cdn.quantconnect.com/i/tu/short-put-backspread-payoff.png" alt="Strategy payoff decomposition and analysis of short put backspread">
+
+<p>The maximum profit is $K^{high} - K^{low} - P^{high}_0 + P^{low}_0 \times 2$, which occurs when the underlying price is exactly at the lower strike at expiry.</p>
+<p>The maximum loss is $P^{low}_0 \times 2 - P^{high}_0 - S_T$, which occurs when the underlying price drops to zero.</p>
+<p>If the Option is American Option, there is a risk of <a href='/docs/v2/writing-algorithms/reality-modeling/options-models/assignment'>early assignment</a> on the contract you sell.</p>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/41 Short Put Backspread/04 Example.html
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/41 Short Put Backspread/04 Example.html
@@ -1,0 +1,64 @@
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+</script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+
+<p>The following table shows the price details of the assets in the algorithm:</p>
+
+<table class="table qc-table" id="payoff-table">
+<thead>
+<tr><th>Asset</th><th>Price ($)</th><th>Strike ($)</th></tr>
+</thead>
+<tbody>
+<tr><td>Lower-Strike put</td><td>4.70</td><td>825.00</td></tr>
+<tr><td>Higher-strike put</td><td>10.90</td><td>835.00</td></tr>
+<tr><td>Underlying Equity at expiration</td><td>843.19</td><td>-</td></tr>
+</tbody>
+</table>
+
+<style>
+#payoff-table td:nth-child(2), 
+#payoff-table th:nth-child(2), 
+#payoff-table td:nth-child(3), 
+#payoff-table th:nth-child(3) {
+    text-align: right;
+}
+</style>
+
+<p>Therefore, the payoff is</p>
+$$
+\begin{array}{rcll}
+P^{low}_T & = & (K^{low} - S_T)^{+}\\
+& = & (825.00-843.19)^{+}\\
+& = & 0.00\\
+P^{high}_T & = & (K^{high} - S_T)^{+}\\
+& = & (835.00-843.19)^{+}\\
+& = & 0.00\\
+Payoff_T & = & (P^{high}_T - P^{high}_0 - P^{low}_T \times 2 + P^{low}_0 \times 2)\times m - fee\\
+& = & (0 - 10.90 - 0.00\times2 + 4.70\times2)\times100-2.30\\
+& = & -152.30\\
+\end{array}
+$$
+<br>
+<p>So, the strategy loses $152.30.</p>
+
+<p>The following algorithm implements a short put backspread Option strategy:</p>
+
+<div class="python">
+    <div class="qc-embed-frame" style="display: inline-block; position: relative; width: 100%; min-height: 100px; min-width: 300px;">
+        <div class="qc-embed-dummy" style="padding-top: 56.25%;"></div>
+        <div class="qc-embed-element" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;">
+            <iframe class="qc-embed-backtest" height="100%" width="100%" style="border: 1px solid #ccc; padding: 0; margin: 0;" src="https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_5fcfff698500fd7cc3b66c890c2611e5.html"></iframe>
+        </div>
+    </div>
+</div>
+
+<div class="csharp">
+    <div class="qc-embed-frame" style="display: inline-block; position: relative; width: 100%; min-height: 100px; min-width: 300px;">
+        <div class="qc-embed-dummy" style="padding-top: 56.25%;"></div>
+        <div class="qc-embed-element" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;">
+            <iframe class="qc-embed-backtest" height="100%" width="100%" style="border: 1px solid #ccc; padding: 0; margin: 0;" src="https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_c7db4c8122f59ddc1f9947110e8c6ae6.html"></iframe>
+        </div>
+    </div>
+</div>

--- a/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/41 Short Put Backspread/metadata.json
+++ b/03 Writing Algorithms/22 Trading and Orders/07 Option Strategies/41 Short Put Backspread/metadata.json
@@ -1,0 +1,12 @@
+{
+    "type": "metadata",
+    "values": {
+        "description": "Short put backspread, a combination of bear put spread and short put, consists of buying a higher-strike put and selling two lower-srtike puts with the same expiry.",
+        "keywords": "shrot put backspread, bear put spread, limited-reward-limited-risk strategy, strategy payoff, early assignment",
+        "og:description": "Short put backspread, a combination of bear put spread and short put, consists of buying a higher-strike put and selling two lower-srtike puts with the same expiry.",
+        "og:title": "Short Put Backspread - Documentation QuantConnect.com",
+        "og:type": "website",
+        "og:site_name": "Short Put Backspread - QuantConnect.com",
+        "og:image": "https://cdn.quantconnect.com/docs/i/writing-algorithms/trading-and-orders/option-strategies/short-put-backspread.png"
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Add documentations of `OptionStrategies.CallBackspread`, `OptionStrategies.PutBackspread`, `OptionStrategies.ShortCallBackspread`, `OptionStrategies.ShortPutBackspread` in Writing Algorithms / Trading and Orders / Option Strategies

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
newly merged Lean function

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
