### PR TITLE
Bug change equity options speedup

### DIFF
--- a/Resources/option-indicators/automatic-indicator.php
+++ b/Resources/option-indicators/automatic-indicator.php
@@ -41,14 +41,14 @@
         {
             return;
         }
-        var expiry = filteredChain.Min(contract => contract.Expiry);
-        filteredChain = filteredChain
-            .Where(contract => contract.Expiry == expiry)
-            .OrderBy(contract => Math.Abs(contract.Strike - contract.UnderlyingLastPrice))
-            .Take(4);
+        var expiry = filteredChain.Min(contract =&gt; contract.Expiry);
+        filteredChain = filteredChain.Where(contract =&gt; contract.Expiry == expiry);
+        
+        var minStrikeDelta = filteredChain.Min(contract =&gt; Math.Abs(contract.Strike - contract.UnderlyingLastPrice));
+        filteredChain = filteredChain.Where(contract =&gt; Math.Abs(contract.Strike - contract.UnderlyingLastPrice) == minStrikeDelta);
 
         // Group the contracts into call/put pairs.
-        foreach (var group in filteredChain.GroupBy(contract => contract.Strike))
+        foreach (var group in filteredChain.GroupBy(contract =&gt; contract.Strike))
         {
             var contracts = group.ToList();
             if (contracts.Count() > 1)
@@ -95,7 +95,7 @@
     
     def initialize(self) -&gt; None:
         self.set_start_date(2024, 9, 1)
-        self.set_end_date(2024, 12, 31)
+        self.set_end_date(2024, 9, 30)
         self.set_cash(500_000)
         # Seed the price of each asset with its last known price to avoid trading errors.
         self.set_security_initializer(

--- a/Resources/option-indicators/automatic-indicator.php
+++ b/Resources/option-indicators/automatic-indicator.php
@@ -9,7 +9,7 @@
     public override void Initialize()
     {
         SetStartDate(2024, 9, 1);
-        SetEndDate(2024, 12, 31);
+        SetEndDate(2024, 9, 30);
         SetCash(500000);
         // Seed the price of each asset with its last known price to avoid trading errors.
         SetSecurityInitializer(

--- a/Resources/option-indicators/manual-indicator.php
+++ b/Resources/option-indicators/manual-indicator.php
@@ -11,7 +11,7 @@
     public override void Initialize()
     {
         SetStartDate(2024, 9, 1);
-        SetEndDate(2024, 12, 31);
+        SetEndDate(2024, 9, 30);
         SetCash(500000);
         // Seed the price of each asset with its last known price to avoid trading errors.
         SetSecurityInitializer(

--- a/Resources/option-indicators/manual-indicator.php
+++ b/Resources/option-indicators/manual-indicator.php
@@ -47,14 +47,14 @@
         {
             return;
         }
-        var expiry = filteredChain.Min(contract => contract.Expiry);
-        filteredChain = filteredChain
-            .Where(contract => contract.Expiry == expiry)
-            .OrderBy(contract => Math.Abs(contract.Strike - contract.UnderlyingLastPrice))
-            .Take(4);
+        var expiry = filteredChain.Min(contract =&gt; contract.Expiry);
+        filteredChain = filteredChain.Where(contract =&gt; contract.Expiry == expiry);
+        
+        var minStrikeDelta = filteredChain.Min(contract =&gt; Math.Abs(contract.Strike - contract.UnderlyingLastPrice));
+        filteredChain = filteredChain.Where(contract =&gt; Math.Abs(contract.Strike - contract.UnderlyingLastPrice) == minStrikeDelta);
 
         // Group the contracts into call/put pairs.
-        foreach (var group in filteredChain.GroupBy(contract => contract.Strike))
+        foreach (var group in filteredChain.GroupBy(contract =&gt; contract.Strike))
         {
             var contracts = group.ToList();
             if (contracts.Count > 1)
@@ -133,7 +133,7 @@
 
     def initialize(self) -&gt; None:
         self.set_start_date(2024, 9, 1)
-        self.set_end_date(2024, 12, 31)
+        self.set_end_date(2024, 9, 30)
         self.set_cash(500_000)
         # Seed the price of each asset with its last known price to avoid trading errors.
         self.set_security_initializer(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed Index contains duplicate entries cannot reshape rutime error

#### Description
<!--- Describe your changes in detail -->
Speed up [equity-options/greeks-and-implied-volatility/indicators](https://www.quantconnect.com/docs/v2/writing-algorithms/securities/asset-classes/equity-options/greeks-and-implied-volatility/indicators) and  [future-options/greeks-and-implied-volatility/indicators](https://www.quantconnect.com/docs/v2/writing-algorithms/securities/asset-classes/future-options/greeks-and-implied-volatility/indicators) Backtests to ensure they run in under one minute. Fixed filtering logic in C# equivalent to match Python Backtest

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensures consistency and accuracy across both languages 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->