### PR TITLE
fixed Futures SP_500_E_MINI

### DIFF
--- a/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/02 Universe Settings/08 Contract Depth Offset.php
+++ b/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/02 Universe Settings/08 Contract Depth Offset.php
@@ -16,7 +16,7 @@ self.universe_settings.contract_depth_offset = 1
 self.add_universe_selection(
     FutureUniverseSelectionModel(
         timedelta(1), 
-        lambda _: [Symbol.create(Futures.Indices.SP500E_MINI, SecurityType.FUTURE, Market.CME)]
+        lambda _: [Symbol.create(Futures.Indices.SP_500_E_MINI, SecurityType.FUTURE, Market.CME)]
     )
 )</pre>
 </div>

--- a/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/07 Futures Universes/50 Future Universe Selection.php
+++ b/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/07 Futures Universes/50 Future Universe Selection.php
@@ -21,7 +21,7 @@ self.add_universe_selection(
     FutureUniverseSelectionModel(
         # Refresh the universe daily.
         timedelta(1), 
-        lambda _: [Symbol.create(Futures.Indices.SP500E_MINI, SecurityType.FUTURE, Market.CME)]
+        lambda _: [Symbol.create(Futures.Indices.SP_500_E_MINI, SecurityType.FUTURE, Market.CME)]
     )
 )</pre>
 </div>
@@ -89,7 +89,7 @@ def initialize(self) -&gt; None:
 def select_future_chain_symbols(self, utc_time: datetime) -&gt; List[Symbol]:
     # Add E-mini S&P 500 and Gold Futures to the universe.
     return [ 
-        Symbol.create(Futures.Indices.SP500E_MINI, SecurityType.FUTURE, Market.CME),
+        Symbol.create(Futures.Indices.SP_500_E_MINI, SecurityType.FUTURE, Market.CME),
         Symbol.create(Futures.Metals.GOLD, SecurityType.FUTURE, Market.COMEX)
     ]</pre>
 </div>
@@ -142,7 +142,7 @@ class FrontMonthFutureUniverseSelectionModel(FutureUniverseSelectionModel):
     def select_future_chain_symbols(self, utc_time: datetime) -> List[Symbol]:
         # Add E-mini S&P 500 and Gold Futures to the universe.
         return [ 
-            Symbol.create(Futures.Indices.SP500E_MINI, SecurityType.FUTURE, Market.CME),
+            Symbol.create(Futures.Indices.SP_500_E_MINI, SecurityType.FUTURE, Market.CME),
             Symbol.create(Futures.Metals.GOLD, SecurityType.FUTURE, Market.COMEX) 
         ]
 

--- a/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/07 Futures Universes/51 Open Interest Future Universe Selection.php
+++ b/03 Writing Algorithms/34 Algorithm Framework/02 Universe Selection/07 Futures Universes/51 Open Interest Future Universe Selection.php
@@ -18,7 +18,7 @@ self.universe_settings.asynchronous = True
 self.add_universe_selection(
     OpenInterestFutureUniverseSelectionModel(
         self, 
-        lambda utc_time: [Symbol.create(Futures.Indices.SP500E_MINI, SecurityType.FUTURE, Market.CME)]
+        lambda utc_time: [Symbol.create(Futures.Indices.SP_500_E_MINI, SecurityType.FUTURE, Market.CME)]
     )
 )</pre>
 </div>
@@ -110,7 +110,7 @@ def initialize(self) -&gt; None:
 # Define the selection function, which returns Symbol objects.
 def select_future_chain_symbols(self, utc_time: datetime) -&gt; List[Symbol]:
     return [ 
-        Symbol.create(Futures.Indices.SP500E_MINI, SecurityType.FUTURE, Market.CME),
+        Symbol.create(Futures.Indices.SP_500_E_MINI, SecurityType.FUTURE, Market.CME),
         Symbol.create(Futures.Metals.GOLD, SecurityType.FUTURE, Market.COMEX)
     ]</pre>
 </div>

--- a/05 Lean CLI/05 Datasets/05 QuantConnect/01 Download By Ticker/02 Costs/07 Futures.php
+++ b/05 Lean CLI/05 Datasets/05 QuantConnect/01 Download By Ticker/02 Costs/07 Futures.php
@@ -76,7 +76,7 @@
         self.set_start_date(2020, 1, 1)
         self.set_end_date(2021, 1, 1)
         future = self.add_future(
-            Futures.Indices.SP500E_MINI,
+            Futures.Indices.SP_500_E_MINI,
             data_normalization_mode=DataNormalizationMode.BACKWARDS_RATIO,
             data_mapping_mode=DataMappingMode.OPEN_INTEREST,
             contract_depth_offset=0

--- a/python-code-manage/exceptions.py
+++ b/python-code-manage/exceptions.py
@@ -72,7 +72,7 @@ SWAPS = {
     "CharlesSchwab": "CharlesSchwab",
     "VWAP": "Vwap",
     "OneWeekBasedOnUSD": "OneWeekBasedOnUsd",
-    "SP500EMini": "SP500E_MINI",
+    "SP500EMini": "SP_500_E_MINI",
     "CrudeOilWTI": "CRUDE_OIL_WTI",
     "Gold": "GOLD",
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix incorrect futures constant in documentation: `Futures.Indices.SP500E_MINI` → `Futures.Indices.SP_500_E_MINI`

#### Description
<!--- Describe your changes in detail -->
Updated documentation examples to use the correct attribute name `SP_500_E_MINI` instead of the incorrect `SP500E_MINI` for E-mini S&P 500 futures contracts. The incorrect naming convention was causing runtime errors across multiple documentation code blocks.
- `Futures.Indices.SP500E_MINI` → `Futures.Indices.SP_500_E_MINI`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This correction ensures that users referencing the documentation can correctly use the futures constant without encountering attribute or reference errors in their algorithms.  
It improves documentation accuracy and reduces confusion for developers using the **Futures Indices** universe.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
