### PR TITLE
Fix url_check case-sensitive replacements applied after lowercasing

### DIFF
--- a/url_check.py
+++ b/url_check.py
@@ -402,8 +402,9 @@ async def _check_url(
 def _check_section_anchor(url: str, files: list[str], file_index: dict[str, list[str]], results: dict[str, list[str]]):
     """Validate that a #section anchor corresponds to a real file in the repo."""
     after_v2 = url.split("docs/v2/", 1)[1]
-    expected_raw = after_v2.replace("/", os.sep).replace("-", " ").replace("#", os.sep).lower()
-    expected = _apply_replacements(expected_raw)
+    expected_no_lower = after_v2.replace("/", os.sep).replace("-", " ").replace("#", os.sep)
+    expected = _apply_replacements(expected_no_lower).lower()
+    expected_raw = expected_no_lower.lower()
 
     section = url.split("#", 1)[1]
     section_name_raw = section.replace("-", " ")


### PR DESCRIPTION
## Summary
- PR #2241 introduced a regression where `expected_raw` is lowercased before `_apply_replacements()` is called, but SECTION_REPLACEMENTS entries are case-sensitive (e.g. `"Volatility3F"` won't match `"volatility3f"`)
- Fix: apply replacements before lowercasing, restoring the original order of operations while keeping the fallback-matching improvements from #2241
- This resolves all 21 `missing_section` false positives reported in the issue

Resolves #2243

## Test plan
- [ ] Verify the url_check workflow no longer reports the 21 missing_section errors
- [ ] Confirm no new false positives or missed broken links are introduced