### PR TITLE
Add Chained Universes Options SKILL and trim existing SKILLs

### DIFF
--- a/skill-templates/indicators/indicator-universes/SKILL.md
+++ b/skill-templates/indicators/indicator-universes/SKILL.md
@@ -7,8 +7,6 @@ description: Use when selecting a QuantConnect/LEAN universe based on per-symbol
 
 The pattern: stream the universe's daily data through one indicator instance per symbol, then filter or rank the universe by the indicator's value. Wrap the per-symbol state in a `SelectionData` class kept in a per-symbol dict on the algorithm.
 
-**Do not call py`self.history(...)`cs`History(...)` inside the universe selection callback to compute indicators.** It runs every selection step for every symbol — for an 8000-symbol Equity fundamentals universe that's thousands of history requests per trading day. Stream the data through the indicator instead; that's what the universe data is for.
-
 ## Basic pattern (Equity / Fundamentals)
 
 US Equities only support **data-point indicators** for universe selection (SMA, EMA, RSI, StandardDeviation, BollingerBands, etc. — anything that updates from `(time, value)`), not bar indicators (ATR, candle patterns).
@@ -17,13 +15,10 @@ US Equities only support **data-point indicators** for universe selection (SMA, 
 class EquityIndicatorUniverseSelectionAlgorithm(QCAlgorithm):
 
     def initialize(self):
-        self.set_start_date(2024, 9, 1)
-        self.set_end_date(2024, 12, 31)
         self.settings.seed_initial_prices = True
         self._selection_data_by_symbol = {}
         self._universe = self.add_universe(self._select_assets)
-        # Warm-up must cover the indicator's warm-up period (in trading days).
-        self.set_warm_up(timedelta(60))
+        self.set_warm_up(21, Resolution.DAILY)
 
     def _select_assets(self, fundamentals):
         # 1. Update each symbol's indicator and keep only those that are ready.
@@ -81,12 +76,9 @@ public class EquityIndicatorUniverseSelectionAlgorithm : QCAlgorithm
 
     public override void Initialize()
     {
-        SetStartDate(2024, 9, 1);
-        SetEndDate(2024, 12, 31);
         Settings.SeedInitialPrices = true;
         _universe = AddUniverse(SelectAssets);
-        // Warm-up must cover the indicator's warm-up period (in trading days).
-        SetWarmUp(TimeSpan.FromDays(60));
+        SetWarmUp(21, Resolution.Daily);
     }
 
     private IEnumerable<Symbol> SelectAssets(IEnumerable<Fundamental> fundamentals)
@@ -171,7 +163,7 @@ public class SelectionData
 
 1. **One `SelectionData` per symbol, kept in a dict on the algorithm.** Indicators are stateful — you cannot recompute them from scratch each selection or you'll just be re-doing history calls. The dict lives across selection callbacks. Lazy-create the entry on first sight of a symbol (py`setdefault(...)`cs`TryGetValue` + assign idiom).
 2. **Lifecycle cleanup.** Symbols leave the universe dataset (delisting, fundamentals coverage drop, exchange removal). Without removing entries for absent symbols, the dict grows unbounded over a long backtest.
-3. **Warm-up.** py`set_warm_up(timedelta(N))`cs`SetWarmUp(TimeSpan.FromDays(N))` makes LEAN replay `N` calendar days into the universe selection callback before the live start. That's how the indicators get fed enough bars to be ready by the first real selection. **`N` must be ≥ the indicator's warm-up period in trading days, with slack for weekends/holidays** — for a 21-day SMA, 60 calendar days is comfortable. Return an empty list while py`self.is_warming_up`cs`IsWarmingUp` so the universe stays empty (selection on un-ready indicators is meaningless and would also subscribe to assets you don't actually want yet).
+3. **Warm-up.** py`set_warm_up(N, Resolution.DAILY)`cs`SetWarmUp(N, Resolution.Daily)` makes LEAN replay `N` daily bars into the universe selection callback before the live start, so the indicators are ready by the first real selection. **Set `N` to the longest indicator's warm-up period in bars** — `SimpleMovingAverage(21)` needs `N = 21`. Use this bar-count overload (not py`set_warm_up(timedelta(N))`cs`SetWarmUp(TimeSpan.FromDays(N))`): counting trading bars handles weekends and holidays without padding, and daily resolution is all the indicator needs since the universe feeds it daily bars at runtime. Return an empty list while py`self.is_warming_up`cs`IsWarmingUp` so the universe stays empty (selection on un-ready indicators is meaningless and would also subscribe to assets you don't actually want yet).
 4. **The per-symbol update method returns the indicator's readiness.** This is the filter for "do I have enough data to use this indicator now?" — pairing it with the comprehension / LINQ `Where` makes it one expression.
 
 ## Leave universe selection on its daily schedule
@@ -185,7 +177,7 @@ When can you legitimately slow it down?
 - **Data-point indicators (SMA, EMA, RSI, …):** OK if the slower cadence _is_ the indicator semantic you want — e.g., a deliberate "21-week SMA of weekly closes," scheduled weekly and sized in weeks (`SimpleMovingAverage(21)` with a weekly schedule). Each close stands on its own, so sampling them at the slower cadence is coherent.
 - **Crypto bar indicators (ATR, candle patterns, anything that needs OHLC):** never. The CryptoUniverse data point is always a daily bar regardless of how often selection runs. Sampling only Friday's daily bar at a weekly cadence throws away Mon–Thu's high/low/range — the resulting ATR isn't "weekly true range," it's "daily true range computed from one day per week," which is meaningless. Keep selection daily.
 
-## Equity-only: handle splits and dividends or your indicator is wrong
+## Equity-only: handle splits and dividends
 
 py`Fundamental.price`cs`Fundamental.Price` is the previous trading day's **raw** close — actual unadjusted trading price. (py`Fundamental.adjusted_price`cs`Fundamental.AdjustedPrice` is the split- and dividend-adjusted version.) Streaming raw prices into an indicator works fine until a split or dividend, at which point the raw price drops abruptly — a 2-for-1 split halves it overnight; a dividend knocks it down by the dividend amount on ex-date. An SMA fed across that boundary mixes pre-action and post-action prices on different scales and produces a spurious dip.
 
@@ -201,12 +193,10 @@ Same shape, different universe constructor and different bar fields:
 class CryptoIndicatorUniverseSelectionAlgorithm(QCAlgorithm):
 
     def initialize(self):
-        self.set_start_date(2024, 9, 1)
-        self.set_end_date(2024, 12, 31)
         self.settings.seed_initial_prices = True
         self._selection_data_by_symbol = {}
         self._universe = self.add_universe(CryptoUniverse.coinbase(self._select_assets))
-        self.set_warm_up(timedelta(60))
+        self.set_warm_up(30, Resolution.DAILY)
 
     def _select_assets(self, data):
         ready_pairs = [
@@ -247,11 +237,9 @@ public class CryptoIndicatorUniverseSelectionAlgorithm : QCAlgorithm
 
     public override void Initialize()
     {
-        SetStartDate(2024, 9, 1);
-        SetEndDate(2024, 12, 31);
         Settings.SeedInitialPrices = true;
         _universe = AddUniverse(CryptoUniverse.Coinbase(SelectAssets));
-        SetWarmUp(TimeSpan.FromDays(60));
+        SetWarmUp(30, Resolution.Daily);
     }
 
     private IEnumerable<Symbol> SelectAssets(IEnumerable<CryptoUniverse> data)
@@ -327,25 +315,6 @@ These universes are almost always paired with a py`self.schedule.on(...)`cs`Sche
 
 ## Common mistakes
 
-- **Calling py`self.history(...)`cs`History(...)` per symbol inside the selection callback.** Doesn't scale and is the entire reason this pattern exists. The only legitimate history call is the post-split rewarm in the Equity `SelectionData` update, which fires once per affected symbol per corporate action.
-- **Forgetting to clean up `SelectionData` for departed symbols.** The dict grows forever. Use the set difference between the dict's keys and the symbols in the current data.
-- **Returning a populated list during py`self.is_warming_up`cs`IsWarmingUp`.** Selection happens on un-ready indicators.
-- **Warm-up shorter than the indicator's warm-up period.** py`set_warm_up(timedelta(N))`cs`SetWarmUp(TimeSpan.FromDays(N))` is **calendar days**, not trading days. For a 21-bar daily indicator, 21 days isn't enough for US Equities — weekends and holidays mean ~30 calendar days is the floor; pad to 1.5–2× the indicator length to be safe.
-- **Ignoring py`price_scale_factor`cs`PriceScaleFactor` on Equity.** Raw py`f.price`cs`f.Price` drops abruptly through splits and dividends; the indicator's window straddles the boundary and produces a spurious value. Symptoms are subtle: rankings spike around heavily-dividend-paying or recently-split stocks.
-- **Using a short-circuit operator (py`and`cs`&&`) instead of `&` between two update calls.** The short-circuit form means if the first indicator isn't ready, the second never updates that bar, and the two indicators become permanently out of sync. The canonical pattern is to _combine_ the side-effecting update with the joint readiness check in one expression: py`return ind1.update(...) & ind2.update(...)`cs`return ind1.Update(...) & ind2.Update(...)`. Each update returns the indicator's new readiness, so the `&`-joined expression doubles as the row's readiness.
-- **Splitting update from readiness, then writing `update(...) & update(...)` followed by a `&`-joined readiness check.** Once the updates have run, the readiness check is just a bool read with no side effect — short-circuit (py`and`cs`&&`) is fine there, and `&` is just noise. Don't carry the "non-short-circuit" rule into pure boolean expressions.
+- **Calling py`self.history(...)`cs`History(...)` per symbol inside the selection callback.** The entire reason this pattern exists is to avoid computationally expensive history calls. The only legitimate history call is the post-split rewarm in the Equity `SelectionData` update, which fires once per affected symbol per corporate action.
+- **Splitting update from readiness, then writing `update(...) & update(...)` followed by a `&`-joined readiness check.** Once the updates have run, the readiness check is a bool read with no side effect — short-circuit (py`and`cs`&&`) is correct there, and `&` is just noise. The "non-short-circuit" rule is for the side-effecting update calls only.
 - **Putting the selection logic on intraday data.** Universe selection callbacks usually fire once per day. The indicators are seeing daily bars regardless of py`universe_settings.resolution`cs`UniverseSettings.Resolution` — `SimpleMovingAverage(21)` means 21 days, not 21 minutes.
-- **Trying to use a bar indicator on an Equity universe.** `Fundamental` has no OHLCV — only the previous day's close in py`f.price`cs`f.Price`. `ATR`, candle patterns, and other indicators that genuinely need high/low/open cannot be driven from `Fundamental`. (`BollingerBands` and similar that compute on closes are _data-point_ indicators — they're fine.) On Crypto, the data point does have OHLCV, so wrap it in a `TradeBar` before passing to a true bar indicator.
-
-## Checklist when writing one of these
-
-1. Is there a `SelectionData` class with the indicator(s) as instance attributes / properties?
-2. Is there a per-symbol dict on the algorithm, with lazy-create on first sight of a symbol (py`setdefault`cs`TryGetValue` + assign)?
-3. Is there a cleanup step removing entries for symbols no longer in the current data?
-4. Does the per-symbol update method return the indicator's readiness so the comprehension / LINQ filter can keep only ready symbols?
-5. Is py`set_warm_up(timedelta(N))`cs`SetWarmUp(TimeSpan.FromDays(N))` set, with `N` ≥ ~1.5× the longest indicator's warm-up period in calendar days?
-6. Does the callback return an empty list while py`self.is_warming_up`cs`IsWarmingUp`?
-7. **Equity only:** is py`price_scale_factor`cs`PriceScaleFactor` cached and checked, with reset + py`SCALED_RAW`cs`ScaledRaw` rewarm on change?
-8. **Crypto only:** for bar indicators, is the universe data point being wrapped in a `TradeBar` before update? **Equity only:** are all indicators data-point indicators (no bar indicators)?
-9. Between multiple update calls in the per-symbol update method, is the operator `&` (non-short-circuit), not py`and`cs`&&`? And conversely, are pure readiness reads using py`and`cs`&&`, not `&`?
-10. Is universe selection running on its default daily schedule (no py`universe_settings.schedule.on(...)`cs`UniverseSettings.Schedule.On(...)` slowing it down)? The exception is a data-point indicator where the slower cadence _is_ the indicator semantic (e.g., a 21-week SMA on weekly closes). Crypto bar indicators always need the daily cadence — never slow them down.

--- a/skill-templates/live-trading/notifications/SKILL.md
+++ b/skill-templates/live-trading/notifications/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notifications
-description: Use when a QuantConnect/LEAN live algorithm sends data out or receives external instructions. Triggers — code uses py`notify.email`cs`Notify.Email`/py`notify.sms`cs`Notify.Sms`/py`notify.telegram`cs`Notify.Telegram`/py`notify.web`cs`Notify.Web`/py`notify.ftp`cs`Notify.Ftp`/py`notify.sftp`cs`Notify.Sftp`, py`signal_export.*`cs`SignalExport.*`, py`on_command`cs`OnCommand`, py`add_command`cs`AddCommand`, py`broadcast_command`cs`BroadcastCommand`, py`link()`cs`Link()`, or a class implementing `ISignalExportTarget` / `Command`; phrases like "Discord/Slack alert on fills", "email on drawdown", "push portfolio targets to Collective2/Numerai/vBase/our endpoint", "custom signal export to my broker", "manual liquidate from outside", "parent algo signals child", "multi-algorithm arbitrage". Skip when — purely in-algo log/debug (use `logging` skill).
+description: Use when a QuantConnect/LEAN live algorithm sends data out or receives external instructions. Triggers — code uses py`notify.email`cs`Notify.Email`/py`notify.sms`cs`Notify.Sms`/py`notify.telegram`cs`Notify.Telegram`/py`notify.web`cs`Notify.Web`/py`notify.ftp`cs`Notify.Ftp`/py`notify.sftp`cs`Notify.Sftp`, py`signal_export.*`cs`SignalExport.*`, py`on_command`cs`OnCommand`, py`add_command`cs`AddCommand`, py`broadcast_command`cs`BroadcastCommand`, py`link()`cs`Link()`, or a class implementing `ISignalExportTarget` / `Command`; phrases like "Discord/Slack alert on fills", "email on drawdown", "push portfolio targets to our endpoint", "custom signal export to my broker", "manual liquidate from outside", "parent algo signals child", "multi-algorithm arbitrage". Skip when — purely in-algo log/debug (use `logging` skill).
 ---
 
 # External Communication in QuantConnect / LEAN
@@ -14,7 +14,7 @@ A live-trading algorithm has several primitives for talking to the outside world
 
 | Direction | Content | Primitive |
 | --- | --- | --- |
-| Out | Portfolio targets / trade signals to a platform | **Signal Exports** (bundled Collective2 / Numerai / vBase, or custom `ISignalExportTarget`) |
+| Out | Portfolio targets / trade signals to a platform | **Signal Exports** (custom `ISignalExportTarget`) |
 | Out | Human-facing alert (fill, error, daily summary) | `notify.email` / `sms` / `telegram` / `web` |
 | Out | Bulk file delivery to a counterparty | `notify.ftp` / `notify.sftp` |
 | In | Manual instruction (liquidate, parameter change) | **Commands** (py`on_command`cs`OnCommand` or `Command` subclass) |
@@ -31,26 +31,13 @@ A live-trading algorithm has several primitives for talking to the outside world
 
 ## Trade signals / portfolio targets → Signal Exports
 
-For portfolio targets to a fund, allocator, or trading platform: use **Signal Exports**, not `notify.web`. The signal-export manager:
+For portfolio targets to a fund, allocator, or trading platform: use **Signal Exports**, not `notify.web`. They plug into the trading workflow — a `send` call fires automatically on every fill with the current portfolio state — and the manager:
 
 - Debounces fills into one batched call (default 5s window).
 - Passes a standardized `PortfolioTarget` list, not an ad-hoc payload.
-- Has bundled providers for Collective2, Numerai, vBase.
 - Survives broker reconnects without duplicating the payload.
 
-For Collective2/Numerai/vBase the bundled provider is enough — register via py`signal_export.add_signal_export_providers(...)`cs`SignalExport.AddSignalExportProviders(...)` in `initialize`, then call py`signal_export.set_target_portfolio_from_portfolio()`cs`SignalExport.SetTargetPortfolioFromPortfolio()` to push.
-
-For any other destination, write a custom `ISignalExportTarget`. Don't reach for `notify.web` to roll your own.
-
-**Why not `notify.web` for trade data?**
-
-- `notify.web` is fire-and-forget HTTP POST with a 300s receiver timeout, no retry, no debouncing. Every fill triggers a separate call → quota burn, race conditions, partial state at the receiver.
-- Signal Exports send a single coherent portfolio snapshot per debounce window — the receiver sees the *intended* state, not a stream of deltas.
-- Trade-data payloads tend to drift (per-symbol weights, metadata). A signal exporter encapsulates the schema; ad-hoc webhook bodies drift across versions.
-
-Reach for `notify.web` only when the recipient is a notification consumer (Discord channel, monitoring webhook), not a trading system that's about to act on the payload.
-
-### Custom Signal Exports
+### Implementation
 
 Implement `ISignalExportTarget` — a class with py`send(parameters: SignalExportTargetParameters) -> bool`cs`bool Send(SignalExportTargetParameters parameters)` and py`dispose() -> None`cs`void Dispose()`. Register in `initialize` via py`signal_export.add_signal_export_provider(...)`cs`SignalExport.AddSignalExportProvider(...)`. py`parameters.algorithm`cs`parameters.Algorithm` is the algorithm; py`parameters.targets`cs`parameters.Targets` is the list of `PortfolioTarget`s.
 
@@ -118,7 +105,7 @@ Putting `notify.*` inside py`on_data`cs`OnData` on minute or tick resolution sat
 - Scheduled events (daily summary, threshold alerts) — see the `scheduled-events` skill.
 - Signal / state transitions — only on the *change*, not every bar the condition is true.
 
-### Don't send raw subscribed-dataset content
+### Send derived values only
 
 The notification system **can't be used for data distribution** — that's a terms-of-use violation, not a quota concern. Send derived information (signal value, portfolio value, fill summary), not raw bars/quotes/trades from QuantConnect-subscribed datasets.
 
@@ -126,16 +113,7 @@ The notification system **can't be used for data distribution** — that's a ter
 
 Commands inject data **into** a running live algorithm. Typical uses: a manual "panic close-all", a click-to-confirm grey-box trade, or coordinating sibling algorithms (arbitrage between exchanges, child strategies offloading execution to a brokerage-connected parent).
 
-Commands give you authenticated delivery routed through QC infrastructure, real-time pickup (no polling latency), and both REST/API broadcast and project-targeted send (via `project_id` + py`link().download_data()`cs`Link().DownloadData()`) for parent/child coordination.
-
-**Why not poll the Object Store?**
-
-You *can* technically have one algorithm write a JSON blob to the Object Store and another read it. Don't:
-
-- Object Store reads aren't real-time. You'd need a per-bar or scheduled poll — which adds latency and burns quota.
-- Concurrent-write semantics are undefined: two writers can clobber each other silently.
-- No delivery acknowledgement. A skipped read fails open, not closed.
-- Object Store is for persistent state (trained models, accumulated features, end-of-run CSVs); Commands are the queue.
+Commands give you authenticated delivery with real-time pickup — no upload-to-Object-Store-and-poll round-trip — and both REST/API broadcast and project-targeted send (via `project_id` + py`link().download_data()`cs`Link().DownloadData()`) work for parent/child coordination.
 
 ## Before writing any code: ask the user about the payload
 
@@ -205,50 +183,3 @@ For a parent that just translates payloads into orders, set py`self.settings.see
 - **`Link(new { ... })` uses an anonymous object whose property names go on the wire verbatim.** `new { Ticker = "AAPL" }` produces `{"Ticker": "AAPL"}`, which a Python sibling reads as `data.Ticker` (not `data.ticker`). For lowercase keys, use `Dictionary<string, object>`.
 <!-- /csharp-only -->
 
-# Universal rules
-
-- **py`self.live_mode`cs`LiveMode` gate every `notify.*` and command-send site.** Notifications and command-send primitives are no-ops outside Cloud live trading.
-- **Signal Exports run everywhere (incl. backtests).** Either skip provider registration when not in live mode, or short-circuit at the top of `send`.
-- **Fire on events, not per-bar.** Every channel here has a quota or rate-limit; per-bar firing exhausts it.
-- **No raw subscribed-dataset content in any payload.** Derived values only.
-
-# Checklist
-
-## Direction & primitive
-
-1. **Direction?** Out → notify or Signal Export. In → Command. Don't poll Object Store as a queue.
-2. **Out, payload is portfolio targets / trade signals?** Signal Exports, not `notify.web`. Bundled provider for Collective2/Numerai/vBase; custom class for anything else.
-3. **Out, recipient is a human / monitoring system?** Pick the right `notify.*` channel.
-4. **In, instruction or coordination?** Commands.
-
-## Notifications
-
-5. Every `notify.*` call gated with py`self.live_mode`cs`LiveMode`?
-6. Channel used more than once → routed through a `_notify_*` helper with credentials at module scope?
-7. Call site is an event handler, not per-bar `on_data`? If per-bar, can it be gated on a real state change?
-8. **SMS:** urgent enough to justify per-message QCC? Phone in E.164? Body under 1,600 chars?
-9. **Email:** attachment filename via `headers={'filename': ...}`? Body under 10 KB?
-10. **Telegram:** group ID a negative integer? Bot in the group (or `token` passed)? Emojis as UTF-32 escapes?
-11. **Webhook:** receiver responds within 300s? Discord targets wrapped in `{"content": ...}`?
-12. **FTP vs SFTP:** auth method matches the server (password vs SSH key, not both)?
-13. Payload contains raw subscribed-dataset content? Swap for a derived value.
-
-## Custom Signal Exports
-
-14. Reuse one HTTP client via the constructor; close in `dispose`.
-15. Return a `bool` — never raise out of `send`.
-16. Live-mode gated if the endpoint is production.
-17. Quantity is a weight, not a share count — use py`PortfolioTarget.percent`cs`PortfolioTarget.Percent` to convert if needed.
-18. Pass `tag` through — it's the only carrier of caller-provided context.
-
-## Commands
-
-19. Asked the user about payload fields, single vs multi-shape, and send mechanism?
-20. Comment in the algorithm pointing at the sender-script docs + the payload shape this handler reads?
-21. Send sites gated with py`self.live_mode`cs`LiveMode`?
-22. Encapsulated commands registered with `add_command` on every receiver?
-23. py`Command.run`cs`Command.Run` returns `True`/`False`, not implicit `None`?
-24. Broadcast payloads include py`"sender": self.project_id`cs`sender = ProjectId`?
-25. Python `Command.run` calling subclass methods? Use the static-reference pattern (`MyCommand.ALGORITHM = self`).
-26. Broadcast sites filter `on_order_event` to py`OrderStatus.FILLED`cs`OrderStatus.Filled`?
-27. C# payload field access uses PascalCase? Numeric fields explicitly cast?

--- a/skill-templates/logging/SKILL.md
+++ b/skill-templates/logging/SKILL.md
@@ -255,26 +255,8 @@ Embedding the actual value being logged usually makes the message unique on its 
 
 ## Common mistakes
 
-- **Logging every bar.** Switch to event-driven (order fill, signal change, scheduled rebalance) or a daily summary.
-- **Logging inside a per-symbol loop.** Aggregate inside, emit one line outside. For 5000-symbol universes the difference is 1 line vs 5000 per bar.
-- **Logging "HOLD" / "no action" outcomes.** They're 99% of the iterations and tell you nothing.
-- **Identical strings across calls.** `log` deduplicates silently — include a changing value so each line is distinct.
-- **`log` right after py`market_order`cs`MarketOrder`** — context detached from the order. Put it on the order via py`tag="..."`cs`tag: "..."` instead.
 - **Logging raw market data** (bars, trades, quotes from subscribed datasets). Not permitted *and* the highest-volume content possible. Log the derived quantity (signal value, portfolio value, decision).
 - **End-of-run state logged from py`on_data`cs`OnData`** — belongs in py`on_end_of_algorithm`cs`OnEndOfAlgorithm` so it fires exactly once.
 - **No logging at all in live.** When something goes wrong you'll have nothing to diagnose against. Always log fills and key state transitions; route verbose diagnostics through `safe_log`.
-- **Diagnostic logs only inside the taken branch.** Won't explain *missing* orders. Log values *before* the `if`, covering every term in the condition.
-- **Using the log file to accumulate structured rows** for Research analysis. Use the Object Store instead.
 - **py`debug`cs`Debug` / py`error`cs`Error` from py`on_data`cs`OnData` on minute/tick data.** Rate-limited to ~1/second, so most calls vanish. For high-frequency diagnostics use `log`; reserve `debug`/`error` for a handful of notable events per day.
 - **py`quit`cs`Quit` without a following `return`.** The algorithm *will* stop, but the current method keeps executing until it returns naturally; orders placed after the quit call still go through.
-
-## Checklist
-
-1. Could this line be event-gated (fill, scheduled fire, signal change) instead of running every bar / every iteration?
-2. If it's inside a loop, is it summarizing the loop's outcome rather than firing per iteration?
-3. If it logs "no action" / "HOLD", does it really need to be there?
-4. Is the message unique each call (timestamp or changing value), so duplicate-suppression doesn't silently drop it?
-5. Does it cover every value in the decision condition, *before* the branch, so a missing order is explainable?
-6. If it's an order-context message, is it on the order via `tag=` rather than a separate `log` call?
-7. If it's bulk structured data for Research, is it accumulated in memory and saved to the Object Store in py`on_end_of_algorithm`cs`OnEndOfAlgorithm`?
-8. If it's verbose live-only diagnostics, is it routed through `safe_log` (gated on py`self.live_mode`cs`LiveMode`)?

--- a/skill-templates/scheduled-events/SKILL.md
+++ b/skill-templates/scheduled-events/SKILL.md
@@ -66,53 +66,9 @@ TimeRules.SetDefaultTimeZone(TimeZones.Utc);
 Schedule.On(DateRules.EveryDay("BTCUSD"), TimeRules.Midnight, CryptoRebalance);
 ```
 
-## If the event rebalances the portfolio: two extra constraints
+## Pick a fire time outside every bar
 
-Scheduled events are used for lots of things — logging, signal checks, closing trailing positions, periodic reporting. This section applies **only** if the event places `PortfolioTarget`s (i.e. a rebalance).
-
-1. **Enable py`self.settings.seed_initial_prices = True`cs`Settings.SeedInitialPrices = true` in py`initialize`cs`Initialize`.** Without it, securities that join the universe may have no price on the first tick of the rebalance — `PortfolioTarget(symbol, weight)` has nothing to size against and the rebalance errors or silently skips. With it, LEAN seeds each new security with its last known price the moment it enters the universe.
-2. **Filter out zero-price securities before building targets.** Even with py`seed_initial_prices`cs`SeedInitialPrices`, a freshly-added symbol can still have py`price == 0`cs`Price == 0` briefly (delisting day, data gap, no bar for the asset since it entered the universe). Orders at zero throw errors and leave the portfolio under-invested.
-
-```python
-def _rebalance(self):
-    if not self._universe.selected:
-        return
-    securities = [self.securities[symbol] for symbol in self._universe.selected]
-    securities = [s for s in securities if s.price]
-    if not securities:
-        return
-    weight = 1 / len(securities)
-    targets = [PortfolioTarget(security, weight) for security in securities]
-    self.set_holdings(targets, True)
-```
-
-```csharp
-private void Rebalance()
-{
-    if (_universe.Selected == null)
-    {
-        return;
-    }
-    // Materialize Selected before counting + iterating; it's IEnumerable<Symbol>.
-    var securities = _universe.Selected.Select(s => Securities[s]).Where(s => s.Price > 0).ToList();
-    if (!securities.Any())
-    {
-        return;
-    }
-    // 1m forces decimal division — integer division would truncate to 0.
-    var weight = 1m / securities.Count;
-    var targets = securities.Select(s => new PortfolioTarget(s, weight)).ToList();
-    SetHoldings(targets, true);
-}
-```
-
-Neither constraint applies to non-rebalancing scheduled events.
-
-## Critical rule: never fire inside a data bar
-
-Every asset's data is delivered in bars that cover a time period (see https://www.quantconnect.com/docs/v2/writing-algorithms/key-concepts/time-modeling/periods). A Scheduled Event that fires in the middle of a bar will read stale data (the previous bar) and may place orders that fill at prices inconsistent with what the logic "saw."
-
-**The single rule: don't fire during a bar that's still forming.** Everything below is an application of that rule — work out when the asset's bars are being generated at your resolution, and pick a fire time that lands _between_ bars (or outside the asset's trading session).
+A Scheduled Event that fires while a bar is still forming reads stale data (the previous bar) and may place orders that fill at prices inconsistent with what the logic "saw." Pick a fire time that lands _between_ bars (or outside the asset's trading session). The valid windows depend on the data resolution.
 
 ### Minute data
 
@@ -152,6 +108,20 @@ Schedule.On(DateRules.WeekStart("SPY"), TimeRules.At(8, 0), Rebalance);
 ```
 
 **Why 08:00:** in live trading, universe selection runs between 07:00 and 08:00 ET. Scheduling the rebalance at 08:00 guarantees py`self._universe.selected`cs`_universe.Selected` reflects the **current day's** universe constituents, not the previous day's.
+
+## String tickers work
+
+Use a plain string ticker in the date/time rules to create the schedule for US Equities without subscribing to an extra security you don't want to trade.
+
+```python
+self.date_rules.week_start('SPY')
+self.time_rules.after_market_open('SPY', 1)
+```
+
+```csharp
+DateRules.WeekStart("SPY");
+TimeRules.AfterMarketOpen("SPY", 1);
+```
 
 ## Align universe selection with the rebalance schedule
 
@@ -217,75 +187,6 @@ General approach:
 
 Worked example: daily dynamic US Equity universe (must fire at 08:00 ET, which is 12:00 or 13:00 UTC) + daily Crypto (must fire at 00:00 UTC). The valid-fire windows don't overlap, so either use hourly Crypto (then the Equity slot at 08:00 ET / 13:00 UTC is also a top-of-hour Crypto slot and works), or accept separate Scheduled Events as a last resort.
 
-## String tickers work — don't build a Symbol just for the rule
+## Common mistakes
 
-The date/time rule methods accept a plain string ticker (or a `Symbol`). The string ticker does **not** need to have been added to the algorithm:
-
-```python
-# Good — concise, no Symbol boilerplate
-self.date_rules.week_start('SPY')
-self.time_rules.after_market_open('SPY', 1)
-```
-
-```csharp
-// Good — concise, no Symbol boilerplate
-DateRules.WeekStart("SPY");
-TimeRules.AfterMarketOpen("SPY", 1);
-```
-
-**Do not pass a `Universe` object.** It looks reasonable — you've added a universe, and it feels like the rule should anchor to "that universe's calendar" — but the date/time rule methods don't accept a universe and the runtime error is opaque. Pass the ticker of an asset that trades on the relevant market (e.g. `'SPY'` for a US Equity universe):
-
-```python
-# WRONG — Universe object is not accepted by date_rules / time_rules
-self._universe = self.add_universe(self._select_assets)
-self.schedule.on(
-    self.date_rules.every_day(self._universe),
-    self.time_rules.after_market_open(self._universe, 1),
-    self._rebalance,
-)
-
-# Right — anchor the calendar to a representative ticker for the market
-self.schedule.on(
-    self.date_rules.every_day('SPY'),
-    self.time_rules.after_market_open('SPY', 1),
-    self._rebalance,
-)
-```
-
-```csharp
-// WRONG — Universe object is not accepted by DateRules / TimeRules
-_universe = AddUniverse(SelectAssets);
-Schedule.On(
-    DateRules.EveryDay(_universe),
-    TimeRules.AfterMarketOpen(_universe, 1),
-    Rebalance);
-
-// Right — anchor the calendar to a representative ticker for the market
-Schedule.On(
-    DateRules.EveryDay("SPY"),
-    TimeRules.AfterMarketOpen("SPY", 1),
-    Rebalance);
-```
-
-## Common mistakes to avoid
-
-- **py`after_market_open('SPY', 1)`cs`AfterMarketOpen("SPY", 1)` with daily data** — fires at 09:31 ET, which is inside the daily bar. Use py`time_rules.at(8, 0)`cs`TimeRules.At(8, 0)` instead.
-- **py`time_rules.every(timedelta(minutes=30))`cs`TimeRules.Every(TimeSpan.FromMinutes(30))` with hourly data during a trading session** — the `X:30` fires land mid-bar. Either fire only at the top of the hour, or only outside the asset's trading session.
-- **Assuming hourly US Equity bars align to the 09:30 open** — they don't. Hourly bars are wall-clock aligned: 10:00, 11:00, 12:00, … are boundaries; 10:30, 11:30, … are not. The first bar of the session is a 30-minute 09:30–10:00 partial, then the grid is whole-hour from there. So py`at(10, 30)`cs`At(10, 30)` with hourly US Equity data fires inside the 10:00–11:00 bar, not on a boundary. If the user specifies a non-top-of-hour intraday time, switch to minute resolution or raise the conflict — don't silently fire mid-bar.
-- **Rebalancing a dynamic Equity universe before universe selection finishes** — in live, universe selection runs between 07:00 and 08:00 ET, so firing earlier than 08:00 means py`self._universe.selected`cs`_universe.Selected` still holds the previous day's constituents. If you use daily data, run at 08:00 ET. If you use intraday data, run at the top of the hour or minute, but not before 08:00 ET.
-- **Building a `Symbol` just to pass to the date/time rules** — a string works.
-- **Passing a `Universe` object to the date/time rules** — e.g. py`date_rules.every_day(self._universe)`cs`DateRules.EveryDay(_universe)` or py`time_rules.after_market_open(self._universe, 1)`cs`TimeRules.AfterMarketOpen(_universe, 1)`. These methods take a string ticker or a `Symbol`, not a universe. Pass a representative ticker for the relevant market (`'SPY'`, `'BTCUSD'`, etc.).
-- **Firing on a weekend / holiday calendar that doesn't match the asset** — use the asset's own ticker in py`date_rules.week_start('SPY')`cs`DateRules.WeekStart("SPY")` so the calendar matches the market the asset trades on.
-- **Time-zone mismatch between the time rule and the data** — e.g. scheduling Crypto at py`at(0, 0)`cs`At(0, 0)` without setting UTC, so the event fires at 00:00 ET (05:00 UTC), five hours into the daily Crypto bar. Either call py`time_rules.set_default_time_zone(TimeZones.UTC)`cs`TimeRules.SetDefaultTimeZone(TimeZones.Utc)` or pass the time zone to py`at(...)`cs`At(...)` explicitly.
-- **Splitting a multi-asset-class rebalance into one Scheduled Event per asset class** — prefer a single rebalance function firing at one time valid for every asset. If no such time exists, drop a data resolution to widen the valid-fire windows before resorting to multiple events.
-- **Running universe selection daily when the rebalance is weekly/monthly** — wastes work. Pass the same date rule to py`self.universe_settings.schedule.on(...)`cs`UniverseSettings.Schedule.On(...)` so universe selection and rebalance only run on the same days.
-
-## Quick checklist when writing a Scheduled Event
-
-1. What is the coarsest data resolution of the assets this event reads or trades?
-2. Does the chosen time fall **outside** every bar of that resolution for those assets?
-3. If the event depends on py`self._universe.selected`cs`_universe.Selected` for a dynamic US Equity universe, is it at/after 08:00 ET?
-4. Is the calendar (py`date_rules.week_start(...)`cs`DateRules.WeekStart(...)`) anchored to an asset that trades on the relevant market?
-5. Do you know which time zone py`time_rules.at(...)`cs`TimeRules.At(...)` is being interpreted in (algorithm zone by default, or the time-rule default zone)? Use that to verify the fire time lands outside every asset's bar boundaries.
-6. If the algorithm trades multiple asset classes, is there a single fire time valid for all of them? If not, widen the windows by dropping a data resolution before splitting into multiple events.
-7. If the rebalance runs less often than every trading day, is the dynamic universe on the same date rule via py`self.universe_settings.schedule.on(...)`cs`UniverseSettings.Schedule.On(...)`?
+- **Calendar ticker that doesn't match the traded asset** — pass the asset's own ticker to py`date_rules.week_start('SPY')`cs`DateRules.WeekStart("SPY")` so the weekend / holiday calendar matches the market the asset trades on.

--- a/skill-templates/universes/equity/chained-universes-options/SKILL.md
+++ b/skill-templates/universes/equity/chained-universes-options/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: chained-universes-options
+description: Use when chaining a dynamic Equity universe (Fundamental or ETF constituents) with an Equity Option universe in a QuantConnect/LEAN algorithm. Triggers — code that wants Option contracts on top of a moving equity universe via py`self.add_universe_options(universe, filter)`cs`AddUniverseOptions(universe, filter)`; questions like "how do I add options on top of my fundamental universe", "options on the top-N PE-ratio stocks", "QQQ constituents with their front-month calls", "why are my option strikes wrong after a stock split", "where do I react to option contracts joining/leaving the chain". Skip when — single static Option universe (call py`add_option`cs`AddOption` once in py`initialize`cs`Initialize`) or a non-Options chain (use the alternative-data chain pattern).
+---
+
+# Chained Equity → Equity Options Universes in QuantConnect / LEAN
+
+Chain a dynamic Equity universe (Fundamental, ETF constituents) with Option contracts on each selected underlying by calling py`self.add_universe_options(universe, option_filter)`cs`AddUniverseOptions(universe, optionFilter)` **once in py`initialize`cs`Initialize`**, after creating the parent universe and saving its reference. LEAN handles the rest: the parent's selector picks the equities; LEAN automatically subscribes the matching Option contracts and routes additions/removals through py`on_securities_changed`cs`OnSecuritiesChanged` as the parent universe rotates.
+
+## Required setup
+
+1. **Save the parent universe's reference** — py`add_universe(...)`cs`AddUniverse(...)` returns the `Universe` object you pass to py`add_universe_options(...)`cs`AddUniverseOptions(...)`.
+2. **py`self.universe_settings.data_normalization_mode = DataNormalizationMode.RAW`cs`UniverseSettings.DataNormalizationMode = DataNormalizationMode.Raw`** in py`initialize`cs`Initialize`. Option strikes are quoted in raw dollars; the underlying must be in the same scale or strike-relative filters like py`u.strikes(0, 2)`cs`u.Strikes(0, 2)` (ATM ± 2 strikes) compare across scales and pick the wrong contracts — most visible right after a split, when the adjusted price diverges sharply from the raw strike grid.
+3. **Provide an Option filter** — a function that takes an `OptionFilterUniverse` and returns one. Without it, LEAN subscribes to the entire chain per underlying, which is enormous.
+
+## Pattern A: Fundamental → Options
+
+```python
+def initialize(self):
+    # Strikes are raw dollars — keep the underlying in the same scale.
+    self.universe_settings.data_normalization_mode = DataNormalizationMode.RAW
+
+    universe = self.add_universe(self._select_assets)
+    self.add_universe_options(universe, self._option_filter)
+
+def _select_assets(self, fundamentals):
+    ranked = sorted(
+        (f for f in fundamentals if not np.isnan(f.valuation_ratios.pe_ratio)),
+        key=lambda f: f.valuation_ratios.pe_ratio,
+    )
+    return [f.symbol for f in ranked[:10]]
+
+def _option_filter(self, u):
+    return u.strikes(0, 2).front_month().calls_only()
+```
+
+```csharp
+public override void Initialize()
+{
+    // Strikes are raw dollars — keep the underlying in the same scale.
+    UniverseSettings.DataNormalizationMode = DataNormalizationMode.Raw;
+
+    var universe = AddUniverse(SelectAssets);
+    AddUniverseOptions(universe, OptionFilter);
+}
+
+private IEnumerable<Symbol> SelectAssets(IEnumerable<Fundamental> fundamentals)
+{
+    return fundamentals
+        .Where(f => !double.IsNaN(f.ValuationRatios.PERatio))
+        .OrderBy(f => f.ValuationRatios.PERatio)
+        .Take(10)
+        .Select(f => f.Symbol);
+}
+
+private OptionFilterUniverse OptionFilter(OptionFilterUniverse u) =>
+    u.Strikes(0, 2).FrontMonth().CallsOnly();
+```
+
+## Pattern B: ETF constituents → Options
+
+Only the parent universe constructor changes; the py`add_universe_options(universe, filter)`cs`AddUniverseOptions(universe, filter)` call and the filter are identical.
+
+```python
+def initialize(self):
+    self.universe_settings.data_normalization_mode = DataNormalizationMode.RAW
+
+    etf_universe = self.universe.etf("QQQ", Market.USA, self.universe_settings, self._etf_filter)
+    self.add_universe(etf_universe)
+    self.add_universe_options(etf_universe, self._option_filter)
+
+def _etf_filter(self, constituents):
+    return [c.symbol for c in sorted(constituents, key=lambda c: c.weight, reverse=True)[:10]]
+```
+
+```csharp
+public override void Initialize()
+{
+    UniverseSettings.DataNormalizationMode = DataNormalizationMode.Raw;
+
+    var etfUniverse = Universe.ETF("QQQ", Market.USA, UniverseSettings, EtfFilter);
+    AddUniverse(etfUniverse);
+    AddUniverseOptions(etfUniverse, OptionFilter);
+}
+
+private IEnumerable<Symbol> EtfFilter(IEnumerable<ETFConstituentUniverse> constituents) =>
+    constituents.OrderByDescending(c => c.Weight).Take(10).Select(c => c.Symbol);
+```
+
+## Reacting per-contract
+
+LEAN drives the chain automatically. If you need to react to specific contracts as they join/leave (attach an indicator, set a custom property, liquidate on removal), hook py`on_securities_changed`cs`OnSecuritiesChanged` and branch on py`security.symbol.security_type`cs`security.Symbol.SecurityType` — the same handler sees the equity, its Option canonical, and each subscribed contract.
+
+## Common mistakes
+
+- **Calling py`add_option(symbol)`cs`AddOption(symbol)` from the selector or py`on_securities_changed`cs`OnSecuritiesChanged` to attach options to a chained universe.** That is the static-universe API. Use py`add_universe_options`cs`AddUniverseOptions` once in py`initialize`cs`Initialize` instead.
+- **Returning a list of `Symbol` from the Option filter.** The filter must return the `OptionFilterUniverse` (the input, post-fluent-chain). A list silently produces an empty universe.


### PR DESCRIPTION
## Summary

Two related changes in two commits:

1. **Trim existing SKILLs for CLAUDE.md compliance** — drops sections that duplicate body content per CLAUDE.md rules 6, 8, 9. Affects \`indicator-universes\`, \`logging\`, \`scheduled-events\`, and \`notifications\`. Net: ~249 deletions, ~32 insertions.

2. **Add Chained Universes Options SKILL** — new SKILL at \`skill-templates/universes/equity/chained-universes-options/\` covering the chained Equity → Equity Options pattern (\`add_universe_options(universe, filter)\`, \`DataNormalizationMode.RAW\`, lifecycle via \`on_securities_changed\`).

Per CLAUDE.md rule 11, the bundled \`skills/**\` output is not included — the auto-PR workflow added by #2338 keeps it in sync.

## Test plan

- [ ] \`python skill-templates/bundle-skills.py --validate-only\` passes for all 5 SKILLs.
- [ ] Full build (\`python skill-templates/bundle-skills.py\`) splits each SKILL cleanly into Python and C# variants under \`skills/python/\` and \`skills/csharp/\`.
- [ ] After merge, the \`upload_skills.yml\` workflow opens / updates the \`github-action-skills-bundle\` auto-PR with the regenerated bundle.