### PR TITLE
Fix symbol name for E-mini S&P 500 Futures

### DIFF
--- a/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/07 Futures Universes/50 Future Universe Selection.php
+++ b/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/07 Futures Universes/50 Future Universe Selection.php
@@ -21,7 +21,7 @@ self.add_universe_selection(
     FutureUniverseSelectionModel(
         # Refresh the universe daily.
         timedelta(1), 
-        lambda _: [Symbol.create(Futures.Indices.SP500E_MINI, SecurityType.FUTURE, Market.CME)]
+        lambda _: [Symbol.create(Futures.Indices.SP_500_E_MINI, SecurityType.FUTURE, Market.CME)]
     )
 )</pre>
 </div>
@@ -89,7 +89,7 @@ def initialize(self) -&gt; None:
 def select_future_chain_symbols(self, utc_time: datetime) -&gt; List[Symbol]:
     # Add E-mini S&P 500 and Gold Futures to the universe.
     return [ 
-        Symbol.create(Futures.Indices.SP500E_MINI, SecurityType.FUTURE, Market.CME),
+        Symbol.create(Futures.Indices.SP_500_E_MINI, SecurityType.FUTURE, Market.CME),
         Symbol.create(Futures.Metals.GOLD, SecurityType.FUTURE, Market.COMEX)
     ]</pre>
 </div>
@@ -142,7 +142,7 @@ class FrontMonthFutureUniverseSelectionModel(FutureUniverseSelectionModel):
     def select_future_chain_symbols(self, utc_time: datetime) -> List[Symbol]:
         # Add E-mini S&P 500 and Gold Futures to the universe.
         return [ 
-            Symbol.create(Futures.Indices.SP500E_MINI, SecurityType.FUTURE, Market.CME),
+            Symbol.create(Futures.Indices.SP_500_E_MINI, SecurityType.FUTURE, Market.CME),
             Symbol.create(Futures.Metals.GOLD, SecurityType.FUTURE, Market.COMEX) 
         ]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix incorrect futures constant in documentation: `Futures.Indices.SP500E_MINI` → `Futures.Indices.SP_500_E_MINI`

#### Description
<!--- Describe your changes in detail -->
Updated documentation examples to use the correct attribute name `SP_500_E_MINI` instead of the incorrect `SP500E_MINI` for E-mini S&P 500 futures contracts. The incorrect naming convention was causing runtime errors across multiple documentation code blocks.
- `Futures.Indices.SP500E_MINI` → `Futures.Indices.SP_500_E_MINI`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes [#9078](https://github.com/QuantConnect/Lean/issues/9078)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This correction ensures that users referencing the documentation can correctly use the futures constant without encountering attribute or reference errors in their algorithms.  
It improves documentation accuracy and reduces confusion for developers using the **Futures Indices** universe.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
