### PR TITLE
Fix function name case to match implementation above and PEP8

### DIFF
--- a/04 Research Environment/01 Key Concepts/02 Research Engine/05 Import Project Code.html
+++ b/04 Research Environment/01 Key Concepts/02 Research Engine/05 Import Project Code.html
@@ -14,10 +14,10 @@ One of the drawbacks of using the Research Environment you may encounter is the 
 
 <div  class='python'>
 <div class="section-example-container">
-<pre class="python">from helpers import Add
+<pre class="python">from helpers import add
 
 # reuse method from helpers.py
-Add(3, 4)</pre>
+add(3, 4)</pre>
 </div></div>
 
 <p class='python'>If you adjust the file that you import, restart the Research Environment session to import the latest version of the file. To restart the Research Environment, <a href='/docs/v2/research-environment/key-concepts/getting-started#05-Stop-Nodes'>stop the research node</a> and then <a href='/docs/v2/research-environment/key-concepts/getting-started#03-Open-Notebooks'>open the notebook</a> again.</p>


### PR DESCRIPTION
The documentation example incorrectly referenced the 'add' function with uppercase 'A' ('Add') in both the import statement and function call. This conflicts with:
1. The actual function definition in helpers.py (lowercase 'add')
2. PEP8 naming conventions recommending lowercase for function names