### PR TITLE
Fix Object Store keys to include project ID in ML library examples

### DIFF
--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/01 Aesera/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/01 Aesera/07 Save Models.html
@@ -4,7 +4,7 @@
     <li>Set the key name you want to store the model under in the Object Store.</li>
     <div class="section-example-container">
         <pre class="python"># Set the storage key to something representative.
-model_key = "model"</pre>
+model_key = f"{self.project_id}/model"</pre>
     </div>
 
     <li>Call the <code class="csharp">GetFilePath</code><code class="python">get_file_path</code> method with the key.</li>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/01 Aesera/08 Load Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/01 Aesera/08 Load Models.html
@@ -2,6 +2,7 @@
 <div class="section-example-container">
     <pre class="python"># Load the trained Aesera model from the Object Store.
 def initialize(self) -&gt; None:
+    model_key = f"{self.project_id}/model"
     if self.object_store.contains_key(model_key):
         file_name = self.object_store.get_file_path(model_key)
         self.model = joblib.load(file_name)</pre>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/01 Aesera/99 Examples.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/01 Aesera/99 Examples.html
@@ -95,7 +95,7 @@ class AeseraExampleAlgorithm(QCAlgorithm):
         self._train(D[0], D[1])
 
         # Store the model to object store to retrieve it in other instances in case the algorithm stops.
-        model_key = "model_test_aesera"
+        model_key = f"{self.project_id}/model_test_aesera"
         file_name = self.object_store.get_file_path(model_key)
         joblib.dump(self.predict, file_name)
         self.object_store.save(model_key)

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/02 Copula/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/02 Copula/07 Save Models.html
@@ -4,7 +4,7 @@
     <li>Set the key name you want to store the model under in the Object Store.</li>
     <div class="section-example-container">
         <pre class="python"># Set the storage key to something representative.
-model_key = "copula"</pre>
+model_key = f"{self.project_id}/copula"</pre>
     </div>
 
     <li>Call the <code class="csharp">GetFilePath</code><code class="python">get_file_path</code> method with the key.</li>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/02 Copula/08 Load Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/02 Copula/08 Load Models.html
@@ -2,6 +2,7 @@
 <div class="section-example-container">
     <pre class="python"># Load the trained Aesera model from the Object Store.
 def initialize(self) -&gt; None:
+    model_key = f"{self.project_id}/copula"
     if self.object_store.contains_key(model_key):
         file_name = self.object_store.get_file_path(model_key)
         self.copula_trader.copula = joblib.load(file_name)</pre>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/03 GPlearn/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/03 GPlearn/07 Save Models.html
@@ -3,8 +3,8 @@
     <li>Set the key names you want to store the models under in the Object Store.</li>
     <div class="section-example-container">
         <pre class="python"># Set the storage keys to something representative.
-transformer_model_key = "transformer"
-regressor_model_key = "regressor"</pre>
+transformer_model_key = f"{self.project_id}/transformer"
+regressor_model_key = f"{self.project_id}/regressor"</pre>
     </div>
 
     <li>Call the <code class="csharp">GetFilePath</code><code class="python">get_file_path</code> method with the keys.</li>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/03 GPlearn/08 Load Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/03 GPlearn/08 Load Models.html
@@ -2,6 +2,8 @@
 <div class="section-example-container">
     <pre class="python"># Load the GPLearn model from Object Store to use its saved state and update with new data if needed.
 def initialize(self) -&gt; None:
+    transformer_model_key = f"{self.project_id}/transformer"
+    regressor_model_key = f"{self.project_id}/regressor"
     if self.object_store.contains_key(transformer_model_key) and self.object_store.contains_key(regressor_model_key):
         transformer_file_name = self.object_store.get_file_path(transformer_model_key)
         regressor_file_name = self.object_store.get_file_path(regressor_model_key)

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/03 GPlearn/99 Examples.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/03 GPlearn/99 Examples.html
@@ -38,8 +38,8 @@ class GPlearnExampleAlgorithm(QCAlgorithm):
             self.training_data.add(trade_bar.close)
 
         # Retrieve already trained model from object store to use immediately.
-        transformer_model_key = "Transformer"
-        regressor_model_key = "Regressor"
+        transformer_model_key = f"{self.project_id}/Transformer"
+        regressor_model_key = f"{self.project_id}/Regressor"
         if self.object_store.contains_key(transformer_model_key) and self.object_store.contains_key(regressor_model_key):
             transformer_file_name = self.object_store.get_file_path(transformer_model_key)
             regressor_file_name = self.object_store.get_file_path(regressor_model_key)
@@ -108,8 +108,8 @@ class GPlearnExampleAlgorithm(QCAlgorithm):
 
     def on_end_of_algorithm(self) -&gt; None:
         # Store the model to object store to retrieve it in other instances in case the algorithm stops.
-        transformer_model_key = "Transformer"
-        regressor_model_key = "Regressor"
+        transformer_model_key = f"{self.project_id}/Transformer"
+        regressor_model_key = f"{self.project_id}/Regressor"
         transformer_file_name = self.object_store.get_file_path(transformer_model_key)
         regressor_file_name = self.object_store.get_file_path(regressor_model_key)
         joblib.dump(self.gp_transformer, transformer_file_name)

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/04 Hmmlearn/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/04 Hmmlearn/07 Save Models.html
@@ -4,7 +4,7 @@
     <li>Set the key name you want to store the model under in the Object Store.</li>
     <div class="section-example-container">
         <pre class="python"># Set the key to store the model in the Object Store so you can use it later.
-model_key = "model.hmm"</pre>
+model_key = f"{self.project_id}/model.hmm"</pre>
     </div>
 
     <li>Call the <code class="csharp">GetFilePath</code><code class="python">get_file_path</code> method with the key.</li>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/04 Hmmlearn/08 Load Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/04 Hmmlearn/08 Load Models.html
@@ -2,6 +2,7 @@
 <div class="section-example-container">
     <pre class="python"># Load the hmmlearn model from Object Store to use its saved state and update it with new data if needed.
 def initialize(self) -&gt; None:
+    model_key = f"{self.project_id}/model.hmm"
     if self.object_store.contains_key(model_key):
         file_name = self.object_store.get_file_path(model_key)
         self.model = joblib.load(file_name)</pre>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/04 Hmmlearn/99 Examples.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/04 Hmmlearn/99 Examples.html
@@ -33,8 +33,9 @@ class HmmlearnExampleAlgorithm(QCAlgorithm):
         self.set_warm_up(training_length, Resolution.DAILY)
 
         # Retrieve already trained model from object store to use immediately.
-        if self.object_store.contains_key("model.hmm"):
-            file_name = self.object_store.get_file_path("model.hmm")
+        self._model_key = f"{self.project_id}/model.hmm"
+        if self.object_store.contains_key(self._model_key):
+            file_name = self.object_store.get_file_path(self._model_key)
             self.model = joblib.load(file_name)
         # Create a 2-regime model otherwise to predict different variance regime markets.
         else:
@@ -77,7 +78,6 @@ class HmmlearnExampleAlgorithm(QCAlgorithm):
 
     def on_end_of_algorithm(self) -&gt; None:
         # Store the model to object store to retrieve it in other instances in case the algorithm stops.
-        model_key = "model.hmm"
-        file_name = self.object_store.get_file_path(model_key)
+        file_name = self.object_store.get_file_path(self._model_key)
         joblib.dump(self.model, file_name)</pre>
 </div>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/05 Keras/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/05 Keras/07 Save Models.html
@@ -4,7 +4,7 @@
     <p>The key must end with a <span class='public-file-name'>.keras</span> extension for the native Keras format (recommended) or a <span class='public-file-name'>.h5</span> extension.</p>
     <div class="section-example-container">
         <pre class="python"># Set the key to store the model in the Object Store so you can use it later.
-model_key = "model.keras"</pre>
+model_key = f"{self.project_id}/model.keras"</pre>
     </div>
 
     <li>Call the <code class="csharp">GetFilePath</code><code class="python">get_file_path</code> method with the key.</li>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/05 Keras/08 Load Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/05 Keras/08 Load Models.html
@@ -2,6 +2,7 @@
 <div class="section-example-container">
     <pre class="python"># Load the model from Object Store to use its saved state and update it with new data if needed.
 def initialize(self) -&gt; None:
+    model_key = f"{self.project_id}/model.keras"
     if self.object_store.contains_key(model_key):
         file_name = self.object_store.get_file_path(model_key)
         self.model = load_model(file_name)</pre>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/05 Keras/99 Examples.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/05 Keras/99 Examples.html
@@ -29,9 +29,9 @@ class KerasExampleAlgorithm(QCAlgorithm):
         self._symbol = self.add_equity("SPY", Resolution.DAILY).symbol
 
         # Retrieve already trained model from object store to use immediately.
-        model_key = "model.keras"
-        if self.object_store.contains_key(model_key):
-            file_name = self.object_store.get_file_path(model_key)
+        self._model_key = f"{self.project_id}/model.keras"
+        if self.object_store.contains_key(self._model_key):
+            file_name = self.object_store.get_file_path(self._model_key)
             self.model = load_model(file_name)
 
         # Create a MLP model otherwise to predict price movement.
@@ -95,7 +95,6 @@ class KerasExampleAlgorithm(QCAlgorithm):
 
     def on_end_of_algorithm(self):
         # Store the model to object store to retrieve it in other instances in case the algorithm stops.
-        model_key = "model.keras"
-        file_name = self.object_store.get_file_path(model_key)
+        file_name = self.object_store.get_file_path(self._model_key)
         self.model.save(file_name)</pre>
 </div>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/06 PyTorch/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/06 PyTorch/07 Save Models.html
@@ -3,7 +3,7 @@
     <li>Set the key name of the model to be stored in the Object Store.</li>
     <div class="section-example-container">
         <pre class="python"># Set the key to store the model in the Object Store so you can use it later.
-model_key = "model"</pre>
+model_key = f"{self.project_id}/model"</pre>
     </div>
 
     <li>Call the <code class="csharp">GetFilePath</code><code class="python">get_file_path</code> method with the key.</li>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/06 PyTorch/08 Load Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/06 PyTorch/08 Load Models.html
@@ -2,6 +2,7 @@
 <div class="section-example-container">
     <pre class="python"># Load the PyTorch model from Object Store to use its saved state and update it with new data if needed.
 def initialize(self) -&gt; None:
+    model_key = f"{self.project_id}/model"
     if self.object_store.contains_key(model_key):
         file_name = self.object_store.get_file_path(model_key)
         self.model = joblib.load(file_name)</pre>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/06 PyTorch/99 Examples.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/06 PyTorch/99 Examples.html
@@ -34,7 +34,7 @@ class PyTorchExampleAlgorithm(QCAlgorithm):
         self.set_warm_up(training_length, Resolution.DAILY)
 
         # Retrieve already trained model from object store to use immediately.
-        self._model_key = 'pytorch-example-model'
+        self._model_key = f"{self.project_id}/pytorch-example-model"
         if self.live_mode and self.object_store.contains_key(self._model_key):
             file_name = self.object_store.get_file_path(self._model_key)
             self.model = joblib.load(file_name)

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/07 Scikit-Learn/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/07 Scikit-Learn/07 Save Models.html
@@ -4,7 +4,7 @@
     <li>Set the key name you want to store the model under in the Object Store.</li>
     <div class="section-example-container">
         <pre class="python"># Set the key to store the model in the Object Store so you can use it later.
-model_key = "model"</pre>
+model_key = f"{self.project_id}/model"</pre>
     </div>
 
     <li>Call the <code class="csharp">GetFilePath</code><code class="python">get_file_path</code> method with the key.</li>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/07 Scikit-Learn/08 Load Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/07 Scikit-Learn/08 Load Models.html
@@ -2,6 +2,7 @@
 <div class="section-example-container">
     <pre class="python"># Load the sklearn model from the Object Store to use its saved state and update it with new data if needed.
 def initialize(self) -&gt; None:
+    model_key = f"{self.project_id}/model"
     if self.object_store.contains_key(model_key):
         file_name = self.object_store.get_file_path(model_key)
         self.model = joblib.load(file_name)</pre>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/09 Tensorflow/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/09 Tensorflow/07 Save Models.html
@@ -4,7 +4,7 @@
     <li>Set the key name of the model to be stored in the Object Store.</li>
     <div class="section-example-container">
         <pre class="python"># Set the key to store the model in the Object Store so you can use it later.
-model_key = "model.keras"</pre>
+model_key = f"{self.project_id}/model.keras"</pre>
     </div>
     <p>Note that the model has to have the suffix <code>.keras</code>.</p>
 

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/09 Tensorflow/08 Load Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/09 Tensorflow/08 Load Models.html
@@ -2,7 +2,7 @@
 <div class="section-example-container">
     <pre class="python"># Load the tensorflow model from the Object Store to use its saved state and update it with new data if needed.
 def initialize(self) -&gt; None:
-    model_key = 'model.keras'
+    model_key = f"{self.project_id}/model.keras"
     if self.object_store.contains_key(model_key):
         file_name = self.object_store.get_file_path(model_key)
         self.model = tf.keras.models.load_model(file_name)</pre>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/10 Tslearn/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/10 Tslearn/07 Save Models.html
@@ -3,7 +3,7 @@
     <li>Set the key name of the model to be stored in the Object Store.</li>
     <div class="section-example-container">
         <pre class="python"># Set the key to store the model in the Object Store for reuse across sessions.
-model_key = "model.hdf5"</pre>
+model_key = f"{self.project_id}/model.hdf5"</pre>
     </div>
 
     <li>Call the <code class="csharp">GetFilePath</code><code class="python">get_file_path</code> method with the key.</li>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/10 Tslearn/08 Load Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/10 Tslearn/08 Load Models.html
@@ -3,6 +3,7 @@
 <div class="section-example-container">
     <pre class="python"># Load the tslearn model from the Object Store to use its saved state and update it with new data if needed.
 def initialize(self) -&gt; None:
+    model_key = f"{self.project_id}/model.hdf5"
     if self.object_store.contains_key(model_key):
         file_name = self.object_store.get_file_path(model_key)
         self.model = TimeSeriesKMeans.from_hdf5(file_name + ".hdf5")</pre>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/10 Tslearn/99 Examples.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/10 Tslearn/99 Examples.html
@@ -75,7 +75,7 @@ class TslearnExampleAlgorithm(QCAlgorithm):
 
     def on_end_of_algorithm(self) -&gt; None:
         # Store the model to object store to retrieve it in other instances in case the algorithm stops.
-        model_key = "model_test.hdf5"
+        model_key = f"{self.project_id}/model_test.hdf5"
         # If the model already exists, delete it so the `to_hdf5` method doesn't raise an error.
         if self.object_store.contains_key(model_key):
             self.object_store.delete(model_key)

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/11 XGBoost/07 Save Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/11 XGBoost/07 Save Models.html
@@ -3,7 +3,7 @@
     <li>Set the key name of the model to be stored in the Object Store.</li>
     <div class="section-example-container">
         <pre class="python"># Set the key to store the model in the Object Store so you can use it later.
-model_key = "model"</pre>
+model_key = f"{self.project_id}/model"</pre>
     </div>
 
     <li>Call the <code class="csharp">GetFilePath</code><code class="python">get_file_path</code> method with the key.</li>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/11 XGBoost/08 Load Models.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/11 XGBoost/08 Load Models.html
@@ -2,6 +2,7 @@
 <div class="section-example-container">
     <pre class="python"># Load the xgboost model from the Object Store to use its saved state and update it with new data if needed.
 def initialize(self) -&gt; None:
+    model_key = f"{self.project_id}/model"
     if self.object_store.contains_key(model_key):
         file_name = self.object_store.get_file_path(model_key)
         self.model = joblib.load(file_name)</pre>

--- a/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/11 XGBoost/99 Examples.html
+++ b/03 Writing Algorithms/31 Machine Learning/03 Popular Libraries/11 XGBoost/99 Examples.html
@@ -34,7 +34,7 @@ class XGBoostExampleAlgorithm(QCAlgorithm):
         self.set_warm_up(training_length, Resolution.DAILY)
 
         # Retrieve already trained model from object store to use immediately.
-        self._model_key = "xgboost-example-model"
+        self._model_key = f"{self.project_id}/xgboost-example-model"
         if self.live_mode and self.object_store.contains_key(self._model_key):
             file_name = self.object_store.get_file_path(self._model_key)
             self.model = joblib.load(file_name)

--- a/03 Writing Algorithms/31 Machine Learning/04 Hugging Face/02 Popular Models/03 Chronos-T5/04 Fine-Tune Model.html
+++ b/03 Writing Algorithms/31 Machine Learning/04 Hugging Face/02 Popular Models/03 Chronos-T5/04 Fine-Tune Model.html
@@ -27,7 +27,7 @@ from logging import getLogger, INFO</pre>
     self._optimizer = 'adamw_torch_fused' if torch.cuda.is_available() else 'adamw_torch'
     self._model_name = "amazon/chronos-t5-tiny"
     self._model_path = self.object_store.get_file_path(
-        f"llm/fine-tune/{self._model_name.replace('/', '-')}/"
+        f"{self.project_id}/llm/fine-tune/{self._model_name.replace('/', '-')}/"
     )</pre> 
   </div>  
   

--- a/03 Writing Algorithms/31 Machine Learning/04 Hugging Face/02 Popular Models/03 Chronos-T5/99 Examples.html
+++ b/03 Writing Algorithms/31 Machine Learning/04 Hugging Face/02 Popular Models/03 Chronos-T5/99 Examples.html
@@ -229,7 +229,7 @@ class HuggingFaceFineTunedDemo(QCAlgorithm):
         self._optimizer = 'adamw_torch_fused' if torch.cuda.is_available() else 'adamw_torch'
         self._model_name = "amazon/chronos-t5-tiny"
         self._model_path = self.object_store.get_file_path(
-            f"llm/fine-tune/{self._model_name.replace('/', '-')}/"
+            f"{self.project_id}/llm/fine-tune/{self._model_name.replace('/', '-')}/"
         )
 
     def _sharpe_ratio(


### PR DESCRIPTION
## Summary
- Updated all Object Store key examples across 10 ML popular library pages (Aesera, Copula, GPLearn, Hmmlearn, Keras, PyTorch, Scikit-Learn, TensorFlow, Tslearn, XGBoost) and Chronos-T5 fine-tuning to include `self.project_id` as a prefix in the key path
- Updated Save Models, Load Models, and Examples pages for each affected library
- Added explicit key variable definitions in Load Models snippets where the key was previously undefined in the snippet context
- Pattern applied: `model_key = f"{self.project_id}/model"` instead of `model_key = "model"`

Resolves #1466

## Test plan
- [x] Verify the pages render correctly on quantconnect.com/docs
- [x] Confirm the key format `{project_id}/model-name` matches the pattern used in the Object Store documentation
- [x] Check that Load Models snippets are now self-contained with the key definition