### PR TITLE
Add LEAN CLI cheat sheet to Getting Started page

### DIFF
--- a/05 Lean CLI/01 Key Concepts/01 Getting Started/99 Cheat Sheet.html
+++ b/05 Lean CLI/01 Key Concepts/01 Getting Started/99 Cheat Sheet.html
@@ -1,0 +1,5 @@
+<p>The following cheat sheet summarizes the most common LEAN CLI commands, grouped by category.</p>
+
+<img class="docs-image" src="https://cdn.quantconnect.com/docs/i/lean-cli.png" alt="LEAN CLI API Cheat Sheet">
+
+<p>To download a copy of this cheat sheet, <a rel="nofollow" target="_blank" href="https://cdn.quantconnect.com/docs/i/lean-cli.png">click here</a>. For a full reference of all available commands, see the <a href='/docs/v2/lean-cli/api-reference'>API Reference</a>.</p>


### PR DESCRIPTION
## Summary
- Add a "Cheat Sheet" section at the bottom of the Getting Started page (`docs/v2/lean-cli/key-concepts/getting-started`)
- Displays the generated cheat sheet image from `https://cdn.quantconnect.com/docs/i/lean-cli.png`
- Includes a download link and a link to the full API Reference

Resolves #1161

## Test plan
- [ ] Verify the page renders correctly at quantconnect.com/docs/v2/lean-cli/key-concepts/getting-started
- [ ] Confirm the cheat sheet image loads from CDN
- [ ] Check that the download link works
- [ ] Verify the API Reference link resolves