### PR TITLE
Fix DataFrame table wrapping and reduce font size

### DIFF
--- a/04 Research Environment/03 Datasets/04 US Equity/11 Wrangle Data.php
+++ b/04 Research Environment/03 Datasets/04 US Equity/11 Wrangle Data.php
@@ -11,7 +11,7 @@ $secondarySymbol = 'tlt';
 $dataFrameImages = array();
 
 $dataFrameImages[0] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -261,7 +261,7 @@ $dataFrameImages[0] = <<<'HTML'
 HTML;
 
 $dataFrameImages[1] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -524,7 +524,7 @@ Name: close, dtype: float64</pre>
 HTML;
 
 $dataFrameImages[3] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -600,7 +600,7 @@ $dataFrameImages[3] = <<<'HTML'
 HTML;
 
 $equityTickerDataFrameHtml = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -678,7 +678,7 @@ HTML;
 $cSharpDataFrameImages = array();
 
 $cSharpDataFrameImages[0] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -731,7 +731,7 @@ $cSharpDataFrameImages[0] = <<<'HTML'
 HTML;
 
 $cSharpDataFrameImages[1] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">

--- a/04 Research Environment/03 Datasets/10 Crypto/09 Wrangle Data.php
+++ b/04 Research Environment/03 Datasets/10 Crypto/09 Wrangle Data.php
@@ -11,7 +11,7 @@ $secondarySymbol = 'ethusd';
 $dataFrameImages = array();
 
 $dataFrameImages[0] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -261,7 +261,7 @@ $dataFrameImages[0] = <<<'HTML'
 HTML;
 
 $dataFrameImages[1] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -524,7 +524,7 @@ Name: close, dtype: float64</pre>
 HTML;
 
 $dataFrameImages[3] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -602,7 +602,7 @@ HTML;
 $cSharpDataFrameImages = array();
 
 $cSharpDataFrameImages[0] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -649,7 +649,7 @@ $cSharpDataFrameImages[0] = <<<'HTML'
 HTML;
 
 $cSharpDataFrameImages[1] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">

--- a/04 Research Environment/03 Datasets/11 Crypto Futures/09 Wrangle Data.php
+++ b/04 Research Environment/03 Datasets/11 Crypto Futures/09 Wrangle Data.php
@@ -11,7 +11,7 @@ $secondarySymbol = 'ethusd';
 $dataFrameImages = array();
 
 $dataFrameImages[0] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -261,7 +261,7 @@ $dataFrameImages[0] = <<<'HTML'
 HTML;
 
 $dataFrameImages[1] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -524,7 +524,7 @@ Name: close, dtype: float64</pre>
 HTML;
 
 $dataFrameImages[3] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -602,7 +602,7 @@ HTML;
 $cSharpDataFrameImages = array();
 
 $cSharpDataFrameImages[0] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -649,7 +649,7 @@ $cSharpDataFrameImages[0] = <<<'HTML'
 HTML;
 
 $cSharpDataFrameImages[1] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">

--- a/04 Research Environment/03 Datasets/16 Forex/09 Wrangle Data.php
+++ b/04 Research Environment/03 Datasets/16 Forex/09 Wrangle Data.php
@@ -11,7 +11,7 @@ $secondarySymbol = 'gbpusd';
 $dataFrameImages = array();
 
 $dataFrameImages[0] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -222,7 +222,7 @@ $dataFrameImages[0] = <<<'HTML'
 HTML;
 
 $dataFrameImages[1] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -446,7 +446,7 @@ Name: close, dtype: float64</pre>
 HTML;
 
 $dataFrameImages[3] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -524,7 +524,7 @@ HTML;
 $cSharpDataFrameImages = array();
 
 $cSharpDataFrameImages[0] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -745,7 +745,7 @@ $cSharpDataFrameImages[0] = <<<'HTML'
 HTML;
 
 $cSharpDataFrameImages[1] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">

--- a/04 Research Environment/03 Datasets/18 CFD/09 Wrangle Data.php
+++ b/04 Research Environment/03 Datasets/18 CFD/09 Wrangle Data.php
@@ -11,7 +11,7 @@ $secondarySymbol = 'usb';
 $dataFrameImages = array();
 
 $dataFrameImages[0] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -222,7 +222,7 @@ $dataFrameImages[0] = <<<'HTML'
 HTML;
 
 $dataFrameImages[1] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -446,7 +446,7 @@ Name: close, dtype: float64</pre>
 HTML;
 
 $dataFrameImages[3] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -524,7 +524,7 @@ HTML;
 $cSharpDataFrameImages = array();
 
 $cSharpDataFrameImages[0] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -745,7 +745,7 @@ $cSharpDataFrameImages[0] = <<<'HTML'
 HTML;
 
 $cSharpDataFrameImages[1] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">

--- a/04 Research Environment/03 Datasets/20 Indices/09 Wrangle Data.php
+++ b/04 Research Environment/03 Datasets/20 Indices/09 Wrangle Data.php
@@ -11,7 +11,7 @@ $secondarySymbol = 'vix';
 $dataFrameImages = array();
 
 $dataFrameImages[0] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -118,7 +118,7 @@ $dataFrameImages[0] = <<<'HTML'
 HTML;
 
 $dataFrameImages[1] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -238,7 +238,7 @@ Name: close, dtype: float64</pre>
 HTML;
 
 $dataFrameImages[3] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -316,7 +316,7 @@ HTML;
 $cSharpDataFrameImages = array();
 
 $cSharpDataFrameImages[0] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -363,7 +363,7 @@ $cSharpDataFrameImages[0] = <<<'HTML'
 HTML;
 
 $cSharpDataFrameImages[1] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">

--- a/04 Research Environment/03 Datasets/24 Alternative Data/06 Wrangle Data.php
+++ b/04 Research Environment/03 Datasets/24 Alternative Data/06 Wrangle Data.php
@@ -11,7 +11,7 @@ $secondarySymbol = 'v3m';
 $dataFrameImages = array();
 
 $dataFrameImages[0] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -144,7 +144,7 @@ $dataFrameImages[0] = <<<'HTML'
 HTML;
 
 $dataFrameImages[1] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -290,7 +290,7 @@ Name: close, dtype: float64</pre>
 HTML;
 
 $dataFrameImages[3] = <<<'HTML'
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -368,7 +368,7 @@ HTML;
 $cSharpDataFrameImages = array();
 
 $cSharpDataFrameImages[0] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -484,7 +484,7 @@ $cSharpDataFrameImages[0] = <<<'HTML'
 HTML;
 
 $cSharpDataFrameImages[1] = <<<'HTML'
-<div class="csharp dataframe-wrapper">
+<div class="csharp dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe csharp" border="0">
   <thead>
     <tr style="text-align: right;">

--- a/Resources/datasets/request-data.php
+++ b/Resources/datasets/request-data.php
@@ -62,7 +62,7 @@ trade_bars_df = <?=$pyVar?>.history(TradeBar, btc_symbol, 5)
 quote_bars_df = <?=$pyVar?>.history(QuoteBar, btc_symbol, 5)
 df = <?=$pyVar?>.history(btc_symbol, 5)   # Includes trade and quote data
 </pre>
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -98,7 +98,7 @@ trade_bars_df = <?=$pyVar?>.history(TradeBar, btc_symbol, 5, Resolution.MINUTE)
 quote_bars_df = <?=$pyVar?>.history(QuoteBar, btc_symbol, 5, Resolution.MINUTE)
 df = <?=$pyVar?>.history(btc_symbol, 5, Resolution.MINUTE)  # Includes trade and quote data
 </pre>
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -135,7 +135,7 @@ trade_bars_df = <?=$pyVar?>.history(TradeBar, btc_symbol, timedelta(days=3))
 quote_bars_df = <?=$pyVar?>.history(QuoteBar, btc_symbol, timedelta(days=3))
 df = <?=$pyVar?>.history(btc_symbol, timedelta(days=3))  # Includes trade and quote data
 </pre>
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -176,7 +176,7 @@ quote_bars_df = <?=$pyVar?>.history(QuoteBar, btc_symbol, timedelta(days=3), Res
 ticks_df = <?=$pyVar?>.history(eth_symbol, timedelta(days=3), Resolution.TICK)
 df = <?=$pyVar?>.history(btc_symbol, timedelta(days=3), Resolution.HOUR)  # Includes trade and quote data
 </pre>
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -219,7 +219,7 @@ quote_bars_df = <?=$pyVar?>.history(QuoteBar, btc_symbol, start_time, end_time)
 ticks_df = <?=$pyVar?>.history(Tick, eth_symbol, start_time, end_time)
 df = <?=$pyVar?>.history(btc_symbol, start_time, end_time)  # Includes trade and quote data
 </pre>
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -260,7 +260,7 @@ quote_bars_df = <?=$pyVar?>.history(QuoteBar, btc_symbol, start_time, end_time, 
 ticks_df = <?=$pyVar?>.history(eth_symbol, start_time, end_time, Resolution.TICK)
 df = <?=$pyVar?>.history(btc_symbol, start_time, end_time, Resolution.HOUR)  # Includes trade and quote data
 </pre>
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -339,7 +339,7 @@ trade_bars_df = <?=$pyVar?>.history(TradeBar, [ibm, aapl], 2)
 quote_bars_df = <?=$pyVar?>.history(QuoteBar, [ibm, aapl], 2)
 df = <?=$pyVar?>.history([ibm, aapl], 2)  # Includes trade and quote data
 </pre>
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -377,7 +377,7 @@ trade_bars_df = <?=$pyVar?>.history(TradeBar, [ibm, aapl], 5, Resolution.DAILY)
 quote_bars_df = <?=$pyVar?>.history(QuoteBar, [ibm, aapl], 5, Resolution.MINUTE)
 df = <?=$pyVar?>.history([ibm, aapl], 5, Resolution.DAILY)  # Includes trade data only. No quote for daily equity data
 </pre>
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -411,7 +411,7 @@ trade_bars_df = <?=$pyVar?>.history(TradeBar, [btc_symbol], timedelta(days=3))
 quote_bars_df = <?=$pyVar?>.history(QuoteBar, [btc_symbol], timedelta(days=3))
 df = <?=$pyVar?>.history([btc_symbol], timedelta(days=3))  # Includes trade and quote data
 </pre>
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">
@@ -446,7 +446,7 @@ quote_bars_df = <?=$pyVar?>.history(QuoteBar, btc_symbol, start_time, end_time)
 ticks_df = <?=$pyVar?>.history(Tick, eth_symbol, start_time, end_time)
 df = <?=$pyVar?>.history([btc_symbol], start_time, end_time)  # Includes trade and quote data
 </pre>
-<div class="python dataframe-wrapper">
+<div class="python dataframe-wrapper" style="font-size: 80%; white-space: nowrap">
 <table class="dataframe python" border="0">
   <thead>
     <tr style="text-align: right;">


### PR DESCRIPTION
## Summary
- Add `white-space: nowrap` to prevent time column text wrapping in DataFrame tables
- Add `font-size: 80%` to reduce table font size for better readability
- Applied to all 46 `dataframe-wrapper` divs across 8 files (Python + C#)

Resolves #2077

## Test plan
- [ ] Verify time columns no longer wrap on the rendered pages
- [ ] Confirm font size is visibly smaller (80%) in DataFrame tables
- [ ] Check horizontal scrolling works for wide tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)