### PR TITLE
Fix inconsistent code formatting in universe types table

### DIFF
--- a/Resources/datasets/available-universe.html
+++ b/Resources/datasets/available-universe.html
@@ -16,7 +16,7 @@
     <tbody>
         <tr>
             <td>International Future Universe</td>
-            <td><ul><li>FutureFilterUniverse</li><li>FutureUniverse</li></ul></td>
+            <td><ul><li><code>FutureFilterUniverse</code></li><li><code>FutureUniverse</code></li></ul></td>
             <td><a href="/docs/v2/writing-algorithms/datasets/quantconnect/international-future-universe">Learn more</a></td>
         </tr>
         <tr>
@@ -26,22 +26,22 @@
         </tr>
         <tr>
             <td>US Equity Option Universe</td>
-            <td><ul><li>OptionFilterUniverse</li><li>OptionUniverse</li></ul></td>
+            <td><ul><li><code>OptionFilterUniverse</code></li><li><code>OptionUniverse</code></li></ul></td>
             <td><a href="/docs/v2/writing-algorithms/datasets/quantconnect/us-equity-option-universe">Learn more</a></td>
         </tr>
         <tr>
             <td>US Future Option Universe</td>
-            <td><ul><li>OptionFilterUniverse</li><li>OptionUniverse</li></ul></td>
+            <td><ul><li><code>OptionFilterUniverse</code></li><li><code>OptionUniverse</code></li></ul></td>
             <td><a href="/docs/v2/writing-algorithms/datasets/quantconnect/us-future-option-universe">Learn more</a></td>
         </tr>
         <tr>
             <td>US Future Universe</td>
-            <td><ul><li>FutureFilterUniverse</li><li>FutureUniverse</li></ul></td>
+            <td><ul><li><code>FutureFilterUniverse</code></li><li><code>FutureUniverse</code></li></ul></td>
             <td><a href="/docs/v2/writing-algorithms/datasets/quantconnect/us-future-universe">Learn more</a></td>
         </tr>
         <tr>
             <td>US Index Option Universe</td>
-            <td><ul><li>OptionFilterUniverse</li><li>OptionUniverse</li></ul></td>
+            <td><ul><li><code>OptionFilterUniverse</code></li><li><code>OptionUniverse</code></li></ul></td>
             <td><a href="/docs/v2/writing-algorithms/datasets/quantconnect/us-index-option-universe">Learn more</a></td>
         </tr>
         <tr>
@@ -126,7 +126,7 @@
         </tr>
         <tr>
             <td>Corporate Buybacks</td>
-            <td><ul><li>SmartInsiderIntentionUniverse</li><li>SmartInsiderTransactionUniverse</li></ul></td>
+            <td><ul><li><code>SmartInsiderIntentionUniverse</code></li><li><code>SmartInsiderTransactionUniverse</code></li></ul></td>
             <td><a href="/docs/v2/writing-algorithms/datasets/smart-insider/corporate-buybacks">Learn more</a></td>
         </tr>
 </tbody>

--- a/code-generators/Alternative-Datasets-Code-Generator.py
+++ b/code-generators/Alternative-Datasets-Code-Generator.py
@@ -183,7 +183,7 @@ if __name__ == '__main__':
                     if universe_attrs:
                         universe_html += f"""        <tr>
             <td>{name}</td>
-            <td>{"<code>" + universe_attrs[0] + "</code>" if len(universe_attrs) == 1 else "<ul><li>" + "</li><li>".join(universe_attrs) + "</li></ul>"}</td>
+            <td>{"<code>" + universe_attrs[0] + "</code>" if len(universe_attrs) == 1 else "<ul><li><code>" + "</code></li><li><code>".join(universe_attrs) + "</code></li></ul>"}</td>
             <td><a href=\"/docs/v2/writing-algorithms/datasets/{vendor.lower().replace(' ', '-')}/{name.lower().replace(' ', '-')}\">Learn more</a></td>
         </tr>
 """


### PR DESCRIPTION
## Summary
- Wrap class names in `<code>` tags when multiple universe types are listed in `<li>` elements in the Available Universes table
- Fix the Alternative-Datasets-Code-Generator.py so future regenerations produce consistent formatting (single and multi-value universe types both use `<code>` tags)

Resolves #2190

## Test plan
- [x] Verify the Available Universes table at /docs/v2/research-environment/universes#03-Available-Universes renders class names consistently in red/code style
- [x] Confirm both single-type rows (e.g. `ETFConstituentUniverse`) and multi-type rows (e.g. `FutureFilterUniverse`, `FutureUniverse`) display with code formatting
- [x] Re-run Alternative-Datasets-Code-Generator.py and verify output matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)