### PR TITLE
Validate SKILL.md frontmatter before uploading skills

### DIFF
--- a/.github/workflows/upload_skills.yml
+++ b/.github/workflows/upload_skills.yml
@@ -12,7 +12,34 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+
+      - name: Validate SKILL.md frontmatter
+        run: |
+          python3 - <<'EOF'
+          import sys, pathlib, yaml
+          REQUIRED = {'name', 'description'}
+          errors = []
+          for p in sorted(pathlib.Path('.').rglob('SKILL.md')):
+              parts = p.read_text(encoding='utf-8').split('---\n', 2)
+              if len(parts) < 3 or parts[0]:
+                  errors.append((p, 'missing or unterminated YAML frontmatter'))
+                  continue
+              try:
+                  data = yaml.safe_load(parts[1])
+              except yaml.YAMLError as e:
+                  errors.append((p, f'invalid YAML: {e}'))
+                  continue
+              if not isinstance(data, dict):
+                  errors.append((p, 'frontmatter must be a mapping'))
+                  continue
+              missing = REQUIRED - data.keys()
+              if missing:
+                  errors.append((p, f'frontmatter missing: {", ".join(sorted(missing))}'))
+          for p, err in errors:
+              print(f'::error file={p}::{err}')
+          sys.exit(1 if errors else 0)
+          EOF
 
       - name: Zip skills
         run:  zip -r skills.zip . -i "**/SKILL.md"


### PR DESCRIPTION
## Summary

- Adds a validation step to `.github/workflows/upload_skills.yml` that parses every `SKILL.md`'s YAML frontmatter with PyYAML and fails the job with inline file annotations if any file is missing/unterminated/invalid frontmatter or lacks the required `name`/`description` keys.
- Bumps `actions/checkout` from `v3` to `v5` to avoid the Node.js 20 deprecation warning (v5 runs on Node.js 24).

## Test plan

- [ ] CI runs the new `Validate SKILL.md frontmatter` step and surfaces any bad frontmatter as an annotation on the offending file.
- [ ] Upload step only runs once validation passes.