### PR TITLE
Fix Python property names and dict type on Memory Metrics page

### DIFF
--- a/03 Writing Algorithms/01 Key Concepts/14 Debugging Tools/07 Memory Metrics.html
+++ b/03 Writing Algorithms/01 Key Concepts/14 Debugging Tools/07 Memory Metrics.html
@@ -14,23 +14,23 @@
     </thead>
     <tbody>
         <tr>
-            <td><code class="csharp">ApplicationMemoryUsed</code><code class="python">application_memory_used</code></td>
+            <td><code class="csharp">ApplicationMemoryUsed</code><code class="python">APPLICATION_MEMORY_USED</code></td>
             <td><code class="csharp">long</code><code class="python">int</code></td>
             <td>Private memory allocated to the current process, including managed and unmanaged memory, in megabytes.</td>
         </tr>
         <tr>
-            <td><code class="csharp">TotalPhysicalMemoryUsed</code><code class="python">total_physical_memory_used</code></td>
+            <td><code class="csharp">TotalPhysicalMemoryUsed</code><code class="python">TOTAL_PHYSICAL_MEMORY_USED</code></td>
             <td><code class="csharp">long</code><code class="python">int</code></td>
             <td>Managed-runtime RAM usage (sampled with <code>GC.GetTotalMemory</code>), in megabytes. LEAN's memory monitor samples this value.</td>
         </tr>
         <tr>
-            <td><code class="csharp">CpuUsage</code><code class="python">cpu_usage</code></td>
+            <td><code class="csharp">CpuUsage</code><code class="python">CPU_USAGE</code></td>
             <td><code class="csharp">decimal</code><code class="python">float</code></td>
             <td>Total CPU usage as a percentage, sampled on a background thread.</td>
         </tr>
         <tr>
             <td><code class="csharp">GetServerStatistics()</code><code class="python">get_server_statistics()</code></td>
-            <td><code class="csharp">Dictionary&lt;string, string&gt;</code><code class="python">dict</code></td>
+            <td><code class="csharp">Dictionary&lt;string, string&gt;</code><code class="python">Dictionary[str, str]</code></td>
             <td>Snapshot dictionary with <code>CPU Usage</code>, <code>Used RAM</code>, <code>Total RAM</code>, <code>Hostname</code>, and <code>LEAN Version</code> entries.</td>
         </tr>
     </tbody>
@@ -49,14 +49,15 @@ Log($"CPU usage: {OS.CpuUsage}%");
 // Log a full snapshot of the server statistics.
 foreach (var kvp in OS.GetServerStatistics()) Log($"{kvp.Key}: {kvp.Value}");</pre>
     <pre class="python"># Log the current memory usage of the algorithm process.
-self.log(f"Total physical memory used: {OS.total_physical_memory_used} MB")
-self.log(f"Application memory used: {OS.application_memory_used} MB")
+self.log(f"Total physical memory used: {OS.TOTAL_PHYSICAL_MEMORY_USED} MB")
+self.log(f"Application memory used: {OS.APPLICATION_MEMORY_USED} MB")
 
 # Log the current CPU usage as a percentage.
-self.log(f"CPU usage: {OS.cpu_usage}%")
+self.log(f"CPU usage: {OS.CPU_USAGE}%")
 
 # Log a full snapshot of the server statistics.
-for key, value in OS.get_server_statistics().items(): self.log(f"{key}: {value}")</pre>
+for kvp in OS.get_server_statistics():
+    self.log(f"{kvp.key}: {kvp.value}")</pre>
 </div>
 
 <p>
@@ -65,7 +66,7 @@ for key, value in OS.get_server_statistics().items(): self.log(f"{key}: {value}"
 </p>
 
 <p>
-  LEAN samples <code class="csharp">OS.TotalPhysicalMemoryUsed</code><code class="python">OS.total_physical_memory_used</code> once per minute and feeds each sample into an exponential moving average.
+  LEAN samples <code class="csharp">OS.TotalPhysicalMemoryUsed</code><code class="python">OS.TOTAL_PHYSICAL_MEMORY_USED</code> once per minute and feeds each sample into an exponential moving average.
   The engine sets <code>emaPeriod = 60</code>, which gives you roughly a 1-hour rolling window.
 </p>
 
@@ -74,7 +75,7 @@ for key, value in OS.get_server_statistics().items(): self.log(f"{key}: {value}"
 sample = OS.TotalPhysicalMemoryUsed;
 memoryUsed = Convert.ToInt64((emaPeriod-1)/emaPeriod * memoryUsed + (1/emaPeriod)*sample);</pre>
     <pre class="python"># Update the smoothed memory reading each minute.
-sample = OS.total_physical_memory_used
+sample = OS.TOTAL_PHYSICAL_MEMORY_USED
 memory_used = int((ema_period - 1) / ema_period * memory_used + (1 / ema_period) * sample)</pre>
 </div>
 


### PR DESCRIPTION
## Summary
- Fix the Python identifiers on the Memory Metrics page: `OS` exposes memory/CPU properties as uppercase Python constants (`APPLICATION_MEMORY_USED`, `TOTAL_PHYSICAL_MEMORY_USED`, `CPU_USAGE`), not snake_case.
- Fix the Python return type for `OS.get_server_statistics()`: it returns a C# `Dictionary[str, str]`, not a native Python `dict`. Update the iteration example to loop directly over the dictionary and access `kvp.key` / `kvp.value` on each item.
- Update every reference (table rows, example block, monitoring paragraph, EMA code snippet) so the Python column is consistent.

Follow-up to #2317 / #2318 (issue #2316).

## Test plan
- [ ] Verify the Memory Metrics page renders correctly on quantconnect.com/docs
- [ ] Confirm the Python example under the language toggle uses the uppercase property names and the `for kvp in OS.get_server_statistics():` pattern
- [ ] Confirm the member table shows `APPLICATION_MEMORY_USED` / `TOTAL_PHYSICAL_MEMORY_USED` / `CPU_USAGE` / `Dictionary[str, str]` under the Python toggle