### PR TITLE
fixed runtime error liquidateExistingHoldings for Python

### DIFF
--- a/03 Writing Algorithms/12 Universes/01 Key Concepts/13 Historical Asset Prices.html
+++ b/03 Writing Algorithms/12 Universes/01 Key Concepts/13 Historical Asset Prices.html
@@ -199,7 +199,7 @@ public class MaintainHistoricalDailyUniversePriceDataAlgorithm : QCAlgorithm
         signal_by_symbol /= signal_by_symbol.sum()
 
         # Rebalance the portfolio based on the signals.
-        self.set_holdings([PortfolioTarget(symbol, signal) for symbol, signal in signal_by_symbol.items()], liquidateExistingHoldings=True)</pre>
+        self.set_holdings([PortfolioTarget(symbol, signal) for symbol, signal in signal_by_symbol.items()], liquidate_existing_holdings=True)</pre>
 </div>
 
 <script type="text/x-mathjax-config">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix incorrect Python parameter in documentation: ` liquidateExistingHoldings` -> `liquidate_existing_holdings`

#### Description
<!--- Describe your changes in detail -->
Updated documentation examples to use the correct parameter `liquidate_existing_holdings` for self.set_holdings(). The incorrect naming convention was causing runtime errors across multiple documentation code blocks.
- ` liquidateExistingHoldings` -> `liquidate_existing_holdings`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This correction ensures that users referencing the documentation can correctly use the futures constant without encountering attribute or reference errors in their algorithms.  
It improves documentation accuracy and reduces confusion for developers using the **Futures Indices** universe.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
