### PR TITLE
Rename example to examples in YAML

### DIFF
--- a/QuantConnect-Platform-2.0.0.yaml
+++ b/QuantConnect-Platform-2.0.0.yaml
@@ -1764,11 +1764,11 @@ components:
           enum:
           - C#
           - Py
-          example: Py
+          examples: Py
           description: Programming language.
         files:
           type: array
-          example: "[{\"name\": \"file.py\", \"content\": \"fileContent\"}]"
+          examples: "[{\"name\": \"file.py\", \"content\": \"fileContent\"}]"
           description: Files to process.
           items:
             $ref: '#/components/schemas/File'
@@ -1778,18 +1778,18 @@ components:
       properties:
         state:
           type: string
-          example: End
+          examples: End
           description: State of the backtest (e.g. Error, End).
         version:
           type: string
-          example: 2.0
+          examples: 2.0
           description: Version of the response.
         payload:
           type: string
           description: Information about the backtest initialization. 
         payloadType:
           type: string
-          example: String
+          examples: String
           description: Type of the payload, e.g. String.
       description: Response to a backtest initialization request.
     CodeCompletionRequest:
@@ -1803,15 +1803,15 @@ components:
           enum:
           - C#
           - Py
-          example: Py
+          examples: Py
           description: Programming language for the code completion.
         sentence:
           type: string
-          example: self.add_equity(\"AAPL\"
+          examples: self.add_equity(\"AAPL\"
           description: Sentence to complete.
         responseSizeLimit:
           type: integer
-          example: 10
+          examples: 10
           description: Maximum size of the responses.
       description: Request to show code completion for a specific text input.
     CodeCompletionResponse:
@@ -1819,11 +1819,11 @@ components:
       properties:
         state:
           type: string
-          example: End
+          examples: End
           description: State of the code completion.
         version:
           type: string
-          example: 2.0
+          examples: 2.0
           description: Version of the response.
         payload:
           type: array
@@ -1832,7 +1832,7 @@ components:
           description: Code completion suggestions. 
         payloadType:
           type: string
-          example: StringArray
+          examples: StringArray
           description: Type of the payload, e.g. StringArray.
       description: Response to a code completion request.
     ErrorEnhanceRequest:
@@ -1846,7 +1846,7 @@ components:
           enum:
           - C#
           - Py
-          example: Py
+          examples: Py
           description: Programming language for the code completion.
         error:
           type: object
@@ -1858,18 +1858,18 @@ components:
       properties:
         state:
           type: string
-          example: End
+          examples: End
           description: State of the code completion.
         version:
           type: string
-          example: 2.0
+          examples: 2.0
           description: Version of the response.
         payload:
           type: string
           description: Error message suggestions.
         payloadType:
           type: string
-          example: String
+          examples: String
           description: Type of the payload, e.g. String.
       description: Response to error enhancement request.
     PEP8ConvertRequest:
@@ -1879,7 +1879,7 @@ components:
       properties:
         files:
           type: array
-          example: "[{\"name\": \"file.py\", \"content\": \"fileContent\"}]"
+          examples: "[{\"name\": \"file.py\", \"content\": \"fileContent\"}]"
           description: Files present in the project in which the algorithm is.
           items:
             $ref: '#/components/schemas/File'
@@ -1889,19 +1889,19 @@ components:
       properties:
         state:
           type: string
-          example: End
+          examples: End
           description: State of PEP8 conversion.
         version:
           type: string
-          example: 2.0
+          examples: 2.0
           description: Version of the response.
         payload:
           type: dict
-          example: {"utils.py": "def add(a,b):\n    return a+b\n"}
+          examples: {"utils.py": "def add(a,b):\n    return a+b\n"}
           description: PEP8 converted code.
         payloadType:
           type: string
-          example: StringDict
+          examples: StringDict
           description: Type of the payload, e.g. StringDict.
       description: Response to a PEP8 conversion request.
     SyntaxCheckResponse:
@@ -1909,11 +1909,11 @@ components:
       properties:
         state:
           type: string
-          example: End
+          examples: End
           description: State of the syntax check.
         version:
           type: string
-          example: 2.0
+          examples: 2.0
           description: Version of the response.
         payload:
           type: array
@@ -1922,7 +1922,7 @@ components:
           description: Code completion suggestions. 
         payloadType:
           type: string
-          example: StringArray
+          examples: StringArray
           description: Type of the payload, e.g. StringArray.
       description: Response to a syntax check request.
     SearchRequest:
@@ -1936,11 +1936,11 @@ components:
           enum:
           - C#
           - Py
-          example: Py
+          examples: Py
           description: Programming language of the content to search.
         criteria:
           type: array
-          example: "[{\"input\": \"option\", \"type\": \"Docs\", \"count\": 1}]"
+          examples: "[{\"input\": \"option\", \"type\": \"Docs\", \"count\": 1}]"
           items:
             $ref: '#/components/schemas/SearchCriteria'
           description: Criteria for the search.
@@ -1950,15 +1950,15 @@ components:
       properties:
         input:
           type: string
-          example: option
+          examples: option
           description: Input for the search.
         type:
           type: string
-          example: Docs
+          examples: Docs
           description: Type of the search criteria.
         count:
           type: integer
-          example: 1
+          examples: 1
           description: Number of results to return.
       description: Search criteria.
     SearchResponse:
@@ -1966,11 +1966,11 @@ components:
       properties:
         state:
           type: string
-          example: End
+          examples: End
           description: State of the search.
         version:
           type: string
-          example: 2.0
+          examples: 2.0
           description: Version of the response.
         retrivals:
           type: array
@@ -1979,7 +1979,7 @@ components:
           description: List of search results.
         messageId:
           type: integer
-          example: 0
+          examples: 0
           description: ID of the message.
       description: Response to a search request.
     SearchRetrieval:
@@ -1987,18 +1987,18 @@ components:
       properties:
         url:
           type: string
-          example: option[Index Options - QuantConnect.com](https://www.quantconnect.com/docs/v2/writing-algorithms/universes/index-options)
+          examples: option[Index Options - QuantConnect.com](https://www.quantconnect.com/docs/v2/writing-algorithms/universes/index-options)
           description: Input for the search.
         score:
           type: number
-          example: 0.320344448
+          examples: 0.320344448
           description: Relevance score of the search result.
         content:
           type: string
           description: Content of the search result.
         type:
           type: number
-          example: 2
+          examples: 2
           description: Type of the search result.
       description: Search criteria.
     AbortOptimizationRequest:
@@ -2006,7 +2006,7 @@ components:
       properties:
         optimizationId:
           type: string
-          example: O-401d3d40b5a0e9f8c46c954a303f3ddd
+          examples: O-401d3d40b5a0e9f8c46c954a303f3ddd
           description: Optimization ID we want to abort.
       description: Abort an optimization.
     AccountResponse:
@@ -2014,7 +2014,7 @@ components:
       properties:
         organizationId:
           type: string
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
           description: The organization Id.
         creditBalance:
           type: number
@@ -2143,7 +2143,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project to read.
         backtestId:
           type: string
@@ -2160,22 +2160,22 @@ components:
           description: Name of the backtest.
         organizationId:
           type: string
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
           description: Orgainization ID.
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project ID
         completed:
           type: boolean
           description: Boolean true when the backtest is completed.
         optimizationId:
           type: string
-          example: O-401d3d40b5a0e9f8c46c954a303f3ddd
+          examples: O-401d3d40b5a0e9f8c46c954a303f3ddd
           description: Optimization task ID, if the backtest is part of an optimization.
         backtestId:
           type: string
-          example: 26c7bb06b8487cff1c7b3c44652b30f1
+          examples: 26c7bb06b8487cff1c7b3c44652b30f1
           description: Assigned backtest ID.
         tradeableDates:
           type: integer
@@ -2265,7 +2265,7 @@ components:
       properties:
         backtestId:
           type: string
-          example: 26c7bb06b8487cff1c7b3c44652b30f1
+          examples: 26c7bb06b8487cff1c7b3c44652b30f1
           description: Assigned backtest ID
         status:
           type: string
@@ -2287,7 +2287,7 @@ components:
           format: float
         optimizationId:
           type: string
-          example: O-401d3d40b5a0e9f8c46c954a303f3ddd
+          examples: O-401d3d40b5a0e9f8c46c954a303f3ddd
           description: Optimization task ID, if the backtest is part of an optimization.
         tradeableDates:
           type: integer
@@ -2354,15 +2354,15 @@ components:
         id:
           type: string
           description: '''Interactive'' / ''FXCM'' / ''Oanda'' / ''Tradier'' /''PaperTrading'''
-          example: "Default"
+          examples: "Default"
         user:
           type: string
           description: Username associated with brokerage.
-          example: ""
+          examples: ""
         password:
           type: string
           description: Password associated with brokerage.
-          example: ""
+          examples: ""
         environment:
           type: string
           description: Represents the types of environments supported by brokerages for trading.
@@ -2372,7 +2372,7 @@ components:
         account:
           type: string
           description: Account of the associated brokerage.
-          example: ""
+          examples: ""
       description: Base class for settings that must be configured per Brokerage to create new algorithms via the API.
     BinanceSettings:
       type: object
@@ -2631,7 +2631,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id we wish to compile.
       description: Request to compile a project.
     CoinbaseSettings:
@@ -2679,11 +2679,11 @@ components:
         profileImage:
           type: string
           description: The url of the user profile image.
-          example: "https://cdn.quantconnect.com/web/i/users/profile/abc123.jpeg"
+          examples: "https://cdn.quantconnect.com/web/i/users/profile/abc123.jpeg"
         email:
           type: string
           description: The registered email of the user.
-          example: "abc@123.com"
+          examples: "abc@123.com"
         name:
           type: string
           description: The display name of the user.
@@ -2701,19 +2701,19 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id we want to add the collaborator to.
         collaboratorUserId:
           type: string
-          example: "mia-ai"
+          examples: "mia-ai"
           description: User Id of the collaborator we want to add.
         collaborationLiveControl:
           type: boolean
-          example: true
+          examples: true
           description: Gives the right to deploy and stop live algorithms.
         collaborationWrite:
           type: boolean
-          example: false
+          examples: false
           description: Gives the right to edit the code.
       description: Request to add a new collaborator.
     CreateCollaboratorResponse:
@@ -2735,7 +2735,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project from which to read one or multiple collaborators.
       description: Request to list the collaborators in a project.
     ReadCollaboratorsResponse:
@@ -2764,19 +2764,19 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id we want to add the collaborator to.
         collaboratorUserId:
           type: string
-          example: "mia-ai"
+          examples: "mia-ai"
           description: User Id of the collaborator we want to add.
         liveControl:
           type: boolean
-          example: true
+          examples: true
           description: Gives the right to deploy and stop live algorithms.
         write:
           type: boolean
-          example: true
+          examples: true
           description: Gives the right to edit the code.
       description: Request to update an existing collaborator.
     UpdateCollaboratorResponse:
@@ -2799,11 +2799,11 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id we want to remove the collaborator from.
         collaboratorUserId:
           type: string
-          example: "mia-ai"
+          examples: "mia-ai"
           description: User Id of the collaborator we want to remove.
       description: Request to remove a collaborator.
     DeleteCollaboratorResponse:
@@ -2823,7 +2823,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project id.
         open:
           type: boolean
@@ -2842,7 +2842,7 @@ components:
       properties:
         compileId:
           type: string
-          example: c0edc6-49048b
+          examples: c0edc6-49048b
           description: Compile Id for a sucessful build.
         state:
           type: string
@@ -2853,7 +2853,7 @@ components:
           - BuildError
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id we sent for compile.
         signature:
           type: string
@@ -2885,19 +2885,19 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id we sent for compile.
         compileId:
           type: string
-          example: c0edc6-49048b
+          examples: c0edc6-49048b
           description: Compile Id for the project to backtest.
         backtestName:
           type: string
-          example: "New Backtest"
+          examples: "New Backtest"
           description: Optional. Name for the new backtest.
         parameters[name]:
           type: object
-          example: parameters[ema_fast] = 10, parameters[ema_slow] = 100
+          examples: parameters[ema_fast] = 10, parameters[ema_slow] = 100
           description: Optional. Parameters used in the backtest.
       description: Request to create a new backtest.
     CreateLiveAlgorithmRequest:
@@ -2912,14 +2912,14 @@ components:
         versionId:
           type: string
           description: The version of the Lean used to run the algorithm. -1 is master, however, sometimes this can create problems with live deployments. If you experience problems using, try specifying the version of Lean you would like to use.
-          example: "-1"
+          examples: "-1"
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id.
         compileId:
           type: string
-          example: c0edc6-49048b
+          examples: c0edc6-49048b
           description: Compile Id.
         nodeId:
           type: string
@@ -2968,7 +2968,7 @@ components:
               - CharlesSchwab
               - BybitBrokerage
               - IEXDataFeed
-            example: QuantConnectBrokerage
+            examples: QuantConnectBrokerage
           value:
             type: object
             description: Data provider configuration.
@@ -3015,12 +3015,12 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project for the live instance we want to run the command against.
         command:
           type: object
           description: The command to run.
-          example: { "$type": "OrderCommand", "symbol": { "id": "BTCUSD 2XR", "value": "BTCUSD" }, "order_type": "market", "quantity": "0.1", "limit_price": 0, "stop_price": 0, "tag": "" }
+          examples: { "$type": "OrderCommand", "symbol": { "id": "BTCUSD 2XR", "value": "BTCUSD" }, "order_type": "market", "quantity": "0.1", "limit_price": 0, "stop_price": 0, "tag": "" }
       description: Request to create a live command.
     BroadcastLiveCommandRequest:
       type: object
@@ -3031,15 +3031,15 @@ components:
         organizationId:
           type: string
           description: Organization Id of the projects we would like to broadcast the command to
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
         excludeProjectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project for the live instance we want to exclude from the broadcast list. If null, all projects will be included.
         command:
           type: object
           description: The command to run.
-          example: { "$type": "OrderCommand", "symbol": { "id": "BTCUSD 2XR", "value": "BTCUSD" }, "order_type": "market", "quantity": "0.1", "limit_price": 0, "stop_price": 0, "tag": "" }
+          examples: { "$type": "OrderCommand", "symbol": { "id": "BTCUSD 2XR", "value": "BTCUSD" }, "order_type": "market", "quantity": "0.1", "limit_price": 0, "stop_price": 0, "tag": "" }
       description: Request to create a live command.
     CreateOptimizationRequest:
       type: object
@@ -3058,31 +3058,31 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project ID of the project the optimization belongs to.
         name:
           type: string
-          example: "Mia First Optimization Job"
+          examples: "Mia First Optimization Job"
           description: Name of the optimization.
         target:
           type: string
           description: Target of the optimization.
-          example: TotalPerformance.PortfolioStatistics.SharpeRatio
+          examples: TotalPerformance.PortfolioStatistics.SharpeRatio
         targetTo:
           type: string
           description: Target extremum of the optimization.
-          example: \'max\' or \'min\'
+          examples: \'max\' or \'min\'
         targetValue:
           type: number
           description: Optimization target value.
-          example: 1
+          examples: 1
         strategy:
           type: string
           description: Optimization strategy.
-          example: QuantConnect.Optimizer.Strategies.GridSearchOptimizationStrategy
+          examples: QuantConnect.Optimizer.Strategies.GridSearchOptimizationStrategy
         compileId:
           type: string
-          example: c0edc6-49048b
+          examples: c0edc6-49048b
           description: Optimization compile ID.
         parameters:
           type: array
@@ -3097,11 +3097,11 @@ components:
         estimatedCost:
           type: number
           description: Estimated cost for optimization.
-          example: 10
+          examples: 10
         nodeType:
           type: string
           description: Optimization node type.
-          example: O2-8
+          examples: O2-8
           enum:
           - O2-8
           - O4-12
@@ -3109,18 +3109,18 @@ components:
         parallelNodes:
           type: integer
           description: Number of parallel nodes for optimization.
-          example: 4
+          examples: 4
       description: Request to create an optimization job.
     CreateOptimizationResponse:
       type: object
       properties:
         optimizationId:
           type: string
-          example: O-401d3d40b5a0e9f8c46c954a303f3ddd
+          examples: O-401d3d40b5a0e9f8c46c954a303f3ddd
           description: Optimization ID.
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project ID of the project the optimization belongs to.
         name:
           type: string
@@ -3136,7 +3136,7 @@ components:
         nodeType:
           type: string
           description: Optimization node type.
-          example: O2-8
+          examples: O2-8
           enum:
           - O2-8
           - O4-12
@@ -3192,7 +3192,7 @@ components:
           - Py
         organizationId:
           type: string
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
           description: The organization to create project under. If you don't provide a value, it defaults to your preferred organization.
       description: Request to create a project with the specified name and language via QuantConnect.com API.
     CreateProjectFileRequest:
@@ -3204,15 +3204,15 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id to which the file belongs.
         name:
           type: string
-          example: main.py
+          examples: main.py
           description: The name of the new file.
         content:
           type: string
-          example: |
+          examples: |
             class CustomClass:
                 def __init__(self):
                     pass
@@ -3226,11 +3226,11 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id to which the file belongs.
         name:
           type: string
-          example: file.py
+          examples: file.py
           description: The name of the file that should be deleted.
       description: Request to delete a file in a project.
     DeleteProjectRequest:
@@ -3240,7 +3240,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id to which the file belongs.
       description: Request to delete a project.
     DeleteBacktestRequest:
@@ -3251,11 +3251,11 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id for the backtest we want to delete.
         backtestId:
           type: string
-          example: 26c7bb06b8487cff1c7b3c44652b30f1
+          examples: 26c7bb06b8487cff1c7b3c44652b30f1
           description: Backtest Id we want to delete.
       description: Request to delete a backtest.
     DeleteObjectStoreRequest:
@@ -3266,11 +3266,11 @@ components:
       properties:
         organizationId:
           type: string
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
           description: Organization ID we'd like to delete the Object Store file from.
         key:
           type: string
-          example: key1
+          examples: key1
           description: Key to the Object Store file
       description: Request to delete Object Store metadata of a specific organization and key.    
     DeleteOptimizationRequest:
@@ -3278,7 +3278,7 @@ components:
       properties:
         optimizationId:
           type: string
-          example: O-401d3d40b5a0e9f8c46c954a303f3ddd
+          examples: O-401d3d40b5a0e9f8c46c954a303f3ddd
           description: Optimization ID we want to delete.
       description: Delete an optimization.
     EncryptionKey:
@@ -3300,11 +3300,11 @@ components:
         time:
           type: integer
           description: Estimate time in seconds.
-          example: 60
+          examples: 60
         balance:
           type: integer
           description: Estimate balance in QCC.
-          example: 10
+          examples: 10
       description: Response received when estimating the cost of an optimization.
     EstimateOptimizationRequest:
       type: object
@@ -3320,31 +3320,31 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project ID of the project the optimization belongs to.
         name:
           type: string
-          example: "Mia First Optimization Job"
+          examples: "Mia First Optimization Job"
           description: Name of the optimization.
         target:
           type: string
           description: Target of the optimization.
-          example: TotalPerformance.PortfolioStatistics.SharpeRatio
+          examples: TotalPerformance.PortfolioStatistics.SharpeRatio
         targetTo:
           type: string
           description: Target extremum of the optimization.
-          example: \'max\' or \'min\'
+          examples: \'max\' or \'min\'
         targetValue:
           type: number
           description: Optimization target value.
-          example: 1
+          examples: 1
         strategy:
           type: string
           description: Optimization strategy.
-          example: QuantConnect.Optimizer.Strategies.GridSearchOptimizationStrategy
+          examples: QuantConnect.Optimizer.Strategies.GridSearchOptimizationStrategy
         compileId:
           type: string
-          example: c0edc6-49048b
+          examples: c0edc6-49048b
           description: Optimization compile ID.
         parameters:
           type: array
@@ -3379,11 +3379,11 @@ components:
       properties:
         organizationId:
           type: string
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
           description: Organization ID we would like to get the Object Store files from.
         keys:
           type: array
-          example: "[\"key1\", \"key2\"]"
+          examples: "[\"key1\", \"key2\"]"
           description: Keys to the Object Store files.
           items:
             type: string
@@ -3396,11 +3396,11 @@ components:
       properties:
         organizationId:
           type: string
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
           description: Organization ID we would like to get the Object Store files from.
         jobId:
           type: string
-          example: string
+          examples: string
           description: Job ID for getting a download URL for.
       description: Request to get a download URL for certain Object Store files.
     GetObjectStorePropertiesRequest:
@@ -3411,11 +3411,11 @@ components:
       properties:
         organizationId:
           type: string
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
           description: Organization ID we would like to get the Object Store properties from.
         key:
           type: string
-          example: key1
+          examples: key1
           description: Key to the Object Store.
       description: Request to get Object Store properties of a specific organization and keys.
     GetObjectStoreResponse:
@@ -3468,7 +3468,7 @@ components:
         size:
           type: number
           description: Object Store file size.
-          example: 24
+          examples: 24
         md5:
           type: string
           description: MD5 (hashing algorithm) hash authentication code.
@@ -3574,7 +3574,7 @@ components:
         currencySymbol:
           type: string
           description: The currency symbol of the holding.
-          example: $
+          examples: $
         averagePrice:
           type: number
           description: Average Price of our Holding in the currency the symbol is traded in.
@@ -3787,7 +3787,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id of the library project.
         libraryName:
           type: string
@@ -3805,11 +3805,11 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id for the live instance.
         deployId:
           type: string
-          example: L-sdf86b7045bb83203e79d2aa6150b321
+          examples: L-sdf86b7045bb83203e79d2aa6150b321
           description: Unique live algorithm deployment identifier (similar to a backtest id).
         status:
           type: string
@@ -3903,15 +3903,15 @@ components:
       properties:
         message:
           type: string
-          example: message
+          examples: message
           description: Error message.
         status:
           type: string
-          example: Running
+          examples: Running
           description: Indicates the status of the algorihtm, i.e. 'Running', 'Stopped'.
         deployId:
           type: string
-          example: L-sdf86b7045bb83203e79d2aa6150b321
+          examples: L-sdf86b7045bb83203e79d2aa6150b321
           description: Algorithm deployment ID.
         cloneId:
           type: integer
@@ -3985,7 +3985,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id for the live instance we want to liquidate.
       description: Request to liquidate a live algorithm.
     ListObjectStoreRequest:
@@ -3995,11 +3995,11 @@ components:
       properties:
         organizationId:
           type: string
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
           description: Organization ID we'd like to list the Object Store files from.
         path:
           type: string
-          example: "/folder1"
+          examples: "/folder1"
           description: Optional. Path to the Object Store files.
       description: Request to list Object Store files of a specific organization and path.
     ListObjectStoreResponse:
@@ -4008,7 +4008,7 @@ components:
         path:
           type: string
           description: Path to the files in the Object Store.
-          example: Mia
+          examples: Mia
         objects:
           type: array
           description: List of objects stored.
@@ -4036,7 +4036,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project ID we'd like to get a list of optimizations for.
       description: Project ID we'd like to get a list of optimizations for.
     ListOptimizationResponse:
@@ -4106,7 +4106,7 @@ components:
         status:
           type: string
           description: Status of the chart generation process.
-          example: loading
+          examples: loading
         success:
           type: boolean
           description: Indicate if the API request was successful.
@@ -4177,7 +4177,7 @@ components:
           description: Project the node is being used for.
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project the node is being used for.
         busy:
           type: boolean
@@ -4226,11 +4226,11 @@ components:
       properties:
         organizationId:
           type: string
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
           description: Orgainization ID.
         key:
           type: string
-          example: key1
+          examples: key1
           description: Unique key to access the object in Object Store.
         objectData:
           type: string
@@ -4243,7 +4243,7 @@ components:
         key:
           type: string
           description: Object Store key.
-          example: "Mia/Test"
+          examples: "Mia/Test"
         name:
           type: string
           description: File or folder name.
@@ -4254,14 +4254,14 @@ components:
         mime:
           type: string
           description: MIME type.
-          example: application/json
+          examples: application/json
         folder:
           type: boolean
           description: True if it is a folder, false otherwise.
         size:
           type: number
           description: Object Store file size.
-          example: 13
+          examples: 13
       description: Summary information of the Object Store.
     OptimizationConstraint:
       type: object
@@ -4269,53 +4269,53 @@ components:
         target:
           type: string
           description: Property we want to track
-          example: TotalPerformance.PortfolioStatistics.SharpeRatio
+          examples: TotalPerformance.PortfolioStatistics.SharpeRatio
         operator:
           type: string
           description: The target comparison operation
-          example: greater
+          examples: greater
         targetValue:
           type: number
           description: The value of the property we want to track
-          example: 1
+          examples: 1
     OptimizationParameter:
       type: object
       properties:
         name:
           type: string
           description: Name of optimization parameter.
-          example: rsi_period
+          examples: rsi_period
         min:
           type: number
           description: Minimum value of optimization parameter, applicable for boundary conditions.
-          example: 10
+          examples: 10
         max:
           type: number
           description: Maximum value of optimization parameter, applicable for boundary conditions.
-          example: 20
+          examples: 20
         step:
           type: number
           description: Movement, should be positive
-          example: 1
+          examples: 1
         minStep:
           type: number
           description: Minimal possible movement for current parameter, should be positive. Used by <code>Strategies.EulerSearchOptimizationStrategy</code> to determine when this parameter can no longer be optimized.
-          example: 1
+          examples: 1
     OptimizationTarget:
       type: object
       properties:
         target:
           type: string
           description: Property we want to track
-          example: TotalPerformance.PortfolioStatistics.SharpeRatio
+          examples: TotalPerformance.PortfolioStatistics.SharpeRatio
         extremum:
           type: string
           description: Defines the direction of optimization.
-          example: max or min
+          examples: max or min
         targetValue:
           type: number
           description: The value of the property we want to track
-          example: 1
+          examples: 1
     ProjectNodes:
       type: object
       properties:
@@ -4359,14 +4359,14 @@ components:
       properties:
         optimizationId:
           type: string
-          example: O-401d3d40b5a0e9f8c46c954a303f3ddd
+          examples: O-401d3d40b5a0e9f8c46c954a303f3ddd
           description: Optimization ID.
         snapshotId:
           type: string
           description: Snapshot iD of this optimization.
         projectId:
           type: string
-          example: 23456789
+          examples: 23456789
           description: Project ID of the project the optimization belongs to.
         name:
           type: string
@@ -4382,7 +4382,7 @@ components:
         nodeType:
           type: string
           description: Optimization node type.
-          example: O2-8
+          examples: O2-8
           enum:
           - O2-8
           - O4-12
@@ -4390,7 +4390,7 @@ components:
         parallelNodes:
           type: integer
           description: Number of parallel nodes for optimization.
-          example: 4
+          examples: 4
         criterion:
           type: object
           description: Optimization statistical target.
@@ -4418,7 +4418,7 @@ components:
         strategy:
           type: string
           description: Optimization strategy.
-          example: QuantConnect.Optimizer.Strategies.GridSearchOptimizationStrategy
+          examples: QuantConnect.Optimizer.Strategies.GridSearchOptimizationStrategy
         requested:
           type: string
           description: Optimization requested date and time.
@@ -4773,7 +4773,7 @@ components:
           key:
             type: string
             description: ID of the symbol of the holding.
-            example: AAPL R735QTJ8XC9X
+            examples: AAPL R735QTJ8XC9X
           value:
             type: object
             description: Holding object associated with the symbol ID.
@@ -4784,7 +4784,7 @@ components:
           key:
             type: string
             description: Cash currency.
-            example: USD
+            examples: USD
           value:
             type: object
             description: Cash object associated with the cash currency.
@@ -4803,11 +4803,11 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project id.
         organizationId:
           type: string
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
           description: Orgainization id.
         name:
           type: string
@@ -4899,7 +4899,7 @@ components:
           description: ID of the project file. This can also be null.
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: ID of the project.
         name:
           type: string
@@ -5124,11 +5124,11 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id to which the file belongs.
         name:
           type: string
-          example: file.py
+          examples: file.py
           description: Optional. The name of the file that will be read.
       description: Request to read all files from a project or just one (if the name is provided).
     ReadCompileRequest:
@@ -5139,11 +5139,11 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id we sent for compile.
         compileId:
           type: string
-          example: c0edc6-49048b
+          examples: c0edc6-49048b
           description: Compile Id returned during the creation request.
       description: Request to read a compile packet job.
     ReadLiveLogsRequest:
@@ -5156,10 +5156,10 @@ components:
       properties:
         format:
           description: Format of the log results
-          example: json
+          examples: json
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id of the live running algorithm.
         algorithmId:
           type: string
@@ -5201,7 +5201,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project. If not provided the API will return a details list of all projects.
       description: Request to get details about a specific project or a details list of all projects.
     ReadProjectNodesRequest:
@@ -5211,7 +5211,7 @@ components:
       properties:
         projectId:
           type: string
-          example: 23456789
+          examples: 23456789
           description: Project Id to which the nodes refer.
       description: Request to get details about nodes of a specific organization.
     ReadLiveAlgorithmRequest:
@@ -5221,11 +5221,11 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project to read.
         deployId:
           type: string
-          example: L-sdf86b7045bb83203e79d2aa6150b321
+          examples: L-sdf86b7045bb83203e79d2aa6150b321
           description: Specific instance Id to read.
       description: Request to read out a single algorithm.
     ReadLivePortfolioRequest:
@@ -5235,7 +5235,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project from which to read the live algorithm.
       description: Request to read the portfolio state from a live algorithm.
     ReadLiveOrdersRequest:
@@ -5246,15 +5246,15 @@ components:
       properties:
         start:
           type: integer
-          example: 0
+          examples: 0
           description: Starting index of the orders to be fetched. Required if end > 100.
         end:
           type: integer
-          example: 100
+          examples: 100
           description: Last index of the orders to be fetched. Note that end - start must be less than 100.
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project from which to read the live algorithm.
       description: Request to read orders from a live algorithm.
     ReadLiveInsightsRequest:
@@ -5265,15 +5265,15 @@ components:
       properties:
         start:
           type: integer
-          example: 0
+          examples: 0
           description: Starting index of the insights to be fetched. Required if end > 100.
         end:
           type: integer
-          example: 100
+          examples: 100
           description: Last index of the insights to be fetched. Note that end - start must be less than 100.
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project from which to read the live algorithm.
       description: Request to read insights from a live algorithm.
     ListLiveAlgorithmsRequest:
@@ -5297,11 +5297,11 @@ components:
             - History
         start:
           type: number
-          example: 1717801200
+          examples: 1717801200
           description: Earliest launched time of the algorithms in UNIX timestamp.
         end:
           type: number
-          example: 171851200
+          examples: 171851200
           description: Latest launched time of the algorithms in UNIX timestamp.
       description: Request for a list of live running algorithms.
     ReadBacktestRequest:
@@ -5312,15 +5312,15 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project from which to read one or multiple backtests.
         backtestId:
           type: string
-          example: 26c7bb06b8487cff1c7b3c44652b30f1
+          examples: 26c7bb06b8487cff1c7b3c44652b30f1
           description: When provided, specific backtest Id to read.
         chart:
           type: string
-          example: "Strategy Equity"
+          examples: "Strategy Equity"
           description: Optional. If provided, the API will return the backtests charts.
       description: Request to read a single backtest from a project.
     ListBacktestRequest:
@@ -5330,11 +5330,11 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project from which to read one or multiple backtests.
         includeStatistics:
           type: boolean
-          example: true
+          examples: true
           description: If true, the backtests summaries from the response will contain the statistics with their corresponding values.
       description: Request to list the backtests from a project.
     QuantConnectSettings:
@@ -5393,27 +5393,27 @@ components:
         projectId:
           type: integer
           description: Project ID of the request.
-          example: 12345678
+          examples: 12345678
         backtestId:
           type: string
           description: Associated Backtest ID for this chart request.
-          example: 2a748c241eb93b0b57b4747b3dacc80e
+          examples: 2a748c241eb93b0b57b4747b3dacc80e
         name:
           type: string
           description: The requested chart name.
-          example: "Strategy Equity"
+          examples: "Strategy Equity"
         count:
           type: integer
           description: The number of data points to request.
-          example: 100
+          examples: 100
         start:
           type: integer
           description: Optional. If provided, the Utc start seconds timestamp of the request.
-          example: 1717801200
+          examples: 1717801200
         end:
           type: integer
           description: Optional. If provided, the Utc end seconds timestamp of the request.
-          example: 1743462000
+          examples: 1743462000
       description: Request body to obtain a chart from a backtest.
     ReadBacktestOrdersRequest:
       required:
@@ -5425,19 +5425,19 @@ components:
       properties:
         start:
           type: integer
-          example: 0
+          examples: 0
           description: Starting index of the orders to be fetched. Required if end > 100.
         end:
           type: integer
-          example: 100
+          examples: 100
           description: Last index of the orders to be fetched. Note that end - start must be less than 100.
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project from which to read the backtest.
         backtestId:
           type: string
-          example: 26c7bb06b8487cff1c7b3c44652b30f1
+          examples: 26c7bb06b8487cff1c7b3c44652b30f1
           description: Id of the backtest from which to read the orders.
       description: Request to read orders from a backtest.
     ReadBacktestInsightsRequest:
@@ -5450,19 +5450,19 @@ components:
       properties:
         start:
           type: integer
-          example: 0
+          examples: 0
           description: Starting index of the insights to be fetched. Required if end > 100.
         end:
           type: integer
-          example: 100
+          examples: 100
           description: Last index of the insights to be fetched. Note that end - start must be less than 100.
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Id of the project from which to read the backtest.
         backtestId:
           type: string
-          example: 26c7bb06b8487cff1c7b3c44652b30f1
+          examples: 26c7bb06b8487cff1c7b3c44652b30f1
           description: Id of the backtest from which to read the insights.
       description: Request to read insights from a backtest.
     ReadLiveChartRequest:
@@ -5476,24 +5476,24 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project ID of the request.
         name:
           type: string
           description: The requested chart name.
-          example: "Strategy Equity"
+          examples: "Strategy Equity"
         count:
           type: integer
           description: The number of data points to request.
-          example: 100
+          examples: 100
         start:
           type: integer
           description: The Utc start seconds timestamp of the request.
-          example: 1717801200  
+          examples: 1717801200  
         end:
           type: integer
           description: The Utc end seconds timestamp of the request.
-          example: 1743462000
+          examples: 1743462000
       description: Request to body to obtain a chart from a live algorithm.
     ReadChartResponse:
       type: object
@@ -5518,7 +5518,7 @@ components:
       properties:
         optimizationId:
           type: string
-          example: O-401d3d40b5a0e9f8c46c954a303f3ddd
+          examples: O-401d3d40b5a0e9f8c46c954a303f3ddd
           description: Optimization ID for the optimization we want to read.
       description: Request to read a optimization from a project.
     ReadOptimizationResponse:
@@ -5588,35 +5588,35 @@ components:
         Equity:
           type: string
           description: Total portfolio value.
-          example: '$100.00'
+          examples: '$100.00'
         Fees:
           type: string
           description: Transaction fee.
-          example: '-$100.00'
+          examples: '-$100.00'
         Holdings:
           type: string
           description: Equity value of security holdings.
-          example: '$100.00'
+          examples: '$100.00'
         Net Profit:
           type: string
           description: Net profit.
-          example: '$100.00'
+          examples: '$100.00'
         Probabilistic Sharpe Ratio:
           type: string
           description: Probabilistic Sharpe Ratio.
-          example: '50.00%'
+          examples: '50.00%'
         Return:
           type: string
           description: Return.
-          example: '50.00%'
+          examples: '50.00%'
         Unrealized:
           type: string
           description: Unrealized profit/loss.
-          example: '$100.00'
+          examples: '$100.00'
         Volume:
           type: string
           description: Total transaction volume.
-          example: '$100.00'
+          examples: '$100.00'
     ChartResolution:
       type: string
       description: Storage format of the charting data
@@ -5702,7 +5702,7 @@ components:
       properties:
         organizationId:
           type: string
-          example: 5cad178b20a1d52567b534553413b691
+          examples: 5cad178b20a1d52567b534553413b691
           description: Organization ID we'd like to upload the file to.
         key:
           type: string
@@ -5797,7 +5797,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id for the live instance we want to stop.
       description: Request to stop a live algorithm.
     Symbol:
@@ -6127,11 +6127,11 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id for the backtest we want to update.
         backtestId:
           type: string
-          example: 26c7bb06b8487cff1c7b3c44652b30f1
+          examples: 26c7bb06b8487cff1c7b3c44652b30f1
           description: Backtest Id we want to update.
         name:
           type: string
@@ -6149,15 +6149,15 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id to which the file belongs.
         oldFileName:
           type: string
-          example: file1.py
+          examples: file1.py
           description: The current name of the file.
         newName:
           type: string
-          example: file2.py
+          examples: file2.py
           description: The new name for the file.
       description: Request to update the name of a file.
     UpdateFileContentsRequest:
@@ -6169,15 +6169,15 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id to which the file belongs.
         name:
           type: string
-          example: main.py
+          examples: main.py
           description: The name of the file that should be updated.
         content:
           type: string
-          example: |
+          examples: |
             class CustomClass:
                 def __init__(self):
                     pass
@@ -6191,11 +6191,11 @@ components:
       properties:
         optimizationId:
           type: string
-          example: O-401d3d40b5a0e9f8c46c954a303f3ddd
+          examples: O-401d3d40b5a0e9f8c46c954a303f3ddd
           description: Optimization ID we want to update.
         name:
           type: string
-          example: "New Optimization Name"
+          examples: "New Optimization Name"
           description: Name we'd like to assign to the optimization.
       description: Updates the name of an optimization.
     UpdateProjectRequest:
@@ -6206,15 +6206,15 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id to which the file belongs.
         name:
           type: string
-          example: "New Project Name"
+          examples: "New Project Name"
           description: The new name for the project.
         description:
           type: string
-          example: "New Project Description"
+          examples: "New Project Description"
           description: The new description for the project.
       description: Update a project name, or description.
     UpdateProjectNodesRequest:
@@ -6224,7 +6224,7 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id to which the nodes refer.
         nodes:
           type: array
@@ -6241,10 +6241,10 @@ components:
       properties:
         projectId:
           type: integer
-          example: 23456789
+          examples: 23456789
           description: Project Id for the backtest we want to update.
         backtestId:
-          example: 26c7bb06b8487cff1c7b3c44652b30f1
+          examples: 26c7bb06b8487cff1c7b3c44652b30f1
           type: Backtest Id we want to update.
         tags:
           type: array


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Rename example to examples in YAML

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The mcp server tests are throwing warnings because Pydantic Field objects don't support `example` (deprecated), but they support `examples`.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- x ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
