### PR TITLE
Add WaveTrend Oscillator reference entry

### DIFF
--- a/Resources/indicators/IndicatorImageGenerator.py
+++ b/Resources/indicators/IndicatorImageGenerator.py
@@ -751,10 +751,16 @@ class IndicatorImageGenerator(QCAlgorithm):
             'self.vtx(self._symbol, 14)',
             [['current', "plusvortex", "minusvortex"]]
         ),
+        'wave-trend-oscillator': IndicatorInfo(
+            WaveTrendOscillator(10, 21, 4),
+            'WaveTrendOscillator(10, 21, 4)',
+            'WTO(_symbol, 10, 21, 4)',
+            'self.wto(self._symbol, 10, 21, 4)'
+        ),
         'wilder-accumulative-swing-index': IndicatorInfo(
-            WilderAccumulativeSwingIndex(20), 
-            'WilderAccumulativeSwingIndex(20)', 
-            'ASI(_symbol, 20)', 
+            WilderAccumulativeSwingIndex(20),
+            'WilderAccumulativeSwingIndex(20)',
+            'ASI(_symbol, 20)',
             'self.asi(self._symbol, 20, Resolution.DAILY)'
         ),
         'wilder-moving-average': IndicatorInfo(


### PR DESCRIPTION
Companion to [QuantConnect/Lean#6411](https://github.com/QuantConnect/Lean/issues/6411) -- adds the `WaveTrendOscillator` entry to `Resources/indicators/IndicatorImageGenerator.py`.

**Draft until** the paired Lean PR merges. The reference snippets under `Resources/indicators/` and the per-indicator pages under `03 Writing Algorithms/28 Indicators/01 Supported Indicators/` are not regenerated here -- `code-generators/indicator_reference_code_generator.py` fetches `QCAlgorithm` method metadata from the public inspector service, which will only surface the new `WTO` helper once the Lean PR is merged. Docs CI regenerates the preview images and reference snippets post-merge.