### PR TITLE
Fix C# notebook cell separation, Plotly NuGet refs, and display()

### DIFF
--- a/04 Research Environment/01 Key Concepts/02 Research Engine/06 Import C# Libraries.html
+++ b/04 Research Environment/01 Key Concepts/02 Research Engine/06 Import C# Libraries.html
@@ -11,8 +11,8 @@
     <li>Load the necessary assembly files.</li>
     <div class="section-example-container">
         <pre class="csharp">#load "../QuantConnect.csx"
-#r "../Plotly.NET.dll"
-#r "../Plotly.NET.Interactive.dll"
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"
 #r "../Deedle.dll"</pre>
     </div>
 

--- a/04 Research Environment/03 Datasets/01 Key Concepts/99 Examples.html
+++ b/04 Research Environment/03 Datasets/01 Key Concepts/99 Examples.html
@@ -4,10 +4,14 @@
 <p>The following example studies the trend on the SP500 EMini Future contract. To study the short term supply-demand relationship, we consolidate the data into 5 minute bars and calculate the bid and ask dollar volume.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
-#load "../QuantConnect.csx"
-using QuantConnect;
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.Consolidators;

--- a/04 Research Environment/03 Datasets/04 US Equity/12 Plot Data.html
+++ b/04 Research Environment/03 Datasets/04 US Equity/12 Plot Data.html
@@ -14,8 +14,12 @@
     <li>Import the <code class="python">plotly</code><code class="csharp">Plot.NET</code> library.</li>
     <div class="section-example-container">
         <pre class="python">import plotly.graph_objects as go</pre>
-        <pre class="csharp">#r "../Plotly.NET.dll"
-using Plotly.NET;
+        <pre class="csharp">#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+    </div>
+<div class="csharp section-example-container">
+    <pre class="csharp">using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;</pre>
     </div>
 
@@ -63,7 +67,7 @@ layout.SetValue("title", title);</pre>
     <li>Show the plot.<br></li>
     <div class="section-example-container">
         <pre class="python">fig.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Candlestick charts display the open, high, low, and close prices of the security.</p>
 </ol>
@@ -119,7 +123,7 @@ layout.SetValue("title", title);</pre>
     <li>Show the plot.</li>
     <div class="section-example-container">
         <pre class="python">plt.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Line charts display the value of the property you selected in a time series.</p>
 </ol>

--- a/04 Research Environment/03 Datasets/04 US Equity/99 Examples.html
+++ b/04 Research Environment/03 Datasets/04 US Equity/99 Examples.html
@@ -4,10 +4,16 @@
 <p>The following example studies the candlestick pattern of the SPY. To study the short term pattern, we consolidate the data into 5 minute bars and plot the 5-minute candlestick plot.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using System;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using System;
 using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -17,9 +23,8 @@ using QuantConnect.Algorithm;
 using QuantConnect.Research;
 using QuantConnect.Securities;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -70,7 +75,7 @@ layout.SetValue("title", title);
 // Assign the Layout to the chart.
 chart.WithLayout(layout);
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Import plotly library for plotting.
 import plotly.graph_objects as go
 

--- a/04 Research Environment/03 Datasets/06 Equity Fundamental Data/06 Plot Data.html
+++ b/04 Research Environment/03 Datasets/06 Equity Fundamental Data/06 Plot Data.html
@@ -11,10 +11,11 @@
 
     <li class="csharp">Load the <code>Plotly.NET</code> package.</li>
     <div class="csharp section-example-container">
-        <pre class='csharp'>#r "../Plotly.NET.dll"
-#r "../Plotly.NET.Interactive.dll"
-
-using Plotly.NET;
+        <pre class='csharp'>#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+    </div>
+<div class="csharp section-example-container">
+        <pre class='csharp'>using Plotly.NET;
 using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;</pre>
     </div>
@@ -76,7 +77,7 @@ for symbol, datum in data.items():
     <li>Show the plot.</li>
     <div class="section-example-container">
         <pre class="python">plt.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Line charts display the value of the property you selected in a time series.</p>
 </ol>

--- a/04 Research Environment/03 Datasets/06 Equity Fundamental Data/99 Examples.html
+++ b/04 Research Environment/03 Datasets/06 Equity Fundamental Data/99 Examples.html
@@ -4,18 +4,23 @@
 <p>The following example studies the trend of PE Ratio of AAPL using a line chart.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using QuantConnect;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -54,7 +59,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Create a QuantBook
 qb = QuantBook()
 

--- a/04 Research Environment/03 Datasets/08 Equity Options/02 Universes/99 Examples.html
+++ b/04 Research Environment/03 Datasets/08 Equity Options/02 Universes/99 Examples.html
@@ -4,10 +4,16 @@
 <p>The following example plots a line chart on the implied volatility curve of the closest expiring calls.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using System;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using System;
 using System.Collections.Generic;
 using QuantConnect;
 using QuantConnect.Data;
@@ -16,9 +22,8 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -69,7 +74,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Instantiate a QuantBook instance.
 qb = QuantBook()
 # Set the date being studied.

--- a/04 Research Environment/03 Datasets/08 Equity Options/03 Individual Contracts/99 Examples.html
+++ b/04 Research Environment/03 Datasets/08 Equity Options/03 Individual Contracts/99 Examples.html
@@ -47,10 +47,13 @@ go.Figure(
         xaxis_rangeslider_visible=False
     )
 ).show()</pre>
-    <pre class="csharp">#load "../QuantConnect.csx"
-#r "../Plotly.NET.dll"
-
-using QuantConnect;
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;
@@ -58,6 +61,7 @@ using QuantConnect.Indicators;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities.Option;
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Get the SPY Option chain for January 1, 2024.
@@ -69,10 +73,10 @@ var chain = qb.OptionChain(underlyingSymbol);
 // Select a contract from the chain.
 var expiry = chain.Select(contract => contract.Expiry).Min();
 var contractSymbol = chain
-    .Where(contract => 
-        contract.Expiry == expiry && 
+    .Where(contract =>
+        contract.Expiry == expiry &&
         contract.Right == OptionRight.Call &&
-        contract.Greeks.Delta > 0.3m && 
+        contract.Greeks.Delta > 0.3m &&
         contract.Greeks.Delta < 0.7m
     )
     .OrderByDescending(contract => contract.OpenInterest)
@@ -103,7 +107,7 @@ layout.SetValue("xaxis", xAxis);
 layout.SetValue("yaxis", yAxis);
 layout.SetValue("title", title);
 chart.WithLayout(layout);
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
 </div>
 <img class='python docs-image' src='https://cdn.quantconnect.com/i/tu/equity-options-price-example-python.png' alt='Candlestick plot of the prices for a SPY Option contract'>
 <img class='csharp docs-image' src='https://cdn.quantconnect.com/i/tu/equity-options-price-example-csharp.png' alt='Candlestick plot of the prices for a SPY Option contract'>
@@ -140,10 +144,13 @@ history = history['openinterest'].unstack(0)[contract_symbol]
 # Plot the open interest history.
 history.plot(title=f'{contract_symbol.value} Open Interest')
 plt.show()</pre>
-    <pre class="csharp">#load "../QuantConnect.csx"
-#r "../Plotly.NET.dll"
-
-using QuantConnect;
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;
@@ -151,6 +158,7 @@ using QuantConnect.Indicators;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities.Option;
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Get the TSLA Option chain for January 1, 2024.
@@ -190,7 +198,7 @@ layout.SetValue("xaxis", xAxis);
 layout.SetValue("yaxis", yAxis);
 layout.SetValue("title", title);
 chart.WithLayout(layout);
-HTML(GenericChart.toChartHTML(chart))
+display(chart)
 </pre>
 </div>
 <img class='python docs-image' src='https://cdn.quantconnect.com/i/tu/equity-options-open-interest-example-python.png' alt='Line plot of the open interest for a TSLA Option contract'>

--- a/04 Research Environment/03 Datasets/10 Crypto/10 Plot Data.html
+++ b/04 Research Environment/03 Datasets/10 Crypto/10 Plot Data.html
@@ -14,8 +14,12 @@
     <li>Import the <code class="python">plotly</code><code class="csharp">Plot.NET</code> library.</li>
     <div class="section-example-container">
         <pre class="python">import plotly.graph_objects as go</pre>
-        <pre class="csharp">#r "../Plotly.NET.dll"
-using Plotly.NET;
+        <pre class="csharp">#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+    </div>
+<div class="csharp section-example-container">
+    <pre class="csharp">using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;</pre>
     </div>
 
@@ -66,7 +70,7 @@ layout.SetValue("title", title);</pre>
     <li>Show the <code>Figure</code>.<br></li>
     <div class="section-example-container">
         <pre class="python">fig.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Candlestick charts display the open, high, low, and close prices of the security.</p>
 </ol>
@@ -131,7 +135,7 @@ chart.WithLayout(layout);</pre>
     <li>Show the plot.</li>
     <div class="section-example-container">
         <pre class="python">plt.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Line charts display the value of the property you selected in a time series.</p>
 </ol>

--- a/04 Research Environment/03 Datasets/10 Crypto/99 Examples.html
+++ b/04 Research Environment/03 Datasets/10 Crypto/99 Examples.html
@@ -4,10 +4,16 @@
 <p>The following example studies the candlestick pattern of the BTCUSD. To study the short term pattern, we consolidate the data into 5 minute bars and plot the 5-minute candlestick plot.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using System;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using System;
 using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -17,9 +23,8 @@ using QuantConnect.Algorithm;
 using QuantConnect.Research;
 using QuantConnect.Securities;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -70,7 +75,7 @@ layout.SetValue("title", title);
 // Assign the Layout to the chart.
 chart.WithLayout(layout);
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Import plotly library for plotting.
 import plotly.graph_objects as go
 

--- a/04 Research Environment/03 Datasets/11 Crypto Futures/10 Plot Data.html
+++ b/04 Research Environment/03 Datasets/11 Crypto Futures/10 Plot Data.html
@@ -14,8 +14,12 @@
     <li>Import the <code class="python">plotly</code><code class="csharp">Plot.NET</code> library.</li>
     <div class="section-example-container">
         <pre class="python">import plotly.graph_objects as go</pre>
-        <pre class="csharp">#r "../Plotly.NET.dll"
-using Plotly.NET;
+        <pre class="csharp">#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+    </div>
+<div class="csharp section-example-container">
+    <pre class="csharp">using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;</pre>
     </div>
 
@@ -66,7 +70,7 @@ layout.SetValue("title", title);</pre>
     <li>Show the <code>Figure</code>.<br></li>
     <div class="section-example-container">
         <pre class="python">fig.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Candlestick charts display the open, high, low, and close prices of the security.</p>
 </ol>
@@ -131,7 +135,7 @@ chart.WithLayout(layout);</pre>
     <li>Show the plot.</li>
     <div class="section-example-container">
         <pre class="python">plt.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Line charts display the value of the property you selected in a time series.</p>
 </ol>

--- a/04 Research Environment/03 Datasets/11 Crypto Futures/99 Examples.html
+++ b/04 Research Environment/03 Datasets/11 Crypto Futures/99 Examples.html
@@ -4,10 +4,16 @@
 <p>The following example studies the candlestick pattern of the BTCUSDT Future. To study the short term pattern, we consolidate the data into 5 minute bars and plot the 5-minute candlestick plot.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using System;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using System;
 using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -17,9 +23,8 @@ using QuantConnect.Algorithm;
 using QuantConnect.Research;
 using QuantConnect.Securities;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -70,7 +75,7 @@ layout.SetValue("title", title);
 // Assign the Layout to the chart.
 chart.WithLayout(layout);
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Import plotly library for plotting.
 import plotly.graph_objects as go
 

--- a/04 Research Environment/03 Datasets/12 Futures/02 Universes/99 Examples.html
+++ b/04 Research Environment/03 Datasets/12 Futures/02 Universes/99 Examples.html
@@ -4,10 +4,16 @@
 <p>The following example studies the candlestick pattern of the ES Future. To study the short term pattern, we consolidate the data into 5 minute bars and plot the 5-minute candlestick plot.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using System;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using System;
 using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -17,9 +23,8 @@ using QuantConnect.Algorithm;
 using QuantConnect.Research;
 using QuantConnect.Securities;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -75,7 +80,7 @@ layout.SetValue("title", title);
 // Assign the Layout to the chart.
 chart.WithLayout(layout);
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Import plotly library for plotting.
 import plotly.graph_objects as go
 

--- a/04 Research Environment/03 Datasets/12 Futures/03 Individual Contracts/99 Examples.html
+++ b/04 Research Environment/03 Datasets/12 Futures/03 Individual Contracts/99 Examples.html
@@ -35,18 +35,21 @@ go.Figure(
     <pre class="csharp">#load "../Initialize.csx"</pre>
 </div>
 <div class="csharp section-example-container">
-    <pre class="csharp">#r "../Plotly.NET.dll"
-using Plotly.NET;
-using Plotly.NET.LayoutObjects;</pre>
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
 </div>
 <div class="csharp section-example-container">
-    <pre class="csharp">#load "../QuantConnect.csx"
-using QuantConnect;
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Research;
 using QuantConnect.Securities;
 using QuantConnect.Data.Market;
-    
+using Plotly.NET;
+using Plotly.NET.Interactive;
+using Plotly.NET.LayoutObjects;
+
 var qb = new QuantBook();
 // Get the front-month ES contract as of December 31, 2021.
 var future = qb.AddFuture(Futures.Indices.SP500EMini);
@@ -75,7 +78,7 @@ layout.SetValue("yaxis", yAxis);
 layout.SetValue("title", title);
 
 chart.WithLayout(layout);
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
 </div>
 
 <img class="python docs-image" src="https://cdn.quantconnect.com/i/tu/futures-candlestick-plot.jpg" alt="Candlestick plot of ES18H22 OHLC">
@@ -106,18 +109,21 @@ closing_prices.plot(title="Close", figsize=(15, 8));
     <pre class="csharp">#load "../Initialize.csx"</pre>
 </div>
 <div class="csharp section-example-container">
-    <pre class="csharp">#r "../Plotly.NET.dll"
-using Plotly.NET;
-using Plotly.NET.LayoutObjects;</pre>
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
 </div>
 <div class="csharp section-example-container">
-    <pre class="csharp">#load "../QuantConnect.csx"
-using QuantConnect;
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Research;
 using QuantConnect.Securities;
 using QuantConnect.Data.Market;
-    
+using Plotly.NET;
+using Plotly.NET.Interactive;
+using Plotly.NET.LayoutObjects;
+
 var qb = new QuantBook();
 // Get the front-month ES contract as of December 31, 2021.
 var future = qb.AddFuture(Futures.Indices.SP500EMini);
@@ -143,7 +149,7 @@ layout.SetValue("yaxis", yAxis);
 layout.SetValue("title", title);
 
 chart.WithLayout(layout);
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
 </div>
 
 <img class="python docs-image" src="https://cdn.quantconnect.com/i/tu/futures-line-plot.jpg" alt="Line chart of close price of Future contracts">

--- a/04 Research Environment/03 Datasets/14 Futures Options/02 Universes/99 Examples.html
+++ b/04 Research Environment/03 Datasets/14 Futures Options/02 Universes/99 Examples.html
@@ -4,10 +4,16 @@
 <p>The following example plots a line chart on the implied volatility curve of the closest expiring calls.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using System;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using System;
 using System.Collections.Generic;
 using QuantConnect;
 using QuantConnect.Data;
@@ -16,9 +22,8 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -73,7 +78,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Instantiate a QuantBook instance.
 qb = QuantBook()
 # Set the date being studied.

--- a/04 Research Environment/03 Datasets/14 Futures Options/03 Individual Contracts/99 Examples.html
+++ b/04 Research Environment/03 Datasets/14 Futures Options/03 Individual Contracts/99 Examples.html
@@ -51,10 +51,13 @@ go.Figure(
         xaxis_rangeslider_visible=False
     )
 ).show()</pre>
-    <pre class="csharp">#load "../QuantConnect.csx"
-#r "../Plotly.NET.dll"
-
-using QuantConnect;
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;
@@ -62,6 +65,7 @@ using QuantConnect.Indicators;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Add the underlying Future contract 
@@ -109,7 +113,7 @@ layout.SetValue("xaxis", xAxis);
 layout.SetValue("yaxis", yAxis);
 layout.SetValue("title", title);
 chart.WithLayout(layout);
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
 </div>
 <img class='python docs-image' src='https://cdn.quantconnect.com/i/tu/future-options-price-example-python.png' alt='Candlestick plot of the prices for an ES Future Option contract'>
 <img class='csharp docs-image' src='https://cdn.quantconnect.com/i/tu/future-options-price-example-csharp.png' alt='Candlestick plot of the prices for an ES Future Option contract'>

--- a/04 Research Environment/03 Datasets/16 Forex/10 Plot Data.html
+++ b/04 Research Environment/03 Datasets/16 Forex/10 Plot Data.html
@@ -14,8 +14,12 @@
     <li>Import the <code class="python">plotly</code><code class="csharp">Plot.NET</code> library.</li>
     <div class="section-example-container">
         <pre class="python">import plotly.graph_objects as go</pre>
-        <pre class="csharp">#r "../Plotly.NET.dll"
-using Plotly.NET;
+        <pre class="csharp">#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+    </div>
+<div class="csharp section-example-container">
+    <pre class="csharp">using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;</pre>
     </div>
 
@@ -66,7 +70,7 @@ layout.SetValue("title", title);</pre>
     <li>Show the <code>Figure</code>.<br></li>
     <div class="section-example-container">
         <pre class="python">fig.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Candlestick charts display the open, high, low, and close prices of the security.</p>
 </ol>
@@ -131,7 +135,7 @@ chart.WithLayout(layout);</pre>
     <li>Show the plot.</li>
     <div class="section-example-container">
         <pre class="python">plt.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Line charts display the value of the property you selected in a time series.</p>
 </ol>

--- a/04 Research Environment/03 Datasets/16 Forex/99 Examples.html
+++ b/04 Research Environment/03 Datasets/16 Forex/99 Examples.html
@@ -4,10 +4,16 @@
 <p>The following example studies the candlestick pattern of the USDJPY. To study the short term pattern, we consolidate the data into 5 minute bars and plot the 5-minute candlestick plot, using the mid prices.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using System;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using System;
 using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -17,9 +23,8 @@ using QuantConnect.Algorithm;
 using QuantConnect.Research;
 using QuantConnect.Securities;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -70,7 +75,7 @@ layout.SetValue("title", title);
 // Assign the Layout to the chart.
 chart.WithLayout(layout);
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Import plotly library for plotting.
 import plotly.graph_objects as go
 

--- a/04 Research Environment/03 Datasets/18 CFD/10 Plot Data.html
+++ b/04 Research Environment/03 Datasets/18 CFD/10 Plot Data.html
@@ -14,8 +14,12 @@
     <li>Import the <code class="python">plotly</code><code class="csharp">Plot.NET</code> library.</li>
     <div class="section-example-container">
         <pre class="python">import plotly.graph_objects as go</pre>
-        <pre class="csharp">#r "../Plotly.NET.dll"
-using Plotly.NET;
+        <pre class="csharp">#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+    </div>
+<div class="csharp section-example-container">
+    <pre class="csharp">using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;</pre>
     </div>
 
@@ -66,7 +70,7 @@ layout.SetValue("title", title);</pre>
     <li>Show the <code>Figure</code>.<br></li>
     <div class="section-example-container">
         <pre class="python">fig.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Candlestick charts display the open, high, low, and close prices of the security.</p>
 </ol>
@@ -131,7 +135,7 @@ chart.WithLayout(layout);</pre>
     <li>Show the plot.</li>
     <div class="section-example-container">
         <pre class="python">plt.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Line charts display the value of the property you selected in a time series.</p>
 </ol>

--- a/04 Research Environment/03 Datasets/18 CFD/99 Examples.html
+++ b/04 Research Environment/03 Datasets/18 CFD/99 Examples.html
@@ -4,10 +4,16 @@
 <p>The following example studies the candlestick pattern of the XAUUSD. To study the short term pattern, we consolidate the data into 5 minute bars and plot the 5-minute candlestick plot, using the mid prices.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using System;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using System;
 using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -17,9 +23,8 @@ using QuantConnect.Algorithm;
 using QuantConnect.Research;
 using QuantConnect.Securities;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -70,7 +75,7 @@ layout.SetValue("title", title);
 // Assign the Layout to the chart.
 chart.WithLayout(layout);
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Import plotly library for plotting.
 import plotly.graph_objects as go
 

--- a/04 Research Environment/03 Datasets/20 Indices/10 Plot Data.html
+++ b/04 Research Environment/03 Datasets/20 Indices/10 Plot Data.html
@@ -14,8 +14,12 @@
     <li>Import the <code class="python">plotly</code><code class="csharp">Plot.NET</code> library.</li>
     <div class="section-example-container">
         <pre class="python">import plotly.graph_objects as go</pre>
-        <pre class="csharp">#r "../Plotly.NET.dll"
-using Plotly.NET;
+        <pre class="csharp">#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+    </div>
+<div class="csharp section-example-container">
+    <pre class="csharp">using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;</pre>
     </div>
 
@@ -66,7 +70,7 @@ layout.SetValue("title", title);</pre>
     <li>Show the <code>Figure</code>.<br></li>
     <div class="section-example-container">
         <pre class="python">fig.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Candlestick charts display the open, high, low, and close prices of the security.</p>
 </ol>
@@ -131,7 +135,7 @@ chart.WithLayout(layout);</pre>
     <li>Show the plot.</li>
     <div class="section-example-container">
         <pre class="python">plt.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Line charts display the value of the property you selected in a time series.</p>
 </ol>

--- a/04 Research Environment/03 Datasets/20 Indices/99 Examples.html
+++ b/04 Research Environment/03 Datasets/20 Indices/99 Examples.html
@@ -4,10 +4,16 @@
 <p>The following example studies the candlestick pattern of the SPX. To study the short term pattern, we consolidate the data into 5 minute bars and plot the 5-minute candlestick plot.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using System;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using System;
 using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -17,9 +23,8 @@ using QuantConnect.Algorithm;
 using QuantConnect.Research;
 using QuantConnect.Securities;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -70,7 +75,7 @@ layout.SetValue("title", title);
 // Assign the Layout to the chart.
 chart.WithLayout(layout);
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Import plotly library for plotting.
 import plotly.graph_objects as go
 

--- a/04 Research Environment/03 Datasets/22 Index Options/02 Universes/99 Examples.html
+++ b/04 Research Environment/03 Datasets/22 Index Options/02 Universes/99 Examples.html
@@ -4,10 +4,16 @@
 <p>The following example plots a line chart on the implied volatility curve of the closest expiring calls.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using System;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using System;
 using System.Collections.Generic;
 using QuantConnect;
 using QuantConnect.Data;
@@ -16,9 +22,8 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -70,7 +75,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Instantiate a QuantBook instance.
 qb = QuantBook()
 # Set the date being studied.

--- a/04 Research Environment/03 Datasets/22 Index Options/03 Individual Contracts/99 Examples.html
+++ b/04 Research Environment/03 Datasets/22 Index Options/03 Individual Contracts/99 Examples.html
@@ -49,10 +49,13 @@ go.Figure(
         xaxis_rangeslider_visible=False
     )
 ).show()</pre>
-    <pre class="csharp">#load "../QuantConnect.csx"
-#r "../Plotly.NET.dll"
-
-using QuantConnect;
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;
@@ -60,6 +63,7 @@ using QuantConnect.Indicators;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities.Option;
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Get the SPX Option chain for January 1, 2024.
@@ -107,7 +111,7 @@ layout.SetValue("xaxis", xAxis);
 layout.SetValue("yaxis", yAxis);
 layout.SetValue("title", title);
 chart.WithLayout(layout);
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
 </div>
 <img class='python docs-image' src='https://cdn.quantconnect.com/i/tu/index-options-price-example-python.png' alt='Candlestick plot of the prices for an SPX Index Option contract'>
 <img class='csharp docs-image' src='https://cdn.quantconnect.com/i/tu/index-options-price-example-csharp.png' alt='Candlestick plot of the prices for an SPX Index Option contract'>
@@ -146,10 +150,13 @@ history = history['openinterest'].unstack(0)[contract_symbol]
 # Plot the open interest history.
 history.plot(title=f'{contract_symbol.value} Open Interest')
 plt.show()</pre>
-    <pre class="csharp">#load "../QuantConnect.csx"
-#r "../Plotly.NET.dll"
-
-using QuantConnect;
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;
@@ -157,6 +164,7 @@ using QuantConnect.Indicators;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities.Option;
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Get the VIX weekly Option chain for January 1, 2024.
@@ -198,7 +206,7 @@ layout.SetValue("xaxis", xAxis);
 layout.SetValue("yaxis", yAxis);
 layout.SetValue("title", title);
 chart.WithLayout(layout);
-HTML(GenericChart.toChartHTML(chart))
+display(chart)
 </pre>
 </div>
 <img class='python docs-image' src='https://cdn.quantconnect.com/i/tu/index-options-open-interest-example-python.png' alt='Line plot of the open interest for a VIWX Index Option contract'>

--- a/04 Research Environment/03 Datasets/24 Alternative Data/03 Create Subscriptions.html
+++ b/04 Research Environment/03 Datasets/24 Alternative Data/03 Create Subscriptions.html
@@ -3,11 +3,14 @@
 <ol>
     <li class="csharp">Load the required assembly files and data types.</li>
     <div class="csharp section-example-container">
-        <pre class="csharp">#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-#r "../Microsoft.Data.Analysis.dll"
-
-using QuantConnect;
+        <pre class="csharp">#load "../Initialize.csx"</pre>
+    </div>
+    <div class="csharp section-example-container">
+        <pre class="csharp">#load "../QuantConnect.csx"
+#r "../Microsoft.Data.Analysis.dll"</pre>
+    </div>
+    <div class="csharp section-example-container">
+        <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;

--- a/04 Research Environment/03 Datasets/24 Alternative Data/07 Plot Data.html
+++ b/04 Research Environment/03 Datasets/24 Alternative Data/07 Plot Data.html
@@ -14,8 +14,12 @@
     <li>Import the <code class="python">plotly</code><code class="csharp">Plot.NET</code> library.</li>
     <div class="section-example-container">
         <pre class="python">import plotly.graph_objects as go</pre>
-        <pre class="csharp">#r "../Plotly.NET.dll"
-using Plotly.NET;
+        <pre class="csharp">#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+    </div>
+<div class="csharp section-example-container">
+    <pre class="csharp">using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;</pre>
     </div>
 
@@ -66,7 +70,7 @@ layout.SetValue("title", title);</pre>
     <li>Show the <code>Figure</code>.<br></li>
     <div class="section-example-container">
         <pre class="python">fig.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Candlestick charts display the open, high, low, and close prices of the alternative data.</p>
 </ol>
@@ -131,7 +135,7 @@ chart.WithLayout(layout);</pre>
     <li>Show the plot.</li>
     <div class="section-example-container">
         <pre class="python">plt.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Line charts display the value of the property you selected in a time series.</p>
 </ol>

--- a/04 Research Environment/03 Datasets/24 Alternative Data/99 Examples.html
+++ b/04 Research Environment/03 Datasets/24 Alternative Data/99 Examples.html
@@ -4,18 +4,23 @@
 <p>The following example studies the trend of 10-year yield curve using a line chart.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types in a separate cell.
-#load "../Initialize.csx"
-
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-using QuantConnect;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.DataSource;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;
 
-// Import Plotly for plotting.
-#r "../Plotly.NET.dll"
 using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
 
 // Create a QuantBook.
@@ -54,7 +59,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Create a QuantBook
 qb = QuantBook()
 

--- a/04 Research Environment/03 Datasets/26 Custom Data/03 Define Custom Data.html
+++ b/04 Research Environment/03 Datasets/26 Custom Data/03 Define Custom Data.html
@@ -4,11 +4,14 @@
 
 
 <div class="section-example-container">
-    <pre class="csharp">#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-#r "../Microsoft.Data.Analysis.dll"
-
-using QuantConnect;
+    <pre class="csharp">#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">#load "../QuantConnect.csx"
+#r "../Microsoft.Data.Analysis.dll"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;

--- a/04 Research Environment/03 Datasets/26 Custom Data/07 Plot Data.html
+++ b/04 Research Environment/03 Datasets/26 Custom Data/07 Plot Data.html
@@ -14,8 +14,12 @@
     <li>Import the <code class="python">plotly</code><code class="csharp">Plot.NET</code> library.</li>
     <div class="section-example-container">
         <pre class="python">import plotly.graph_objects as go</pre>
-        <pre class="csharp">#r "../Plotly.NET.dll"
-using Plotly.NET;
+        <pre class="csharp">#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+    </div>
+<div class="csharp section-example-container">
+    <pre class="csharp">using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;</pre>
     </div>
 
@@ -66,7 +70,7 @@ layout.SetValue("title", title);</pre>
     <li>Show the <code>Figure</code>.<br></li>
     <div class="section-example-container">
         <pre class="python">fig.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Candlestick charts display the open, high, low, and close prices of the security.</p>
 </ol>
@@ -118,7 +122,7 @@ layout.SetValue("title", title);</pre>
     <li>Show the plot.</li>
     <div class="section-example-container">
         <pre class="python">plt.show()</pre>
-        <pre class="csharp">HTML(GenericChart.toChartHTML(chart))</pre>
+        <pre class="csharp">display(chart)</pre>
     </div>
     <p>Line charts display the value of the property you selected in a time series.</p>
 </ol>

--- a/04 Research Environment/04 Charting/05 Plotly NET/02 Preparation.html
+++ b/04 Research Environment/04 Charting/05 Plotly NET/02 Preparation.html
@@ -4,21 +4,23 @@
 
 <div class="section-example-container">
     <pre class="csharp">// Load the assembly files and data types in their own cell.
-#load "../Initialize.csx"
-
-// Load the necessary assembly files.
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-#r "../Plotly.NET.dll"
-#r "../Plotly.NET.Interactive.dll"
-
-// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
 using QuantConnect;
 using QuantConnect.Research;
-            
+
 using Plotly.NET;
 using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
-            
+
 using Accord.Math;
 using Accord.Statistics;</pre>
 </div>

--- a/04 Research Environment/04 Charting/05 Plotly NET/05 Create Candlestick Chart.html
+++ b/04 Research Environment/04 Charting/05 Plotly NET/05 Create Candlestick Chart.html
@@ -32,7 +32,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Show the plot.
-HTML(GenericChart.toChartHTML(chart));</pre>
+display(chart);</pre>
 </div>
 
 <p>The Jupyter Notebook displays the candlestick chart.</p>

--- a/04 Research Environment/04 Charting/05 Plotly NET/06 Create Line Chart.html
+++ b/04 Research Environment/04 Charting/05 Plotly NET/06 Create Line Chart.html
@@ -29,7 +29,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Show the plot.
-HTML(GenericChart.toChartHTML(chart));</pre>
+display(chart);</pre>
 </div>
 
 <p>The Jupyter Notebook displays the line chart.</p>

--- a/04 Research Environment/04 Charting/05 Plotly NET/07 Create Scatter Plot.html
+++ b/04 Research Environment/04 Charting/05 Plotly NET/07 Create Scatter Plot.html
@@ -29,7 +29,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Show the plot.
-HTML(GenericChart.toChartHTML(chart));</pre>
+display(chart);</pre>
 </div>
 
 <p>The Jupyter Notebook displays the scatter plot.</p>

--- a/04 Research Environment/04 Charting/05 Plotly NET/10 Create Heat Map.html
+++ b/04 Research Environment/04 Charting/05 Plotly NET/10 Create Heat Map.html
@@ -41,7 +41,7 @@ layout.SetValue("title", Title.init("Banking Stocks and bank sector ETF Correlat
 heatmap.WithLayout(layout);
 
 // Show the plot.
-HTML(GenericChart.toChartHTML(heatmap))</pre>
+display(heatmap)</pre>
 </div>
 
 <p>The Jupyter Notebook displays the heat map.</p>

--- a/04 Research Environment/04 Charting/05 Plotly NET/11 Create 3D Chart.html
+++ b/04 Research Environment/04 Charting/05 Plotly NET/11 Create 3D Chart.html
@@ -35,7 +35,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Show the plot.
-HTML(GenericChart.toChartHTML(heatmap))</pre>
+display(chart)</pre>
 </div>
 
 <p>The Jupyter Notebook displays the scatter plot.</p>

--- a/04 Research Environment/05 Universes/99 Examples.html
+++ b/04 Research Environment/05 Universes/99 Examples.html
@@ -4,10 +4,16 @@
 <p>The below example studies the top-minus-bottom PE Ratio universe, in which the top 10 PE Ratio stocks are brought, and the bottom 10 are sold in equal weighting daily. We carry out a mini-backtest to analyze its performance.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the required assembly files and data types.
-#load "../Initialize.csx"
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-
-using QuantConnect;
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Algorithm;
@@ -98,7 +104,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Instantiate the QuantBook instance for researching.
 qb = QuantBook()
 

--- a/04 Research Environment/06 Indicators/02 Data Point Indicators/99 Examples.html
+++ b/04 Research Environment/06 Indicators/02 Data Point Indicators/99 Examples.html
@@ -4,14 +4,16 @@
 <p>The following example demonstrates a quick backtest to testify the effectiveness of a Bollinger Band mean-reversal under the research enviornment.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the assembly files and data types in their own cell. 
-#load "../Initialize.csx"
-
-// Load the necessary assembly files. 
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files. 
 #load "../QuantConnect.csx"
 #r "nuget: Plotly.NET"
-#r "nuget: Plotly.NET.Interactive"
-
-// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
 using QuantConnect;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;

--- a/04 Research Environment/06 Indicators/03 Bar Indicators/99 Examples.html
+++ b/04 Research Environment/06 Indicators/03 Bar Indicators/99 Examples.html
@@ -4,14 +4,16 @@
 <p>The following example demonstrates a quick backtest to testify the effectiveness of a William Percent Ratio mean-reversal under the research enviornment.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the assembly files and data types in their own cell. 
-#load "../Initialize.csx"
-
-// Load the necessary assembly files. 
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files. 
 #load "../QuantConnect.csx"
 #r "nuget: Plotly.NET"
-#r "nuget: Plotly.NET.Interactive"
-
-// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
 using QuantConnect;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;

--- a/04 Research Environment/06 Indicators/04 Trade Bar Indicators/99 Examples.html
+++ b/04 Research Environment/06 Indicators/04 Trade Bar Indicators/99 Examples.html
@@ -4,14 +4,16 @@
 <p>The following example demonstrates a quick backtest to testify the effectiveness of a Money Flow Index mean-reversal under the research enviornment.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the assembly files and data types in their own cell. 
-#load "../Initialize.csx"
-
-// Load the necessary assembly files. 
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files. 
 #load "../QuantConnect.csx"
 #r "nuget: Plotly.NET"
-#r "nuget: Plotly.NET.Interactive"
-
-// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
 using QuantConnect;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;

--- a/04 Research Environment/06 Indicators/05 Combining Indicators/99 Examples.html
+++ b/04 Research Environment/06 Indicators/05 Combining Indicators/99 Examples.html
@@ -4,18 +4,20 @@
 <p>The following example demonstrates a quick backtest to testify the effectiveness of a Standard Deviation On Return mean-reversal under the research enviornment.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the assembly files and data types in their own cell.
-#load "../Initialize.csx"
-
-// Load the necessary assembly files.
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-#r "../Plotly.NET.dll"
-#r "../Plotly.NET.Interactive.dll"
-
-// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
 using QuantConnect;
 using QuantConnect.Indicators;
 using QuantConnect.Research;
-            
+
 using Plotly.NET;
 using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
@@ -66,7 +68,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Instantiate the QuantBook instance for researching.
 qb = QuantBook()
 # Request SPY data to work with the indicator.

--- a/04 Research Environment/06 Indicators/06 Custom Indicators/99 Examples.html
+++ b/04 Research Environment/06 Indicators/06 Custom Indicators/99 Examples.html
@@ -4,18 +4,20 @@
 <p>The following example demonstrates researching using a custom-constructed Expected Shortfall indicator. Expected Shortfall refers to the average of the N% worst-case return.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the assembly files and data types in their own cell.
-#load "../Initialize.csx"
-
-// Load the necessary assembly files.
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-#r "../Plotly.NET.dll"
-#r "../Plotly.NET.Interactive.dll"
-
-// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
 using QuantConnect;
 using QuantConnect.Indicators;
 using QuantConnect.Research;
-            
+
 using Plotly.NET;
 using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
@@ -117,7 +119,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Instantiate the QuantBook instance for researching.
 qb = QuantBook()
 # Request SPY data to work with the indicator.

--- a/04 Research Environment/06 Indicators/07 Custom Resolutions/99 Examples.html
+++ b/04 Research Environment/06 Indicators/07 Custom Resolutions/99 Examples.html
@@ -4,18 +4,20 @@
 <p>The following example demonstrates a quick backtest to testify the effectiveness of a Bollinger Band mean-reversal, using 5-miunte bar under the research enviornment.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the assembly files and data types in their own cell.
-#load "../Initialize.csx"
-
-// Load the necessary assembly files.
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
 #load "../QuantConnect.csx"
-#r "../Plotly.NET.dll"
-#r "../Plotly.NET.Interactive.dll"
-
-// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
+#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Import the QuantConnect, Plotly.NET, and Accord packages for calculation and plotting.
 using QuantConnect;
 using QuantConnect.Indicators;
 using QuantConnect.Research;
-            
+
 using Plotly.NET;
 using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;
@@ -108,7 +110,7 @@ layout.SetValue("title", title);
 chart.WithLayout(layout);
 
 // Display the plot.
-HTML(GenericChart.toChartHTML(chart))</pre>
+display(chart)</pre>
     <pre class="python"># Instantiate the QuantBook instance for researching.
 qb = QuantBook()
 # Request SPY data to work with the indicator.

--- a/04 Research Environment/10 Meta Analysis/02 Backtest Analysis/02 Read Backtest Results.php
+++ b/04 Research Environment/10 Meta Analysis/02 Backtest Analysis/02 Read Backtest Results.php
@@ -1,10 +1,13 @@
 <p>To get the results of a backtest, call the <code class="csharp">ReadBacktest</code><code class="python">read_backtest</code> method with the project Id and backtest ID.</p>
 
 <div class="section-example-container">
-    <pre class="csharp">#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-
-using QuantConnect;
+    <pre class="csharp">#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">#load "../QuantConnect.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Api;
 
 var backtest = api.ReadBacktest(projectId, backtestId);</pre>

--- a/04 Research Environment/10 Meta Analysis/02 Backtest Analysis/99 Examples.html
+++ b/04 Research Environment/10 Meta Analysis/02 Backtest Analysis/99 Examples.html
@@ -2,10 +2,14 @@
 <p>The following example reads the last completed backtest statistics in a jupyter notebook.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the necessary assemblies.
-#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-
-using QuantConnect;
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Api;
 using QuantConnect.Research;
 

--- a/04 Research Environment/10 Meta Analysis/03 Optimization Analysis/99 Example.html
+++ b/04 Research Environment/10 Meta Analysis/03 Optimization Analysis/99 Example.html
@@ -2,10 +2,14 @@
 <p>The following example reads the last completed optimization job and obtains the optimum paramteters in a jupyter notebook.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the necessary assemblies.
-#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-
-using QuantConnect;
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Api;
 using QuantConnect.Research;
 

--- a/04 Research Environment/10 Meta Analysis/04 Live Analysis/02 Read Live Results.php
+++ b/04 Research Environment/10 Meta Analysis/04 Live Analysis/02 Read Live Results.php
@@ -1,10 +1,13 @@
 <p>To get the results of a live algorithm, call the <code class="csharp">ReadLiveAlgorithm</code><code class="python">read_live_algorithm</code> method with the project Id and deployment ID.</p>
 
 <div class="section-example-container">
-    <pre class="csharp">#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-
-using QuantConnect;
+    <pre class="csharp">#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">#load "../QuantConnect.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Api;
 
 var liveAlgorithm = api.ReadLiveAlgorithm(projectId, deployId);</pre>

--- a/04 Research Environment/10 Meta Analysis/04 Live Analysis/99 Example.html
+++ b/04 Research Environment/10 Meta Analysis/04 Live Analysis/99 Example.html
@@ -2,10 +2,14 @@
 <p>The following example reads the current running live algorithm's statistics in a jupyter notebook.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the necessary assemblies.
-#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-
-using QuantConnect;
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Api;
 using QuantConnect.Research;
 

--- a/04 Research Environment/10 Meta Analysis/06 Live Deployment Automation/99 Examples.html
+++ b/04 Research Environment/10 Meta Analysis/06 Live Deployment Automation/99 Examples.html
@@ -2,10 +2,14 @@
 <p>The following example will create a new live algorithm deployment using a GPU live node with the <a rel='nofollow' target='_blank' href='https://qnt.co/interactivebrokers'>Interactive Brokers</a> in a jupyter notebook. It can help with a streamline deployment.</p>
 <div class="section-example-container">
     <pre class="csharp">// Load the necessary assemblies.
-#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-
-using QuantConnect;
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Api;
 using QuantConnect.Research;
 

--- a/04 Research Environment/12 Applying Research/02 Mean Reversion/04 Import Libraries.html
+++ b/04 Research Environment/12 Applying Research/02 Mean Reversion/04 Import Libraries.html
@@ -2,10 +2,15 @@
 <p class="python">We'll need to import libraries to help with data processing. Import <code>numpy</code> and <code>scipy</code> libraries by the following:</p>
 
 <div class="section-example-container">
-    <pre class="csharp">#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-
-using QuantConnect;
+    <pre class="csharp">// Load the required assembly files and data types in a separate cell.
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Algorithm;

--- a/04 Research Environment/12 Applying Research/02 Mean Reversion/99 Examples.html
+++ b/04 Research Environment/12 Applying Research/02 Mean Reversion/99 Examples.html
@@ -1,10 +1,14 @@
 <p>The below code snippets concludes the above jupyter research notebook content.</p>
 <div class="section-example-container skip-test">
     <pre class="csharp">// Load the required assembly files and data types.
-#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-
-using QuantConnect;
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Algorithm;

--- a/04 Research Environment/12 Applying Research/04 Uncorrelated Assets/04 Import Libraries.html
+++ b/04 Research Environment/12 Applying Research/04 Uncorrelated Assets/04 Import Libraries.html
@@ -2,10 +2,15 @@
 <p class="python">We'll need to import libraries to help with data processing and visualization. Import <code>numpy</code> and <code>matplotlib</code> libraries by the following:</p>
 
 <div class="section-example-container">
-    <pre class="csharp">#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-
-using QuantConnect;
+    <pre class="csharp">// Load the required assembly files and data types in a separate cell.
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Algorithm;

--- a/04 Research Environment/12 Applying Research/04 Uncorrelated Assets/99 Examples.html
+++ b/04 Research Environment/12 Applying Research/04 Uncorrelated Assets/99 Examples.html
@@ -1,10 +1,14 @@
 <p>The below code snippets concludes the above jupyter research notebook content.</p>
 <div class="section-example-container skip-test">
     <pre class="csharp">// Load the required assembly files and data types.
-#load "../Initialize.csx"
-#load "../QuantConnect.csx"
-
-using QuantConnect;
+#load "../Initialize.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">// Load the necessary assembly files.
+#load "../QuantConnect.csx"</pre>
+</div>
+<div class="section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Algorithm;

--- a/Resources/datasets/research-environment/load-csharp-assemblies.php
+++ b/Resources/datasets/research-environment/load-csharp-assemblies.php
@@ -2,12 +2,14 @@
 <div class="csharp section-example-container">
     <pre class="csharp">#load "../Initialize.csx"</pre>
 </div>
-<li class="csharp">Import the data types.</li>
+<li class="csharp">Load the necessary assembly files.</li>
 <div class="csharp section-example-container">
     <pre class="csharp">#load "../QuantConnect.csx"
-#r "../Microsoft.Data.Analysis.dll"
-
-using QuantConnect;
+#r "../Microsoft.Data.Analysis.dll"</pre>
+</div>
+<li class="csharp">Import the data types.</li>
+<div class="csharp section-example-container">
+    <pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;

--- a/Resources/getting-started/research-environment/example.html
+++ b/Resources/getting-started/research-environment/example.html
@@ -21,8 +21,10 @@ bbdf[['price', 'lowerband', 'middleband', 'upperband']].plot();</pre>
 </div>
 
 <div class="csharp section-example-container">
-	<pre class="csharp">#load "../QuantConnect.csx"
-using QuantConnect;
+	<pre class="csharp">#load "../QuantConnect.csx"</pre>
+</div>
+<div class="csharp section-example-container">
+	<pre class="csharp">using QuantConnect;
 using QuantConnect.Data;
 using QuantConnect.Algorithm;
 using QuantConnect.Research;

--- a/Resources/object-store/example_logging.php
+++ b/Resources/object-store/example_logging.php
@@ -97,11 +97,14 @@
 
     <div class='section-example-container'>
     <pre class='csharp'>// Execute the following command in first
-#load "../Initialize.csx"
-
-// Create a QuantBook object
-#load "../QuantConnect.csx"
-using QuantConnect;
+#load "../Initialize.csx"</pre>
+    </div>
+    <div class='section-example-container'>
+    <pre class='csharp'>// Load the necessary assembly files.
+#load "../QuantConnect.csx"</pre>
+    </div>
+    <div class='section-example-container'>
+    <pre class='csharp'>using QuantConnect;
 using QuantConnect.Research;
 
 var qb = new QuantBook();</pre>

--- a/Resources/object-store/example_plotting.php
+++ b/Resources/object-store/example_plotting.php
@@ -49,11 +49,14 @@
 
     <div class='section-example-container'>
     <pre class='csharp'>// Execute the following command in first
-#load "../Initialize.csx"
-
-// Create a QuantBook object
-#load "../QuantConnect.csx"
-using QuantConnect;
+#load "../Initialize.csx"</pre>
+    </div>
+    <div class='section-example-container'>
+    <pre class='csharp'>// Load the necessary assembly files.
+#load "../QuantConnect.csx"</pre>
+    </div>
+    <div class='section-example-container'>
+    <pre class='csharp'>using QuantConnect;
 using QuantConnect.Research;
 
 var qb = new QuantBook();</pre>
@@ -83,8 +86,12 @@ series.plot()</pre>
 
     <li class='csharp'>Import the <code>Plotly.NET</code> and <code>Plotly.NET.LayoutObjects</code> packages.</li>
     <div class="csharp section-example-container">
-    <pre class="csharp">#r "../Plotly.NET.dll"
-using Plotly.NET;
+    <pre class="csharp">#r "nuget: Plotly.NET"
+#r "nuget: Plotly.NET.Interactive"</pre>
+    </div>
+    <div class="csharp section-example-container">
+    <pre class="csharp">using Plotly.NET;
+using Plotly.NET.Interactive;
 using Plotly.NET.LayoutObjects;</pre>
     </div>
 
@@ -120,10 +127,10 @@ foreach (var line in content.Split('\n'))
 var chart = Chart2D.Chart.Linee&lt;DateTime, decimal, stringe&gt;(index, values);</pre>
     </div>
 
-    <li class='csharp'>Apply the layout to the <code>Line</code> object and create the <code>HTML</code> object.</li>
+    <li class='csharp'>Apply the layout to the <code>Line</code> object and display the chart.</li>
     <div class="csharp section-example-container">
     <pre class="csharp">chart.WithLayout(layout);
-var result = HTML(GenericChart.toChartHTML(chart));</pre>
+display(chart);</pre>
     </div>
 </ol>
 


### PR DESCRIPTION
## Summary
- Separate `#load` directives into their own notebook cells (3-cell pattern: Initialize.csx | QuantConnect.csx + #r | using + code) across 56 files
- Replace old `#r "../Plotly.NET.dll"` references with `#r "nuget: Plotly.NET"` and add `#r "nuget: Plotly.NET.Interactive"`
- Replace `HTML(GenericChart.toChartHTML(...))` with `display(...)` for chart rendering
- Add `using Plotly.NET.Interactive;` where missing
- Fix variable name bug in 3D Chart page (`heatmap` → `chart`)
- Update shared Resources files (load-csharp-assemblies.php, example.html, example_plotting.php, example_logging.php)

Resolves #2303

## Test plan
- [ ] Verify pages render correctly on quantconnect.com/docs
- [ ] Confirm C# notebook code blocks show correct 3-cell pattern
- [ ] Check all Plotly.NET references use NuGet format
- [ ] Verify `display()` calls replaced all `HTML(GenericChart.toChartHTML())` calls
- [ ] Test shared Resources pages (Create Subscriptions, Object Store examples) render correctly