### PR TITLE
Add vBase documentation files for signal exports and integration

### DIFF
--- a/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/01 Introduction.html
+++ b/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/01 Introduction.html
@@ -1,0 +1,13 @@
+<p>
+    <a href='https://qnt.co/vbase' rel='nofollow' target='_blank'>vBase</a> enables you to create a globally credible,
+    independently verifiable audit trail for trading track records, models and signals.
+    This ensures anyone viewing your results can confirm that your results are point-in-time,
+    complete, free from cherry-picking and fully out-of-sample.
+</p>
+<p>
+    QuantConnect users can use validityBase to publish live, verifiable,
+    indices of their trading strategies and signals - increasing their credibility with allocators,
+    clients and potential employers, and significantly increasing their commercial value.
+    Integration is simple. With a single function call from your QuantConnect code,
+    you can automatically build an immutable blockchain-backed audit trail for your signals and models.
+</p>

--- a/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/01 Introduction.html
+++ b/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/01 Introduction.html
@@ -1,5 +1,5 @@
 <p>
-    <a href='https://qnt.co/vbase' rel='nofollow' target='_blank'>vBase</a> enables you to create a globally credible,
+    <a href='https://qnt.co/vbase' rel='nofollow' target='_blank'>validityBase</a> enables you to create a globally credible,
     independently verifiable audit trail for trading track records, models and signals.
     This ensures anyone viewing your results can confirm that your results are point-in-time,
     complete, free from cherry-picking and fully out-of-sample.

--- a/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/02 Add Providers.html
+++ b/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/02 Add Providers.html
@@ -1,0 +1,46 @@
+<p>To export signals to vBase from your algorithm, during <a href="/docs/v2/writing-algorithms/initialization">initialization</a>, add a vBase signal export provider.</p>
+
+<div class="section-example-container">
+<pre class="csharp">SignalExport.AddSignalExportProvider(new VBaseSignalExport(apiKey, collectionName, storeStampedFile = true, idempotent = false));
+</pre>
+<pre class="python">self.signal_export.add_signal_export_provider(VBaseSignalExport(api_key, collection_name, store_stamped_file=True, idempotent=False))
+</pre>
+</div>
+
+<p>The <code>VBaseSignalExport</code> constructor accepts the following arguments:</p>
+
+
+<table class='qc-table table vertical-table'>
+    <tbody>
+        <tr>
+            <td>
+                <h4>Argument: <span><code class="csharp">apiKey</code><code class="python">api_key</code></span></h4>
+                <p class='property-description'>Your vBase API key. You can find it in your profile <a href="https://app.vbase.com/profile#account_settings" rel="nofollow" target="_blank">Account Settings</a> tab.</p>
+                <p>Data Type: <span><code class="csharp">string</code><code class="python">str</code></span></p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <h4>Argument: <span><code class="csharp">collectionName</code><code class="python">collection_name</code></span></h4>
+                <p class='property-description'>The name of the vBase <a href="https://docs.vbase.com/web-tools/how-to-use-vbase-stamper#why-use-collections" rel="nofollow" target="_blank">collection</a> to which the signals will be sent. You can create and manage collections in the vBase app <a href="https://app.vbase.com/profile#collections" rel="nofollow" target="_blank">Collections</a> tab. Think of a collection like a strategy or dataset name.</p>
+                <p>Data Type: <span><code class="csharp">string</code><code class="python">str</code></span></p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <h4>Argument: <span><code class="csharp">storeStampedFile</code><code class="python">store_stamped_file</code></span></h4>
+                <p class='property-description'>Whether to store a stamped copy of the signal in vBase. <b>Important</b> if this is marked "no", then you will be responsible for maintaining an exact copy of your stamped data. Losing or accidentally modifying stamped outputs will prevent your work from being verifiable.</p>
+                <p>Data Type: <span><code>bool</code></span><span class='pipe-separator'>  |  </span> Default Value: <span><code class='python'>True</code><code class='csharp'>true</code></span></p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <h4>Argument: <span><code class="csharp">idempotent</code><code class="python">idempotent</code></span></h4>
+                <p class='property-description'>Whether to make the signal export idempotent. If true, sending the same signal multiple times will only create one record in vBase.</p>
+                <p>Data Type: <span><code>bool</code></span><span class='pipe-separator'>  |  </span> Default Value: <span><code class='python'>False</code><code class='csharp'>false</code></span></p>
+            </td>
+        </tr>
+</tbody>
+</table>
+
+<p>You can add multiple signal export providers to a single algorithm.</p>

--- a/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/03 Asset Classes.html
+++ b/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/03 Asset Classes.html
@@ -1,0 +1,1 @@
+<p>Our vBase integration supports all asset classes.</p>

--- a/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/04 Send Portfolio Targets.php
+++ b/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/04 Send Portfolio Targets.php
@@ -1,0 +1,17 @@
+<p>
+    To send targets, pass a list of <code>PortfolioTarget</code> objects to the 
+    <code class="csharp">SetTargetPortfolio</code><code class="python">set_target_portfolio</code> method. 
+    The method returns a boolean value indicating whether the targets were successfully sent to vBase.
+</p>
+
+<p>
+    <strong>What gets stamped?</strong> The provider builds a <code>sym,wt</code> (symbol-weight) CSV and, under the hood, 
+    uses <code>PortfolioTarget.Percent</code> to convert your absolute target quantities into portfolio weights. 
+    This ensures the stamp reflects the weighted sizing of your positions at the time of export.
+    Default behavior can be customized by overriding the <code>BuildCsv</code> method of the <code>VBaseSignalExport</code> class.
+</p>
+
+<div class="section-example-container">
+<pre class="csharp">var success = SignalExport.SetTargetPortfolio(targets);</pre>
+<pre class="python">success = self.signal_export.set_target_portfolio(targets)</pre>
+</div>

--- a/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/99 Examples.html
+++ b/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/99 Examples.html
@@ -1,0 +1,9 @@
+<div class="example-fieldset"> 
+    <div class="example-legend">Demonstration Algorithms</div>
+    <a class="python example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/VBaseSignalExportDemonstrationAlgorithm.py" target="_BLANK">
+        VBaseSignalExportDemonstrationAlgorithm.py <span class="badge-python pull-right">Python</span>
+    </a>
+    <a class="csharp example-algorithm-link" href="https://github.com/QuantConnect/Lean/blob/master/Algorithm.CSharp/VBaseSignalExportDemonstrationAlgorithm.cs" target="_BLANK">
+        VBaseSignalExportDemonstrationAlgorithm.cs <span class="badge-csharp pull-right">C#</span>
+    </a>
+</div>

--- a/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/metadata.json
+++ b/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/metadata.json
@@ -1,0 +1,11 @@
+{
+    "type": "metadata",
+    "values": {
+        "description": "With our vBase integration, you can creates a globally verifiable record of when data was created, by whom, and how it has changed.",
+        "keywords": "vBase, trading signals, third-party services, live trading, blockchain",
+        "og:description": "With our vBase integration, you can creates a globally verifiable record of when data was created, by whom, and how it has changed.",
+        "og:title": "vBase - Documentation QuantConnect.com",
+        "og:type": "website",
+        "og:site_name": "vBase - QuantConnect.com"
+    }
+}


### PR DESCRIPTION
Added detailed documentation describing the VBaseSignalExport class

#### Description
The VBaseSignalExport class allows you to export signals from an algorithm to vBase.
#### Related Issue
None

#### Motivation and Context
This addition aims to make it easier for users to get started with the VBaseSignalExport class by providing clear, detailed documentation.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

