### PR TITLE
Added handing of missing price #1993

### DIFF
--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/05 PyTorch/06 Predict Labels.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/05 PyTorch/06 Predict Labels.html
@@ -9,8 +9,10 @@ prediction = float(prediction.detach().numpy()[-1])</pre>
 <p>You can use the label prediction to place orders.</p>
 <div class="section-example-container">
     <pre class="python"># Place orders based on the forecasted market direction.
-if prediction > slice[self._symbol].price:
-    self.set_holdings(self._symbol, 1)
-elif prediction < slice[self._symbol].price:            
-    self.set_holdings(self._symbol, -1)</pre>
+if slice[self.symbol]:
+    _price = slice[self.symbol].price
+    if prediction > _price:
+        self.set_holdings(self.symbol, 1)
+    elif prediction < _price:            
+        self.set_holdings(self.symbol, -1)</pre>
 </div>

--- a/Documentation.sln
+++ b/Documentation.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "URLTest", "URL Test\URLTest.csproj", "{6B7B820E-B178-4AF7-A524-FEF18C5ADA7C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6B7B820E-B178-4AF7-A524-FEF18C5ADA7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B7B820E-B178-4AF7-A524-FEF18C5ADA7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B7B820E-B178-4AF7-A524-FEF18C5ADA7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B7B820E-B178-4AF7-A524-FEF18C5ADA7C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CE480C67-F2DC-45FE-9C81-85AA05BF1746}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
I added an `if` statement to deal with the missing value. When the `self.symbol` is missing, the model will skip this deal to avoid interrupting the backtest.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[https://github.com/QuantConnect/Documentation/issues/1993](https://github.com/QuantConnect/Documentation/issues/1993)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We cannot backtest the original algorithm correctly because the missing data may interrupt the backtest mission. By adding the determinate code, the algorithm can skip the missing data point and continue to run.

Before:
<img width="1060" alt="error" src="https://github.com/user-attachments/assets/20e75415-589d-4fa9-8db0-cdced268fb59">

After:
<img width="1055" alt="correct" src="https://github.com/user-attachments/assets/b0e924f3-2957-412c-9f8e-104be1f7f992">


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
