### PR TITLE
Enable support for multiple MCP agents

### DIFF
--- a/09 AI Assistance/03 MCP Server/03 Getting Started.html
+++ b/09 AI Assistance/03 MCP Server/03 Getting Started.html
@@ -20,6 +20,7 @@
         "--rm",
         "-e", "QUANTCONNECT_USER_ID",
         "-e", "QUANTCONNECT_API_TOKEN",
+        "-e", "AGENT_NAME",
         "--platform", "&lt;your_platform&gt;",
         "--name",
         "quantconnect-mcp-server",
@@ -27,7 +28,8 @@
       ],
       "env": {
         "QUANTCONNECT_USER_ID": "&lt;your_user_id&gt;",
-        "QUANTCONNECT_API_TOKEN": "&lt;your_api_token&gt;"
+        "QUANTCONNECT_API_TOKEN": "&lt;your_api_token&gt;",
+        "AGENT_NAME": "MCP Server"
       }
     }
   }
@@ -36,6 +38,7 @@
 
     <p>To get your user Id and API token, see <a href='https://www.quantconnect.com/docs/v2/cloud-platform/community/profile#09-Request-API-Token'>Request API Token</a>.</p>
     <p>Our MCP server is multi-platform capable. The options are <code>linux/amd64</code> for Intel/AMD chips and <code>linux/arm64</code> for ARM chips (for example, Apple's M-series chips).</p>
+    <p>If you simultaneously run multiple agents, set a unique value for the <code>AGENT_NAME</code> environment variable for each agent to keep record of the request source.</p>
 
   <li>Restart Claude Desktop.</li>
     <p>Claude Desktop automatically pulls our MCP server from Docker Hub and connects to it.</p>

--- a/QuantConnect-Platform-2.0.0.yaml
+++ b/QuantConnect-Platform-2.0.0.yaml
@@ -3652,6 +3652,11 @@ components:
           # C# research file
           - "{\"cells\": [{\"cell_type\": \"code\", \"execution_count\": 1, \"metadata\": {}, \"outputs\": [], \"source\": [\"// We need to load assemblies at the start in their own cell\\n\", \"#load \\\"../Initialize.csx\\\"\"]}], \"metadata\": {\"kernelspec\": {\"display_name\": \".NET (C#)\", \"language\": \"C#\", \"name\": \"csharp\"}, \"language_info\": {\"file_extension\": \".cs\", \"mimetype\": \"text/x-csharp\", \"name\": \"C#\", \"pygments_lexer\": \"csharp\", \"version\": \"9.0\"}}, \"nbformat\": 4, \"nbformat_minor\": 2}"
           description: The content of the new file.
+        codeSourceId:
+          type: string
+          examples:
+          - MCP Server
+          description: Name of the environment that's creating the request.
       description: Request to add a file to a project.
     DeleteFileRequest:
       type: object
@@ -3670,6 +3675,11 @@ components:
           - file.py
           - File.cs
           description: The name of the file to delete.
+        codeSourceId:
+          type: string
+          examples:
+          - MCP Server
+          description: Name of the environment that's creating the request.
       description: Request to delete a file in a project.
     DeleteProjectRequest:
       type: object
@@ -5646,6 +5656,11 @@ components:
           - file.py
           - File.cs
           description: The name of the file to read.
+        codeSourceId:
+          type: string
+          examples:
+          - MCP Server
+          description: Name of the environment that's creating the request.
       description: Request to read all files from a project or just one (if the name is provided).
     ReadCompileRequest:
       type: object
@@ -6530,6 +6545,11 @@ components:
           examples: 
           - file2.py
           description: The new name for the file.
+        codeSourceId:
+          type: string
+          examples:
+          - MCP Server
+          description: Name of the environment that's creating the request.
       description: Request to update the name of a file.
     UpdateFileContentsRequest:
       type: object
@@ -6567,6 +6587,11 @@ components:
                 }
             }
           description: The new contents of the file.
+        codeSourceId:
+          type: string
+          examples:
+          - MCP Server
+          description: Name of the environment that's creating the request.
       description: Request to update the contents of a file.
     UpdateOptimizationRequest:
       type: object


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Add AGENT_NAME environment variable to MCP Server Getting Started guide
- Update YAML to have a `codeSourceId` property for /files requests.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/QuantConnect/mcp-server/issues/9

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Enable support for multiple MCP agents

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
