### PR TITLE
Fix date comparison logic in documentation string

### DIFF
--- a/04 Research Environment/02 Initialization/02 Set Dates.html
+++ b/04 Research Environment/02 Initialization/02 Set Dates.html
@@ -5,7 +5,7 @@
     <pre class="python">qb.set_start_date(2022, 1, 1)</pre>
 </div>
 
-<p>The end date of your <code>QuantBook</code> should be greater than the end date. By default, the start date is the current day. To change the end date, call the <code class="csharp">SetEndDate</code><code class="python">set_end_date</code> method.</p>
+<p>The end date of your <code>QuantBook</code> should be greater than the start date. By default, the start date is the current day. To change the end date, call the <code class="csharp">SetEndDate</code><code class="python">set_end_date</code> method.</p>
 
 <div class="section-example-container">
     <pre class="csharp">qb.set_end_date(2022, 8, 15);</pre>


### PR DESCRIPTION
Corrected erroneous comparison instruction where end date was incorrectly compared to itself. The original statement:

"The end date of your QuantBook should be greater than the end date"

contained a logical error since:
1. Comparing end date to itself is always false
2. The intended validation requires comparing end date to start date

Changes:
- Replaced second "end date" reference with "start date"
- Result: "The end date should be greater than the start date"
