### PR TITLE
Add missing descriptions to CLI API Reference pages

### DIFF
--- a/05 Lean CLI/99 API Reference/04 lean cloud live/02 Description.html
+++ b/05 Lean CLI/99 API Reference/04 lean cloud live/02 Description.html
@@ -1,0 +1,9 @@
+<p>
+    The <code>lean cloud live</code> command provides subcommands for managing live trading deployments in the QuantConnect cloud.
+    Use <code>lean cloud live deploy</code> to start a new live deployment, <code>lean cloud live stop</code> to stop a running deployment, and <code>lean cloud live liquidate</code> to stop trading and liquidate all positions.
+</p>
+
+<p>
+    You can also use <code>lean cloud live command</code> to send a custom command to a running live deployment.
+    See the subcommand pages for full details on each operation.
+</p>

--- a/05 Lean CLI/99 API Reference/05 lean cloud live command/02 Description.html
+++ b/05 Lean CLI/99 API Reference/05 lean cloud live command/02 Description.html
@@ -1,0 +1,13 @@
+<p>
+    Sends a custom command to a running cloud live trading project.
+    Use the <code>--data</code> option to pass a JSON string representing the command.
+    The JSON must include a <code>$type</code> field matching a command class defined in your algorithm.
+</p>
+
+<p>
+    Example usage:
+</p>
+
+<div class="cli section-example-container">
+<pre>$ lean cloud live command "My Project" --data "{ \"target\": \"BTCUSD\", \"$type\": \"MyCommand\" }"</pre>
+</div>

--- a/05 Lean CLI/99 API Reference/07 lean cloud live liquidate/02 Description.html
+++ b/05 Lean CLI/99 API Reference/07 lean cloud live liquidate/02 Description.html
@@ -1,0 +1,8 @@
+<p>
+    Stops live trading for the given cloud project and liquidates all existing positions.
+    The <code>&lt;project&gt;</code> argument accepts either the project name or its numeric ID.
+</p>
+
+<p>
+    If you only want to stop trading without liquidating positions, use <a href='/docs/v2/lean-cli/api-reference/lean-cloud-live-stop'><code>lean cloud live stop</code></a> instead.
+</p>

--- a/05 Lean CLI/99 API Reference/08 lean cloud live stop/02 Description.html
+++ b/05 Lean CLI/99 API Reference/08 lean cloud live stop/02 Description.html
@@ -1,0 +1,8 @@
+<p>
+    Stops live trading for the given cloud project without liquidating existing positions.
+    The <code>&lt;project&gt;</code> argument accepts either the project name or its numeric ID.
+</p>
+
+<p>
+    If you want to stop trading and liquidate all positions at the same time, use <a href='/docs/v2/lean-cli/api-reference/lean-cloud-live-liquidate'><code>lean cloud live liquidate</code></a> instead.
+</p>

--- a/05 Lean CLI/99 API Reference/09 lean cloud object-store delete/02 Description.html
+++ b/05 Lean CLI/99 API Reference/09 lean cloud object-store delete/02 Description.html
@@ -1,0 +1,8 @@
+<p>
+    Deletes the value stored under the given <code>&lt;key&gt;</code> from the organization's cloud Object Store.
+    The key must exactly match an existing entry in the Object Store.
+</p>
+
+<p>
+    To view the keys available in the Object Store, use <a href='/docs/v2/lean-cli/api-reference/lean-cloud-object-store-list'><code>lean cloud object-store list</code></a>.
+</p>

--- a/05 Lean CLI/99 API Reference/10 lean cloud object-store get/02 Description.html
+++ b/05 Lean CLI/99 API Reference/10 lean cloud object-store get/02 Description.html
@@ -1,0 +1,10 @@
+<p>
+    Downloads one or more values from the organization's cloud Object Store to your local disk.
+    Provide one or more <code>&lt;key&gt;</code> arguments to select which entries to download.
+    By default, files are saved to the current directory.
+    Use the <code>--destination-folder</code> option to specify a different output folder.
+</p>
+
+<p>
+    To view the keys available in the Object Store, use <a href='/docs/v2/lean-cli/api-reference/lean-cloud-object-store-list'><code>lean cloud object-store list</code></a>.
+</p>

--- a/05 Lean CLI/99 API Reference/11 lean cloud object-store list/02 Description.html
+++ b/05 Lean CLI/99 API Reference/11 lean cloud object-store list/02 Description.html
@@ -1,0 +1,4 @@
+<p>
+    Lists all entries under the given <code>&lt;key&gt;</code> in the organization's cloud Object Store.
+    If you omit the <code>&lt;key&gt;</code> argument, the command lists the contents of the root directory.
+</p>

--- a/05 Lean CLI/99 API Reference/12 lean cloud object-store ls/02 Description.html
+++ b/05 Lean CLI/99 API Reference/12 lean cloud object-store ls/02 Description.html
@@ -1,0 +1,5 @@
+<p>
+    Alias for <a href='/docs/v2/lean-cli/api-reference/lean-cloud-object-store-list'><code>lean cloud object-store list</code></a>.
+    Lists all entries under the given <code>&lt;key&gt;</code> in the organization's cloud Object Store.
+    If you omit the <code>&lt;key&gt;</code> argument, the command lists the contents of the root directory.
+</p>

--- a/05 Lean CLI/99 API Reference/13 lean cloud object-store properties/02 Description.html
+++ b/05 Lean CLI/99 API Reference/13 lean cloud object-store properties/02 Description.html
@@ -1,0 +1,7 @@
+<p>
+    Displays the properties of the value stored under the given <code>&lt;key&gt;</code> in the organization's cloud Object Store, such as its size and last-modified date.
+</p>
+
+<p>
+    To view all available keys, use <a href='/docs/v2/lean-cli/api-reference/lean-cloud-object-store-list'><code>lean cloud object-store list</code></a>.
+</p>

--- a/05 Lean CLI/99 API Reference/14 lean cloud object-store set/02 Description.html
+++ b/05 Lean CLI/99 API Reference/14 lean cloud object-store set/02 Description.html
@@ -1,0 +1,9 @@
+<p>
+    Uploads a local file to the organization's cloud Object Store under the given <code>&lt;key&gt;</code>.
+    The <code>&lt;path&gt;</code> argument specifies the path to the local file to upload.
+    If an entry with the same key already exists, it is overwritten.
+</p>
+
+<p>
+    To verify the upload, use <a href='/docs/v2/lean-cli/api-reference/lean-cloud-object-store-list'><code>lean cloud object-store list</code></a> to view all available keys.
+</p>

--- a/05 Lean CLI/99 API Reference/26 lean decrypt/02 Description.html
+++ b/05 Lean CLI/99 API Reference/26 lean decrypt/02 Description.html
@@ -1,0 +1,9 @@
+<p>
+    Decrypts the files of the given local project using the specified decryption key.
+    Use the <code>--key</code> option to provide the path to the key file.
+    If you don't provide a key, the CLI uses the key stored in the project's <a href='/docs/v2/lean-cli/initialization/configuration#03-Lean-Configuration'>Lean configuration file</a>.
+</p>
+
+<p>
+    To encrypt a project, use <a href='/docs/v2/lean-cli/api-reference/lean-encrypt'><code>lean encrypt</code></a>.
+</p>

--- a/05 Lean CLI/99 API Reference/28 lean encrypt/02 Description.html
+++ b/05 Lean CLI/99 API Reference/28 lean encrypt/02 Description.html
@@ -1,0 +1,9 @@
+<p>
+    Encrypts the files of the given local project using the specified encryption key.
+    Use the <code>--key</code> option to provide the path to the key file.
+    If you don't provide a key, the CLI uses the key stored in the project's <a href='/docs/v2/lean-cli/initialization/configuration#03-Lean-Configuration'>Lean configuration file</a>.
+</p>
+
+<p>
+    To decrypt a project, use <a href='/docs/v2/lean-cli/api-reference/lean-decrypt'><code>lean decrypt</code></a>.
+</p>

--- a/05 Lean CLI/99 API Reference/32 lean live/02 Description.html
+++ b/05 Lean CLI/99 API Reference/32 lean live/02 Description.html
@@ -1,0 +1,9 @@
+<p>
+    The <code>lean live</code> command provides subcommands for managing live trading on your local machine using Docker.
+    Use <code>lean live deploy</code> to start a new local live deployment, <code>lean live stop</code> to stop a running deployment, and <code>lean live liquidate</code> to liquidate positions in a running deployment.
+</p>
+
+<p>
+    You can also interact with a running algorithm using <code>lean live add-security</code>, <code>lean live submit-order</code>, <code>lean live cancel-order</code>, <code>lean live update-order</code>, and <code>lean live command</code>.
+    See the subcommand pages for full details on each operation.
+</p>

--- a/05 Lean CLI/99 API Reference/33 lean live add-security/02 Description.html
+++ b/05 Lean CLI/99 API Reference/33 lean live add-security/02 Description.html
@@ -1,0 +1,9 @@
+<p>
+    Sends a command to a running local live trading algorithm to add a new security subscription.
+    The <code>--ticker</code>, <code>--market</code>, and <code>--security-type</code> options are required.
+    You can optionally configure the resolution, leverage, fill-forward behavior, and extended market hours flag.
+</p>
+
+<p>
+    The algorithm must already be running via <a href='/docs/v2/lean-cli/api-reference/lean-live-deploy'><code>lean live deploy</code></a> before you use this command.
+</p>

--- a/05 Lean CLI/99 API Reference/34 lean live cancel-order/02 Description.html
+++ b/05 Lean CLI/99 API Reference/34 lean live cancel-order/02 Description.html
@@ -1,0 +1,8 @@
+<p>
+    Sends a command to a running local live trading algorithm to cancel a specific open order.
+    The <code>--order-id</code> option is required and must match the ID of the order you want to cancel.
+</p>
+
+<p>
+    The algorithm must already be running via <a href='/docs/v2/lean-cli/api-reference/lean-live-deploy'><code>lean live deploy</code></a> before you use this command.
+</p>

--- a/05 Lean CLI/99 API Reference/35 lean live command/02 Description.html
+++ b/05 Lean CLI/99 API Reference/35 lean live command/02 Description.html
@@ -1,0 +1,13 @@
+<p>
+    Sends a custom command to a running local live trading project.
+    Use the <code>--data</code> option to pass a JSON string representing the command.
+    The JSON must include a <code>$type</code> field matching a command class defined in your algorithm.
+</p>
+
+<p>
+    Example usage:
+</p>
+
+<div class="cli section-example-container">
+<pre>$ lean live command "My Project" --data "{ \"target\": \"BTCUSD\", \"$type\": \"MyCommand\" }"</pre>
+</div>

--- a/05 Lean CLI/99 API Reference/37 lean live liquidate/02 Description.html
+++ b/05 Lean CLI/99 API Reference/37 lean live liquidate/02 Description.html
@@ -1,0 +1,9 @@
+<p>
+    Sends a liquidation command to the latest deployment of the given local live trading project.
+    If you provide the <code>--ticker</code>, <code>--market</code>, and <code>--security-type</code> options, only the matching symbol is liquidated.
+    If you omit those options, all positions in the portfolio are liquidated.
+</p>
+
+<p>
+    To stop a live deployment without liquidating positions, use <a href='/docs/v2/lean-cli/api-reference/lean-live-stop'><code>lean live stop</code></a>.
+</p>

--- a/05 Lean CLI/99 API Reference/38 lean live stop/02 Description.html
+++ b/05 Lean CLI/99 API Reference/38 lean live stop/02 Description.html
@@ -1,0 +1,8 @@
+<p>
+    Stops a running local live trading project without liquidating existing positions.
+    The <code>&lt;project&gt;</code> argument must be the path to the project directory or algorithm file.
+</p>
+
+<p>
+    If you want to stop the deployment and liquidate all positions at the same time, use <a href='/docs/v2/lean-cli/api-reference/lean-live-liquidate'><code>lean live liquidate</code></a> instead.
+</p>

--- a/05 Lean CLI/99 API Reference/39 lean live submit-order/02 Description.html
+++ b/05 Lean CLI/99 API Reference/39 lean live submit-order/02 Description.html
@@ -1,0 +1,10 @@
+<p>
+    Sends a command to a running local live trading algorithm to submit a new order.
+    The <code>--ticker</code>, <code>--market</code>, <code>--security-type</code>, <code>--order-type</code>, and <code>--quantity</code> options are required.
+    For limit and stop orders, provide the <code>--limit-price</code> and <code>--stop-price</code> options as applicable.
+    You can attach a <code>--tag</code> to the order for tracking purposes.
+</p>
+
+<p>
+    The algorithm must already be running via <a href='/docs/v2/lean-cli/api-reference/lean-live-deploy'><code>lean live deploy</code></a> before you use this command.
+</p>

--- a/05 Lean CLI/99 API Reference/40 lean live update-order/02 Description.html
+++ b/05 Lean CLI/99 API Reference/40 lean live update-order/02 Description.html
@@ -1,0 +1,10 @@
+<p>
+    Sends a command to a running local live trading algorithm to update an existing order.
+    The <code>--order-id</code> option is required and must match the ID of the order you want to update.
+    You can update the quantity, limit price, stop price, and tag of the order.
+    Provide only the fields you want to change; omitted fields remain unchanged.
+</p>
+
+<p>
+    The algorithm must already be running via <a href='/docs/v2/lean-cli/api-reference/lean-live-deploy'><code>lean live deploy</code></a> before you use this command.
+</p>

--- a/05 Lean CLI/99 API Reference/44 lean object-store delete/02 Description.html
+++ b/05 Lean CLI/99 API Reference/44 lean object-store delete/02 Description.html
@@ -1,0 +1,4 @@
+<p>
+    Deletes a value from the local Object Store.
+    To view the available keys, use <a href='/docs/v2/lean-cli/api-reference/lean-object-store-list'><code>lean object-store list</code></a>.
+</p>

--- a/05 Lean CLI/99 API Reference/45 lean object-store get/02 Description.html
+++ b/05 Lean CLI/99 API Reference/45 lean object-store get/02 Description.html
@@ -1,0 +1,4 @@
+<p>
+    Downloads a value from the local Object Store to your local disk.
+    To view the available keys, use <a href='/docs/v2/lean-cli/api-reference/lean-object-store-list'><code>lean object-store list</code></a>.
+</p>

--- a/05 Lean CLI/99 API Reference/46 lean object-store list/02 Description.html
+++ b/05 Lean CLI/99 API Reference/46 lean object-store list/02 Description.html
@@ -1,0 +1,3 @@
+<p>
+    Lists all values stored in the local Object Store.
+</p>

--- a/05 Lean CLI/99 API Reference/47 lean object-store ls/02 Description.html
+++ b/05 Lean CLI/99 API Reference/47 lean object-store ls/02 Description.html
@@ -1,0 +1,4 @@
+<p>
+    Alias for <a href='/docs/v2/lean-cli/api-reference/lean-object-store-list'><code>lean object-store list</code></a>.
+    Lists all values stored in the local Object Store.
+</p>

--- a/05 Lean CLI/99 API Reference/48 lean object-store properties/02 Description.html
+++ b/05 Lean CLI/99 API Reference/48 lean object-store properties/02 Description.html
@@ -1,0 +1,7 @@
+<p>
+    Displays the properties of a value stored in the local Object Store, such as its size and last-modified date.
+</p>
+
+<p>
+    To view all available keys, use <a href='/docs/v2/lean-cli/api-reference/lean-object-store-list'><code>lean object-store list</code></a>.
+</p>

--- a/05 Lean CLI/99 API Reference/49 lean object-store set/02 Description.html
+++ b/05 Lean CLI/99 API Reference/49 lean object-store set/02 Description.html
@@ -1,0 +1,4 @@
+<p>
+    Saves a value to the local Object Store.
+    To view the available keys, use <a href='/docs/v2/lean-cli/api-reference/lean-object-store-list'><code>lean object-store list</code></a>.
+</p>

--- a/05 Lean CLI/99 API Reference/51 lean private-cloud add-compute/02 Description.html
+++ b/05 Lean CLI/99 API Reference/51 lean private-cloud add-compute/02 Description.html
@@ -1,0 +1,10 @@
+<p>
+    Adds a compute node to a running private cloud cluster.
+    Use the <code>--token</code>, <code>--master-domain</code>, and <code>--master-port</code> options to connect the node to an existing master server.
+    Use <code>--slave-domain</code> to specify the domain of the node being added.
+    Use <code>--compute</code> to select a compute configuration, and <code>--extra-docker-config</code> to pass additional Docker configuration as a JSON string.
+</p>
+
+<p>
+    Pass <code>--update</code> to pull the latest Docker image before starting, or <code>--stop</code> to stop any existing deployment on this node first.
+</p>

--- a/05 Lean CLI/99 API Reference/52 lean private-cloud start/02 Description.html
+++ b/05 Lean CLI/99 API Reference/52 lean private-cloud start/02 Description.html
@@ -1,0 +1,10 @@
+<p>
+    Starts a new private cloud deployment in a Docker container.
+    Run with <code>--master</code> to start the node as a master server, or <code>--slave</code> to start it as a slave node connected to an existing master.
+    Use <code>--token</code>, <code>--master-domain</code>, and <code>--master-port</code> to configure the connection between master and slave nodes.
+</p>
+
+<p>
+    Use <code>--compute</code> to select a compute configuration and <code>--extra-docker-config</code> to pass additional Docker configuration as a JSON string.
+    Pass <code>--update</code> to pull the latest Docker image before starting, or <code>--stop</code> to stop any existing deployment first.
+</p>

--- a/05 Lean CLI/99 API Reference/53 lean private-cloud stop/02 Description.html
+++ b/05 Lean CLI/99 API Reference/53 lean private-cloud stop/02 Description.html
@@ -1,0 +1,4 @@
+<p>
+    Stops a running private cloud deployment.
+    To start a private cloud, use <a href='/docs/v2/lean-cli/api-reference/lean-private-cloud-start'><code>lean private-cloud start</code></a>.
+</p>


### PR DESCRIPTION
## Summary
- Added `02 Description.html` files for 22 CLI API Reference pages that were missing descriptions
- Covers `lean cloud live`, `lean cloud live liquidate/stop`, `lean cloud object-store` commands, `lean decrypt`, `lean encrypt`, `lean live` group command, `lean live` subcommands (add-security, cancel-order, liquidate, stop, submit-order, update-order), and `lean object-store` commands
- Filled in 8 existing empty description files and created 14 new ones

Resolves #1247

## Test plan
- [ ] Verify the pages render correctly on quantconnect.com/docs with the Description section visible
- [ ] Check all internal links in the description files resolve correctly