### PR TITLE
Add Language Selection SKILL and skills installer

### DIFF
--- a/03 Writing Algorithms/01 Key Concepts/03 Algorithm Engine/SKILL.md
+++ b/03 Writing Algorithms/01 Key Concepts/03 Algorithm Engine/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: language-selection
-description: Use before writing or reviewing any QuantConnect/LEAN algorithm code. A LEAN project is Python XOR C# — detect via QuantConnect MCP `read_project` if available, otherwise by whether the project contains `.cs` or `.py` files. Other Writing Algorithms skills show Python first as a display convention only; both forms are equally canonical, so never default to Python in a C# project.
+description: Use before writing or reviewing any QuantConnect/LEAN algorithm code. A LEAN project is Python XOR C# — detect via QuantConnect MCP `read_project` if available, otherwise by whether the project has `main.py` (Python) or any `.cs` file (C#). Other Writing Algorithms skills show Python first as a display convention only; both forms are equally canonical, so never default to Python in a C# project.
 ---
 
 # Language Selection in QuantConnect / LEAN
 
-A LEAN project is either Python **or** C#, never both — `.cs` and `.py` files do not coexist. Writing the wrong language produces code that won't run.
+A LEAN project is Python **or** C#, never both. Writing the wrong language produces code that won't run.
 
 ## Detect
 
 1. **MCP `read_project`** (if available) → use its `language` field.
-2. **Any `.cs` in the project** → C#. **Any `.py`** → Python.
-3. **Empty project / notebooks only** → ask. Research `.ipynb` files are always Python even in C# projects and don't indicate the algorithm language.
+2. **Otherwise:** `main.py` → Python; any `.cs` file → C#. `.ipynb` doesn't count — research notebooks are always Python even in C# projects.
 
 ## Apply
 
-- Produce every code block in the detected language only — new code, edits, examples, and also when **describing, listing, or citing** a skill (e.g. answering "which skills are you using?"). Snippets that illustrate a skill must render in the project's language, not Python by default.
-- Don't show both languages.
-- Other skills in this pack show Python first as formatting, not preference. Use the **C# implementation** block / equivalents table for C# projects.
+This skill is **silent** — the user already knows their project language. Don't announce the detection, don't preface with "since this is a C# project…", don't ask for confirmation. Just produce the right language in every code block, including when describing or citing another skill (e.g. "which skills are you using?"). Never show both languages.
+
+- Other skills in this pack show Python first as formatting, not preference — for C# projects use each skill's **C# implementation** block or equivalents table.
 - Keep API casing consistent with the language: `self.schedule.on(...)` in Python, `Schedule.On(...)` in C#.
+
+**Only exception — missing `main.py`:** if the project is Python but `main.py` is absent, add `main.py` and tell the user it's mandatory as LEAN's Python entrypoint. This is the sole case where language is mentioned in the reply.

--- a/03 Writing Algorithms/01 Key Concepts/03 Algorithm Engine/SKILL.md
+++ b/03 Writing Algorithms/01 Key Concepts/03 Algorithm Engine/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: language-selection
+description: Use before writing or reviewing any QuantConnect/LEAN algorithm code. A LEAN project is Python XOR C# — detect via QuantConnect MCP `read_project` if available, otherwise by whether the project contains `.cs` or `.py` files. Other Writing Algorithms skills show Python first as a display convention only; both forms are equally canonical, so never default to Python in a C# project.
+---
+
+# Language Selection in QuantConnect / LEAN
+
+A LEAN project is either Python **or** C#, never both — `.cs` and `.py` files do not coexist. Writing the wrong language produces code that won't run.
+
+## Detect
+
+1. **MCP `read_project`** (if available) → use its `language` field.
+2. **Any `.cs` in the project** → C#. **Any `.py`** → Python.
+3. **Empty project / notebooks only** → ask. Research `.ipynb` files are always Python even in C# projects and don't indicate the algorithm language.
+
+## Apply
+
+- Produce every code block in the detected language only — new code, edits, examples, and also when **describing, listing, or citing** a skill (e.g. answering "which skills are you using?"). Snippets that illustrate a skill must render in the project's language, not Python by default.
+- Don't show both languages.
+- Other skills in this pack show Python first as formatting, not preference. Use the **C# implementation** block / equivalents table for C# projects.
+- Keep API casing consistent with the language: `self.schedule.on(...)` in Python, `Schedule.On(...)` in C#.

--- a/install-skills.py
+++ b/install-skills.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Install SKILL.md files from this repo into ~/.claude/skills/<name>/SKILL.md.
+
+<name> is read from the YAML frontmatter of each SKILL.md.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+
+
+FRONTMATTER_NAME = re.compile(r"^name:\s*(.+?)\s*$", re.MULTILINE)
+SKIP_DIRS = {".git", "node_modules", ".venv", "__pycache__"}
+
+
+def extract_name(skill_file: Path) -> str | None:
+    text = skill_file.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end == -1:
+        return None
+    frontmatter = text[3:end]
+    match = FRONTMATTER_NAME.search(frontmatter)
+    return match.group(1).strip() if match else None
+
+
+def find_skill_files(root: Path) -> list[Path]:
+    results: list[Path] = []
+    for path in root.rglob("SKILL.md"):
+        if any(part in SKIP_DIRS for part in path.relative_to(root).parts):
+            continue
+        results.append(path)
+    return sorted(results)
+
+
+def install(src: Path, dst: Path, mode: str, dry_run: bool) -> None:
+    action = f"{'link' if mode == 'link' else 'copy'}: {src} -> {dst}"
+    if dry_run:
+        print(f"DRY-RUN: mkdir -p {dst.parent}")
+        print(f"DRY-RUN: {action}")
+        return
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists() or dst.is_symlink():
+        dst.unlink()
+    if mode == "link":
+        dst.symlink_to(src)
+    else:
+        shutil.copy2(src, dst)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--link",
+        dest="mode",
+        action="store_const",
+        const="link",
+        default="copy",
+        help="Symlink instead of copy (needs admin/Developer Mode on Windows).",
+    )
+    parser.add_argument("-n", "--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent
+    dest_root = Path.home() / ".claude" / "skills"
+
+    installed = skipped = 0
+    for skill_file in find_skill_files(repo_root):
+        rel = skill_file.relative_to(repo_root)
+        name = extract_name(skill_file)
+        if not name:
+            print(f"SKIP: no 'name:' in frontmatter — {rel}", file=sys.stderr)
+            skipped += 1
+            continue
+
+        target = dest_root / name / "SKILL.md"
+        print(f"Installing '{name}' from {rel}")
+        install(skill_file, target, args.mode, args.dry_run)
+        installed += 1
+
+    print()
+    print(f"Done. Installed: {installed}, Skipped: {skipped}")
+    print(f"Dest: {dest_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/install-skills.py
+++ b/install-skills.py
@@ -5,35 +5,38 @@
 """
 from __future__ import annotations
 
-import argparse
-import re
-import shutil
-import sys
+from argparse import ArgumentParser
 from pathlib import Path
+from re import MULTILINE, compile
+from shutil import copy2
+from sys import exit, stderr
 
 
-FRONTMATTER_NAME = re.compile(r"^name:\s*(.+?)\s*$", re.MULTILINE)
-SKIP_DIRS = {".git", "node_modules", ".venv", "__pycache__"}
+FRONTMATTER_NAME = compile(r"^name:\s*(.+?)\s*$", MULTILINE)
+# Only scan the numbered top-level chapters where SKILL.md files may live.
+CHAPTER_DIR = compile(r"^0[1-6] ")
+# Frontmatter lives at the top of the file; 2KB is plenty and avoids reading
+# full SKILL.md bodies (some are hundreds of lines).
+HEAD_BYTES = 2048
 
 
 def extract_name(skill_file: Path) -> str | None:
-    text = skill_file.read_text(encoding="utf-8")
-    if not text.startswith("---"):
+    with skill_file.open(encoding="utf-8") as f:
+        head = f.read(HEAD_BYTES)
+    if not head.startswith("---"):
         return None
-    end = text.find("\n---", 3)
+    end = head.find("\n---", 3)
     if end == -1:
         return None
-    frontmatter = text[3:end]
-    match = FRONTMATTER_NAME.search(frontmatter)
+    match = FRONTMATTER_NAME.search(head[3:end])
     return match.group(1).strip() if match else None
 
 
 def find_skill_files(root: Path) -> list[Path]:
     results: list[Path] = []
-    for path in root.rglob("SKILL.md"):
-        if any(part in SKIP_DIRS for part in path.relative_to(root).parts):
-            continue
-        results.append(path)
+    for child in root.iterdir():
+        if child.is_dir() and CHAPTER_DIR.match(child.name):
+            results.extend(child.rglob("SKILL.md"))
     return sorted(results)
 
 
@@ -44,16 +47,15 @@ def install(src: Path, dst: Path, mode: str, dry_run: bool) -> None:
         print(f"DRY-RUN: {action}")
         return
     dst.parent.mkdir(parents=True, exist_ok=True)
-    if dst.exists() or dst.is_symlink():
-        dst.unlink()
+    dst.unlink(missing_ok=True)
     if mode == "link":
         dst.symlink_to(src)
     else:
-        shutil.copy2(src, dst)
+        copy2(src, dst)
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = ArgumentParser(description=__doc__)
     parser.add_argument(
         "--link",
         dest="mode",
@@ -73,7 +75,7 @@ def main() -> int:
         rel = skill_file.relative_to(repo_root)
         name = extract_name(skill_file)
         if not name:
-            print(f"SKIP: no 'name:' in frontmatter — {rel}", file=sys.stderr)
+            print(f"SKIP: no 'name:' in frontmatter — {rel}", file=stderr)
             skipped += 1
             continue
 
@@ -89,4 +91,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    exit(main())


### PR DESCRIPTION
## Summary
- Add a `language-selection` SKILL under `03 Writing Algorithms/01 Key Concepts/03 Algorithm Engine/` that detects whether the project is Python or C# (via QuantConnect MCP `read_project` or `.cs`/`.py` files) and pins every subsequent code block and skill citation to that language, so Python is not silently produced in a C# project.
- Add `install-skills.py`, a small installer that copies (or symlinks with `--link`) every `SKILL.md` in this repo into `~/.claude/skills/<name>/SKILL.md`, keying off the frontmatter `name` field so contributors can try the SKILLs locally without hand-wiring each folder.

## Test plan
- [ ] `python install-skills.py --dry-run` from the repo root lists every `SKILL.md` (currently `logging`, `scheduled-events`, `language-selection`) and the resolved destination under `~/.claude/skills/`.
- [ ] `python install-skills.py` installs the files; `~/.claude/skills/language-selection/SKILL.md` exists and matches the repo copy.
- [ ] In a Python project, the skill resolves to Python and code blocks come out Python; in a C# project, the same question yields C#.
- [ ] `python install-skills.py --link` (with Developer Mode on Windows / on Linux/macOS) creates symlinks rather than copies.