### PR TITLE
Fix GPLearn research example code errors (#2162)

### DIFF
--- a/04 Research Environment/08 Machine Learning/03 Popular Libraries/02 GPlearn/99 Examples.html
+++ b/04 Research Environment/08 Machine Learning/03 Popular Libraries/02 GPlearn/99 Examples.html
@@ -65,14 +65,13 @@ plt.show()
 r2 = gp_regressor.score(new_X_test, y_test)
 print(f"The explained variance of the GP model: {r2*100:.2f}%")
 
-# Predict the label of the testing set data.
-y_hat = predict(np.array(X_test))
-
 # Store the model in the object store to allow accessing the model in the next research session or in the algorithm for trading.
 transformer_key = "transformer"
 regressor_key = "regressor"
 transformer_file = qb.object_store.get_file_path(transformer_key)
 regressor_file = qb.object_store.get_file_path(regressor_key)
 joblib.dump(gp_transformer, transformer_file)
-joblib.dump(gp_regressor, regressor_file)</pre>
+joblib.dump(gp_regressor, regressor_file)
+qb.object_store.save(transformer_key)
+qb.object_store.save(regressor_key)</pre>
 </div>


### PR DESCRIPTION
## Summary
- Remove undefined \`predict()\` call in the Research Environment GPLearn example (was never defined; predictions were already computed as \`y_predict\` earlier in the snippet)
- Add missing \`qb.object_store.save()\` calls to persist the transformer and regressor models to the object store

Resolves #2162

## Backtest results (Writing Algorithms example, Legacy env, 2024-09-01–2024-12-31)

| Metric | Value |
|---|---|
| Sharpe Ratio | -1.036 |
| Total Orders | 23 |
| Net Profit | -2.635% |
| Compounding Annual Return | -7.695% |
| Win Rate | 47% |
| Max Drawdown | 9.0% |
| Probabilistic Sharpe Ratio | 15.0% |

Project: https://www.quantconnect.com/project/29164258 (leanEnvironment=7, Legacy)

## Test plan
- [x] Writing Algorithms GPLearn example runs without errors in the Legacy package environment (leanEnvironment=7)
- [x] Verify the page renders correctly on quantconnect.com/docs
- [x] Confirm the Research Environment GPLearn notebook example runs without errors in the Legacy package environment
- [x] Check all links resolve