### PR TITLE
Refactor trading logic for BTC and ETH holdings

### DIFF
--- a/Resources/trading-and-orders/crypto-holdings-example.html
+++ b/Resources/trading-and-orders/crypto-holdings-example.html
@@ -1,7 +1,7 @@
 <p>The following examples demonstrate some common practices for crypto holdings.</p>
 
 <h4>Example 1: ETH-BTC Proxy Trading</h4>
-<p>The following algorithm trades trend-following of the ETHBTC crypto pair using a 20-day EMA indicator. To reduce friction (e.g. slippage), we trade the more liquid and popular BTCUSDT and ETHUSDT pair instead. For example, if ETHBTC is above EMA (uptrend), we buy ETHUSDT and sell BTCUSDT with the same size in USDT.</p>
+<p>The following algorithm trades trend-following of the ETHBTC crypto pair using a 20-day EMA indicator. To reduce friction (e.g. slippage), we trade the more liquid and popular BTCUSDT and ETHUSDT pair instead. For example, if ETHBTC is above EMA (uptrend), we sell all BTCUSDT holdings and buy ETHUSDT with the same USDT value, going flat on BTC while holding ETH.</p>
 <div class="section-example-container testable">
     <pre class="csharp">public class CryptoHoldingsAlgorithm : QCAlgorithm
 {
@@ -13,8 +13,6 @@
         SetStartDate(2024, 9, 1);
         SetEndDate(2024, 12, 31);
         SetAccountCurrency("USDT", 1000000m);
-        // Seed the last price to set the initial holding price of the cryptos.
-        SetSecurityInitializer(new BrokerageModelSecurityInitializer(BrokerageModel, new FuncSecuritySeeder(GetLastKnownPrices)));
 
         // We would like to trade the EMA cross between 2 popular cryptos: BTC & ETH,
         // so request ETHBTC data to find trading opportunities.
@@ -24,9 +22,12 @@
         var ethusdt = AddCrypto("ETHUSDT", Resolution.Daily, market: Market.Coinbase);
         _btcusdt = btcusdt.Symbol;
         _ethusdt = ethusdt.Symbol;
+        
         // Simulate an account with various crypto cash through holdings.
         btcusdt.Holdings.SetHoldings(btcusdt.Price, 5m);
+        btcusdt.BaseCurrency.AddAmount(5m);
         ethusdt.Holdings.SetHoldings(ethusdt.Price, 22.5m);
+        ethusdt.BaseCurrency.AddAmount(22.5m);
 
         // Add automatic updating of the EMA indicator for trend trade signal emission.
         _ema = EMA(_ethbtc, 20, Resolution.Daily);
@@ -36,37 +37,38 @@
 
     public override void OnData(Slice slice)
     {
-        if (slice.Bars.TryGetValue(_ethbtc, out var bar) &amp;&amp; _ema.IsReady &amp;&amp;
-        slice.Bars.TryGetValue(_btcusdt, out var btc) &amp;&amp; slice.Bars.TryGetValue(_ethusdt, out var eth))
+        if (slice.Bars.TryGetValue(_ethbtc, out var bar) && _ema.IsReady &&
+            slice.Bars.TryGetValue(_btcusdt, out var btc) && slice.Bars.TryGetValue(_ethusdt, out var eth))
         {
+            var ema = _ema.Current.Value;
+            var btcHoldings = Portfolio.CashBook["BTC"].Amount;
+            var ethHoldings = Portfolio.CashBook["ETH"].Amount;
+            
             // ETHBTC's current price is higher than EMA, suggesting an uptrend.
-            if (bar.Close &gt; _ema &amp;&amp; !Portfolio[_btcusdt].IsShort)
+            if (bar.Close > ema && !Portfolio[_btcusdt].IsShort)
             {
-                // Calculate the order size needed to have equal BTC-ETH value exposure.
-                CalculateOrderSize(btc.Close, eth.Close, out var btcSize, out var ethSize);
-                // To follow the up trend of ETHBTC, sell BTCUSDT and buy ETHUSDT.
-                MarketOrder(_btcusdt, -btcSize);
-                MarketOrder(_ethusdt, ethSize);
+                // To follow the up trend of ETHBTC, sell ALL BTCUSDT and buy ETHUSDT with the same value.
+                if (btcHoldings > 0)
+                {
+                    var btcValue = btcHoldings * btc.Close;
+                    MarketOrder(_btcusdt, -btcHoldings);
+                    var ethSize = btcValue / eth.Close;
+                    MarketOrder(_ethusdt, ethSize);
+                }
             }
             // ETHBTC's current price is below the EMA, suggesting a downtrend.
-            else if (bar.Close &lt; _ema &amp;&amp; !Portfolio[_btcusdt].IsLong)
+            else if (bar.Close < ema && !Portfolio[_btcusdt].IsLong)
             {
-                // Calculate the order size needed to have equal BTC-ETH value exposure.
-                CalculateOrderSize(btc.Close, eth.Close, out var btcSize, out var ethSize);
-                // To follow the down trend of ETHBTC, buy BTCUSDT and sell ETHUSDT.
-                MarketOrder(_ethusdt, -ethSize);
-                MarketOrder(_btcusdt, btcSize);
+                // To follow the downtrend of ETHBTC, sell ALL ETHUSDT and buy BTCUSDT with the same value.
+                if (ethHoldings > 0)
+                {
+                    var ethValue = ethHoldings * eth.Close;
+                    MarketOrder(_ethusdt, -ethHoldings);
+                    var btcSize = ethValue / btc.Close;
+                    MarketOrder(_btcusdt, btcSize);
+                }
             }
         }
-    }
-
-    private void CalculateOrderSize(decimal btcPrice, decimal ethPrice, out decimal btcSize, out decimal ethSize)
-    {
-        // Invest 10% of the portfolio in the 2-leg trade, which will be 5% per each leg.
-        var positionValue = Portfolio.TotalPortfolioValue * 0.05m;
-        // Calculate the extra position needed to hold BTC/ETH in the same size as USDT in the 2-leg trade.
-        btcSize = (positionValue - Portfolio.CashBook["BTC"].ValueInAccountCurrency) / btcPrice;
-        ethSize = (positionValue - Portfolio.CashBook["ETH"].ValueInAccountCurrency) / ethPrice;
     }
 }</pre>
     <pre class="python">class CryptoHoldingsAlgorithm(QCAlgorithm):
@@ -74,9 +76,8 @@
         self.set_start_date(2024, 9, 1)
         self.set_end_date(2024, 12, 31)
         self.set_account_currency("USDT", 1000000)
-        # Seed the last price to set the initial holding price of the cryptos.
-        self.set_security_initializer(BrokerageModelSecurityInitializer(self.brokerage_model, FuncSecuritySeeder(self.get_last_known_prices)))
-
+        
+        
         # We would like to trade the EMA cross between 2 popular cryptos: BTC & ETH,
         # so we request ETHBTC data to find trading opportunities.
         self.ethbtc = self.add_crypto("ETHBTC", Resolution.DAILY, market=Market.COINBASE).symbol
@@ -85,9 +86,13 @@
         ethusdt = self.add_crypto("ETHUSDT", Resolution.DAILY, market=Market.COINBASE)
         self.btcusdt = btcusdt.symbol
         self.ethusdt = ethusdt.symbol
+        
         # Simulate an account with various crypto cash through holdings.
+        # Set the cash book directly with the crypto amounts
         btcusdt.holdings.set_holdings(btcusdt.price, 5)
+        btcusdt.base_currency.add_amount(5)
         ethusdt.holdings.set_holdings(ethusdt.price, 22.5)
+        ethusdt.base_currency.add_amount(22.5)
 
         # Add automatic updating of the EMA indicator for trend trade signal emission.
         self._ema = self.ema(self.ethbtc, 20, Resolution.DAILY)
@@ -98,28 +103,30 @@
         bar = slice.bars.get(self.ethbtc)
         btc = slice.bars.get(self.btcusdt)
         eth = slice.bars.get(self.ethusdt)
+        
         if bar and self._ema.is_ready and btc and eth:
             ema = self._ema.current.value
+            btc_holdings = self.portfolio.cash_book["BTC"].amount
+            eth_holdings = self.portfolio.cash_book["ETH"].amount
+            
             # ETHBTC's current price is higher than EMA, suggesting an uptrend.
             if bar.close &gt; ema and not self.portfolio[self.btcusdt].is_short:
-                # Calculate the order size needed to have equal BTC-ETH value exposure.
-                btc_size, eth_size = self.calculate_order_size(btc.close, eth.close)
-                # To follow the up trend of ETHBTC, sell BTCUSDT and buy ETHUSDT.
-                self.market_order(self.btcusdt, -btc_size)
-                self.market_order(self.ethusdt, eth_size)
+                # To follow the up trend of ETHBTC, sell ALL BTCUSDT and buy ETHUSDT with the same value.
+                if btc_holdings &gt; 0:
+                    btc_value = btc_holdings * btc.close
+                    # Sell all BTC
+                    self.market_order(self.btcusdt, -btc_holdings)
+                    # Buy ETH with the same USDT value
+                    eth_size = btc_value / eth.close
+                    self.market_order(self.ethusdt, eth_size)
             # ETHBTC's current price is below the EMA, suggesting a downtrend.
             elif bar.close &lt; ema and not self.portfolio[self.btcusdt].is_long:
-                # Calculate the order size needed to have equal BTC-ETH value exposure.
-                btc_size, eth_size = self.calculate_order_size(btc.close, eth.close)
-                # To follow the downtrend of ETHBTC, buy BTCUSDT and sell ETHUSDT.
-                self.market_order(self.ethusdt, -eth_size)
-                self.market_order(self.btcusdt, btc_size)
-
-    def calculate_order_size(self, btc_price: float, eth_price: float) -&gt; tuple[float]:
-        # Invest 10% of the portfolio in the 2-leg trade, which will be 5% per each leg.
-        position_value = self.portfolio.total_portfolio_value * 0.05
-        # Calculate the extra position needed to hold BTC/ETH in the same size as USDT in the 2-leg trade.
-        btc_size = (position_value - self.portfolio.cash_book["BTC"].value_in_account_currency) / btc_price
-        eth_size = (position_value - self.portfolio.cash_book["ETH"].value_in_account_currency) / eth_price
-        return btc_size, eth_size</pre>
+                # To follow the downtrend of ETHBTC, sell ALL ETHUSDT and buy BTCUSDT with the same value.
+                if eth_holdings &gt; 0:
+                    eth_value = eth_holdings * eth.close
+                    # Sell all ETH
+                    self.market_order(self.ethusdt, -eth_holdings)
+                    # Buy BTC with the same USDT value
+                    btc_size = eth_value / btc.close
+                    self.market_order(self.btcusdt, btc_size)</pre>
 </div>

--- a/Resources/trading-and-orders/crypto-holdings-example.html
+++ b/Resources/trading-and-orders/crypto-holdings-example.html
@@ -37,18 +37,18 @@
 
     public override void OnData(Slice slice)
     {
-        if (slice.Bars.TryGetValue(_ethbtc, out var bar) && _ema.IsReady &&
-            slice.Bars.TryGetValue(_btcusdt, out var btc) && slice.Bars.TryGetValue(_ethusdt, out var eth))
+        if (slice.Bars.TryGetValue(_ethbtc, out var bar) &amp;&amp; _ema.IsReady &amp;&amp;
+            slice.Bars.TryGetValue(_btcusdt, out var btc) &amp;&amp; slice.Bars.TryGetValue(_ethusdt, out var eth))
         {
             var ema = _ema.Current.Value;
             var btcHoldings = Portfolio.CashBook["BTC"].Amount;
             var ethHoldings = Portfolio.CashBook["ETH"].Amount;
             
             // ETHBTC's current price is higher than EMA, suggesting an uptrend.
-            if (bar.Close > ema && !Portfolio[_btcusdt].IsShort)
+            if (bar.Close &gt; ema &amp;&amp; !Portfolio[_btcusdt].IsShort)
             {
                 // To follow the up trend of ETHBTC, sell ALL BTCUSDT and buy ETHUSDT with the same value.
-                if (btcHoldings > 0)
+                if (btcHoldings &gt; 0)
                 {
                     var btcValue = btcHoldings * btc.Close;
                     MarketOrder(_btcusdt, -btcHoldings);
@@ -57,10 +57,10 @@
                 }
             }
             // ETHBTC's current price is below the EMA, suggesting a downtrend.
-            else if (bar.Close < ema && !Portfolio[_btcusdt].IsLong)
+            else if (bar.Close &lt; ema &amp;&amp; !Portfolio[_btcusdt].IsLong)
             {
                 // To follow the downtrend of ETHBTC, sell ALL ETHUSDT and buy BTCUSDT with the same value.
-                if (ethHoldings > 0)
+                if (ethHoldings &gt; 0)
                 {
                     var ethValue = ethHoldings * eth.Close;
                     MarketOrder(_ethusdt, -ethHoldings);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated trading algorithm to sell all holdings of BTC or ETH when trading ETHBTC based on EMA trends.

#### Description
<!--- Describe your changes in detail -->
Updated logic now the algorithm buys one coin and goes flat on the other coin, no longer holds long and short positions at the same time. Matching backtest in both languages 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensures consistency and accuracy across both languages 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
