### PR TITLE
Add Custom Signal Export SKILL

### DIFF
--- a/03 Writing Algorithms/40 Live Trading/40 Notifications/SKILL.md
+++ b/03 Writing Algorithms/40 Live Trading/40 Notifications/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notifications
-description: Use when adding or reviewing live-trading `Notify.*` calls (Email, SMS, Telegram, Web/Webhook, FTP/SFTP) in a QuantConnect/LEAN algorithm. Notifications run in QuantConnect Cloud live trading only — backtests, local LEAN, and LEAN CLI live deployments don't have them, so guard call sites with `live_mode`. Covers per-channel limits (10 KB email body, 1,600-char SMS, 300 s webhook timeout, default `attachment.txt` filename), the tiered hourly free quota with paid overage (SMS always billed per message regardless of tier), the rule that raw subscribed-dataset content can't be sent (terms-of-use), the Discord webhook content-key JSON envelope, the Telegram group-ID + bot-token + UTF-32 emoji rules, that *receiving* messages is the live-commands skill, and that `notify.*` belongs in event handlers, not per-bar `on_data`.
+description: Use when adding or reviewing live-trading `Notify.*` calls (Email, SMS, Telegram, Web/Webhook, FTP/SFTP) in a QuantConnect/LEAN algorithm. Notifications run in QuantConnect Cloud live trading only — backtests, local LEAN, and LEAN CLI live deployments don't have them, so guard call sites with `live_mode`. Covers per-channel limits (10 KB email body, 1,600-char SMS, 300 s webhook timeout, default `attachment.txt` filename), the tiered hourly free quota with paid overage (SMS always billed per message regardless of tier), the rule that raw subscribed-dataset content can't be sent (terms-of-use), the Discord webhook content-key JSON envelope, the Telegram group-ID + bot-token + UTF-32 emoji rules, that *receiving* messages is the live-commands skill, that *shipping portfolio targets* to a fund/platform belongs in the custom-signal-export skill rather than `notify.web`, and that `notify.*` belongs in event handlers, not per-bar `on_data`.
 ---
 
 # Notifications in QuantConnect / LEAN
@@ -89,6 +89,10 @@ Putting `notify.*` inside `on_data` on minute or tick resolution saturates the h
 
 The notification system **can't be used for data distribution** — that's a terms-of-use violation, not just a quota concern. Send derived information (signal value, portfolio value, fill summary), not raw bars/quotes/trades from QuantConnect-subscribed datasets. The logging skill carries the same rule.
 
+## Shipping trading signals: use signal exports, not webhooks
+
+If the goal is to feed an algorithm's portfolio targets to a fund, allocator, or trading platform — Collective2, Numerai, vBase, or your own endpoint — use signal exports, not `notify.web`. The signal-export manager debounces fills into one batched call (default 5 s window), passes a standardized `PortfolioTarget` list, and has bundled providers for the common destinations. See the custom-signal-export skill. Reach for `notify.*` only for genuine notifications (fill alerts, broker errors, daily summaries) where a human, not a trading system, is the recipient.
+
 ## Receiving messages
 
 Notify is one-way out. To *receive* external instructions (manual liquidate, parameter change), use the live-commands skill.
@@ -104,4 +108,5 @@ Notify is one-way out. To *receive* external instructions (manual liquidate, par
 7. For webhook: receiver responds within 300 s? Discord targets wrapped in a `content`-keyed JSON object?
 8. For FTP vs SFTP: auth method matches the server (password vs SSH key, not both)?
 9. Does the message body contain raw subscribed-dataset content? If yes, swap for a derived value.
-10. Does the algorithm need to *receive* messages? That's the live-commands skill.
+10. Is the payload actually a trading signal / portfolio target headed to a fund or platform? If yes, use signal exports (custom-signal-export skill), not `notify.web`.
+11. Does the algorithm need to *receive* messages? That's the live-commands skill.

--- a/03 Writing Algorithms/40 Live Trading/99 Signal Exports/01 Key Concepts/SKILL.md
+++ b/03 Writing Algorithms/40 Live Trading/99 Signal Exports/01 Key Concepts/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: custom-signal-export
+description: Use when implementing a **custom** `ISignalExportTarget` in a QuantConnect/LEAN algorithm — a class with `send(parameters) -> bool` and `dispose()` registered via `signal_export.add_signal_export_provider`. The class itself is trivial; the real work is shaping the outgoing payload to match what the receiving endpoint expects, which is not something QC defines. Skip this skill (use the bundled provider) if the destination is Collective2, Numerai, or vBase.
+---
+
+# Custom Signal Exports in QuantConnect / LEAN
+
+A custom signal export is a class that implements `ISignalExportTarget` and forwards `PortfolioTarget` objects to an external endpoint. QuantConnect ships providers for Collective2, Numerai, and vBase — only write a custom provider when the destination is your own fund or a service without a built-in.
+
+## The whole interface
+
+```python
+class CustomSignalExport:
+    def send(self, parameters: SignalExportTargetParameters) -> bool: ...
+    def dispose(self) -> None: ...
+```
+
+Register in `initialize`:
+
+```python
+self.signal_export.add_signal_export_provider(CustomSignalExport(...))
+```
+
+`parameters.algorithm` is the algorithm; `parameters.targets` is the list of `PortfolioTarget`s the engine wants you to send.
+
+## The only real question: what payload does the receiver expect?
+
+This is the gotcha. QuantConnect does not define the wire format — the receiving service does. Before writing the class, get from the user (or the receiver's API docs):
+
+1. **Endpoint URL and auth.** Bearer token, API key header, HMAC body? Lift to module-level constants or constructor args, not hard-coded inside `send`.
+2. **Field names and types.** `{symbol, quantity}`? `{ticker, weight}`? `{asset, side, size}`? The receiver's contract drives every line of the body-build code.
+3. **Per-target or per-batch?** Most APIs accept a list — `send` is called once per aggregated batch of fills, so build one request, not N.
+4. **Quantity in shares or in weight?** `parameters.targets[i].quantity` is a **portfolio weight** (a fraction like `0.10`), not a share count. If the receiver wants share counts, round-trip via `PortfolioTarget.Percent`:
+
+   ```python
+   share_target = PortfolioTarget.percent(parameters.algorithm, x.symbol, x.quantity, x.tag)
+   # share_target.quantity is now the share count for that weight.
+   ```
+
+   Pass `x.tag` through — it's the only carrier of caller-provided context (signal id, regime, confidence) and is empty unless the calling code created targets with `PortfolioTarget(symbol, weight, tag="...")`.
+
+## Reference shape
+
+```python
+from requests import Session
+
+class CustomSignalExport:
+    def __init__(self, endpoint: str, api_key: str) -> None:
+        self._endpoint = endpoint
+        self._session = Session()
+        self._session.headers["Authorization"] = f"Bearer {api_key}"
+
+    def send(self, parameters: SignalExportTargetParameters) -> bool:
+        # Shape this body to what the receiver expects.
+        payload = [{"symbol": x.symbol.value, "weight": x.quantity, "tag": x.tag}
+                   for x in parameters.targets]
+        try:
+            response = self._session.post(self._endpoint, json=payload, timeout=30)
+        except Exception as e:
+            parameters.algorithm.error(f"Signal export failed: {e}")
+            return False
+        return response.ok
+
+    def dispose(self) -> None:
+        self._session.close()
+```
+
+C# is the same shape with `public bool Send(SignalExportTargetParameters parameters)` / `public void Dispose()`, a `private readonly HttpClient _httpClient = new();` field, and `_httpClient.PostAsync(url, content).Result` in `Send`.
+
+## Three things that bite
+
+- **Reuse one HTTP client.** Allocate `Session` / `HttpClient` once in the constructor, close in `dispose`. Building a fresh client per `send` exhausts ephemeral ports under load.
+- **Return a `bool`, don't raise.** Catch network and JSON errors and return `False`. An exception escaping `send` aborts the algorithm.
+- **`send` fires in backtests too.** Unlike notifications, signal exports run anywhere the algorithm runs. If the endpoint is production, either skip `add_signal_export_provider` when `not self.live_mode`, or short-circuit at the top of `send` with `if not parameters.algorithm.live_mode: return True`.


### PR DESCRIPTION
## Summary

- Adds a new `custom-signal-export` SKILL.md at [03 Writing Algorithms/40 Live Trading/99 Signal Exports/01 Key Concepts/SKILL.md](03 Writing Algorithms/40 Live Trading/99 Signal Exports/01 Key Concepts/SKILL.md), focused on the only non-trivial part of implementing `ISignalExportTarget`: shaping the outgoing payload to match what the receiver expects.
- Updates the notifications SKILL.md to route portfolio-target use cases to the new skill rather than `notify.web`, mirroring the existing pointer to live-commands for inbound messages.

## Test plan

- [x] SKILL.md renders correctly in the docs site under Live Trading > Signal Exports > Key Concepts.
- [x] Skill is discoverable via the trigger phrasing in its description (custom `ISignalExportTarget`, `send` / `dispose`, `add_signal_export_provider`).
- [x] Notifications skill cross-links resolve when the user is shipping portfolio targets (routes to custom-signal-export) and when they need inbound commands (routes to live-commands).