### PR TITLE
Update VBaseSignalExport docs for direct % holdings

### DIFF
--- a/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/04 Send Portfolio Targets.php
+++ b/03 Writing Algorithms/40 Live Trading/99 Signal Exports/04 vBase/04 Send Portfolio Targets.php
@@ -5,9 +5,9 @@
 </p>
 
 <p>
-    <strong>What gets stamped?</strong> The provider builds a <code>sym,wt</code> (symbol-weight) CSV and, under the hood, 
-    uses <code>PortfolioTarget.Percent</code> to convert your absolute target quantities into portfolio weights. 
-    This ensures the stamp reflects the weighted sizing of your positions at the time of export.
+    <strong>What gets stamped?</strong> The provider builds a <code>sym,wt</code> (symbol-weight) CSV directly from your portfolio targets.
+    Each target's <code>Quantity</code> value is treated as the portfolio weight (percentage of holdings), so you should pass percentage-based targets
+    (e.g., 0.25 for 25% of the portfolio).
     Default behavior can be customized by overriding the <code>BuildCsv</code> method of the <code>VBaseSignalExport</code> class.
 </p>
 


### PR DESCRIPTION
## Summary
- Updates vBase Signal Export documentation to reflect that targets are now sent directly as percentage of holdings (portfolio weights), not converted from absolute quantities via `PortfolioTarget.Percent`
- Aligns docs with the behavior change in [Lean#9281](https://github.com/QuantConnect/Lean/pull/9281)

Closes #2216

## Test plan
- [ ] Verify the updated description in "Send Portfolio Targets" page accurately reflects the current Lean behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)