### PR TITLE
Add JSON schema for webhook notification payload

### DIFF
--- a/01 Cloud Platform/10 Live Trading/05 Notifications/06 Webhooks.php
+++ b/01 Cloud Platform/10 Live Trading/05 Notifications/06 Webhooks.php
@@ -57,7 +57,7 @@
         </tr>
         <tr>
             <td><code>OrderEvents</code></td>
-            <td><code>OrderEvent Array</code><br/>Collection of order events since the last notification. See the Order Event Schema table below for the schema of each object.</td>
+            <td><code>OrderEvent Array</code><br/>Collection of order events since the last notification. For the conceptual model, see <a href='/docs/v2/cloud-platform/api-reference/backtest-management/read-backtest/orders#03-Responses'>OrderEvent in the API Reference</a>. The webhook serialization differs from the API response. See the Order Event Schema table below for the webhook-specific schema.</td>
         </tr>
         <tr>
             <td><code>Portfolio</code></td>


### PR DESCRIPTION
## Summary
- Add JSON payload schema documentation to the Webhooks notification page, including the top-level payload structure, Order Event schema, and Portfolio schema tables
- Add a link to the existing Insight API response schema for the Insights array
- Include an example JSON payload based on the real webhook output

Resolves #2200

## Test plan
- [ ] Verify the page renders correctly on quantconnect.com/docs/v2/cloud-platform/live-trading/notifications#06-Webhooks
- [ ] Confirm all schema tables display properly with correct property names and descriptions
- [ ] Check the internal link to the Insight API response page resolves