### PR TITLE
Track bundled skills/ via auto-PR workflow

### DIFF
--- a/.github/workflows/upload_skills.yml
+++ b/.github/workflows/upload_skills.yml
@@ -28,3 +28,13 @@ jobs:
 
       - name: Upload skills to S3
         run: aws s3 cp skills.zip s3://cdn.quantconnect.com/skills/skills-latest.zip --acl bucket-owner-full-control
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: github-action-skills-bundle
+          add-paths: skills/**
+          title: "Update bundled skills/ tree"
+          body: "Automated changes from skill-templates/bundle-skills.py."
+          committer: "GitHub Actions <github-actions@github.com>"
+          author: "GitHub Actions <github-actions@github.com>"

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,4 @@
 URL Test/bin
 URL Test/obj
 .DS_Store
-skills
 skills.zip


### PR DESCRIPTION
## Summary

- Stop ignoring \`skills/\` in \`.gitignore\` so the bundled output of \`skill-templates/bundle-skills.py\` can live in-tree.
- Add a \`Create Pull Request\` step to \`.github/workflows/upload_skills.yml\` (mirroring the pattern in \`html_generation.yml\`) so every workflow run that finds a \`skills/\` diff opens / updates a PR with the regenerated tree on branch \`github-action-skills-bundle\`.

This means contributors no longer need to commit the bundled output by hand when adding or editing a SKILL — the workflow keeps the tree in sync.

## Test plan

- [ ] Merge this PR.
- [ ] Push a SKILL.md change (or run the workflow manually via \`workflow_dispatch\`) and confirm \`Upload Skills to S3\` runs to completion.
- [ ] Confirm a PR titled \"Update bundled skills/ tree\" appears on branch \`github-action-skills-bundle\` containing the regenerated \`skills/**\` files.
- [ ] On a subsequent run with no SKILL.md changes, confirm no new PR is opened (the action is a no-op when there's no diff).