### PR TITLE
Add Fundamental Universes SKILL with property lookup builder

### DIFF
--- a/skill-templates/bundle-skills.py
+++ b/skill-templates/bundle-skills.py
@@ -35,6 +35,7 @@ Flags:
 """
 from __future__ import annotations
 
+import json
 import re
 from argparse import ArgumentParser
 from dataclasses import dataclass
@@ -42,6 +43,7 @@ from os import environ
 from pathlib import Path
 from shutil import copy2, rmtree
 from sys import exit, stderr
+from urllib.request import urlopen
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import yaml
@@ -52,6 +54,14 @@ DESCRIPTION_MIN = 30
 DESCRIPTION_MAX = 1024
 LANGS = ("python", "csharp")
 IN_ACTIONS = environ.get("GITHUB_ACTIONS") == "true"
+# Enum-like helper classes whose constants are exposed as `fields` (not
+# `properties`); shared by fetch_fundamental_lookup and format_fundamental_lookup.
+FUND_ENUM_HELPER_TYPES = (
+    "MorningstarSectorCode",
+    "MorningstarIndustryGroupCode",
+    "MorningstarIndustryCode",
+    "MorningstarEconomySphereCode",
+)
 # Dual-language inline markers (whitespace between halves tolerated).
 # py-first: py`X`cs`Y`     groups: (1)=python (2)=csharp
 # cs-first: cs`Y`py`X`     groups: (1)=csharp (2)=python
@@ -151,6 +161,84 @@ def strip_code_blocks(content: str, lang: str) -> str:
             out.append(lines[i])
             i += 1
     return "\n".join(out)
+
+
+def fetch_fundamental_lookup(language: str) -> dict[str, list[str]]:
+    """Walk Fundamental and its non-leaf sub-types via the QC inspector.
+
+    BFS from `Fundamental`. For each property whose type lives in
+    `QuantConnect.Data.Fundamental.*` and whose base is *not* MultiPeriodField,
+    queue it for expansion. MultiPeriodField wrappers are listed by name in the
+    parent's properties but never expanded — their only members are period
+    accessors that the skill already documents.
+
+    Each entry is keyed by the property-accessor name from its parent
+    (snake_case in Python, PascalCase in C#) — e.g. CompanyReference is listed
+    under `company_reference` in Python because that's how callers reach it
+    (`f.company_reference`). The root uses the lowercased type name in Python.
+    MultiPeriodField wrappers are suffixed with `*` so the skill can flag which
+    properties need a period accessor.
+    """
+    inspector_url = (
+        "https://www.quantconnect.com/services/inspector"
+        "?language={lang}&type=T:QuantConnect.Data.Fundamental.{type}"
+    )
+    fund_prefix = "QuantConnect.Data.Fundamental."
+    # MultiPeriodField subclasses (and closed generics) are leaf wrappers —
+    # don't recurse into them; their only members are period accessors.
+    leaf_base_prefix = "QuantConnect.Data.Fundamental.MultiPeriodField"
+    root_type = "Fundamental"
+
+    root_display = root_type.lower() if language == "python" else root_type
+    out: dict[str, list[str]] = {}
+    visited: set[str] = set()
+    # Queue items are (type_name, display_name) — display follows the parent's accessor casing.
+    queue: list[tuple[str, str]] = [(root_type, root_display)]
+    while queue:
+        type_name, display = queue.pop(0)
+        if type_name in visited:
+            continue
+        visited.add(type_name)
+        url = inspector_url.format(lang=language, type=type_name)
+        with urlopen(url) as r:
+            data = json.load(r)
+        names: list[str] = []
+        for p in data["properties"]:
+            prop_name = p["property-name"]
+            full = p["property-full-type-name"]
+            base = p.get("property-base-type-full-name") or ""
+            if base.startswith(leaf_base_prefix):
+                names.append(prop_name + "*")
+            else:
+                names.append(prop_name)
+                if full.startswith(fund_prefix):
+                    short = full[len(fund_prefix):]
+                    if short not in visited:
+                        queue.append((short, prop_name))
+        out[display] = names
+    # Append the enum-helper classes — their named integer constants live in
+    # `fields`, not `properties`. They're not reachable via tree-walking and
+    # appear at the bottom of the rendered lookup.
+    for type_name in FUND_ENUM_HELPER_TYPES:
+        url = inspector_url.format(lang=language, type=type_name)
+        with urlopen(url) as r:
+            data = json.load(r)
+        out[type_name] = [f["field-name"] for f in data.get("fields", [])]
+    return out
+
+
+def format_fundamental_lookup(lookup: dict[str, list[str]]) -> str:
+    """Render in three tiers: root, chainable types (alpha), enum helpers (alpha).
+
+    Sorting is case-insensitive so PascalCase headings interleave naturally
+    with snake_case ones; the root is pinned to the top because every other
+    path chains from it.
+    """
+    root = next(iter(lookup))
+    helpers = [k for k in lookup if k in FUND_ENUM_HELPER_TYPES]
+    chainable = [k for k in lookup if k != root and k not in FUND_ENUM_HELPER_TYPES]
+    ordered = [root] + sorted(chainable, key=str.lower) + sorted(helpers, key=str.lower)
+    return "\n".join(f"- **{k}**: {', '.join(lookup[k])}" for k in ordered)
 
 
 def split_for_language(content: str, lang: str) -> str:
@@ -278,12 +366,24 @@ def main() -> int:
     # Wipe the build dir so deletions in the source propagate.
     remove_tree(skills_root, dry_run=args.dry_run)
 
+    fund_lookup_marker = "<!-- fundamental-lookup -->"
+    # Lazily fetched per language; populated only when a skill needs the lookup.
+    fundamental_lookup: dict[str, str] = {}
+
     # Build: split each skill into a Python and a C# tree.
     for skill in skills:
         for lang in LANGS:
+            content = split_for_language(skill.content, lang)
+            if fund_lookup_marker in content:
+                if lang not in fundamental_lookup:
+                    print(f"Fetching Fundamental property tree ({lang}) from inspector...")
+                    fundamental_lookup[lang] = format_fundamental_lookup(
+                        fetch_fundamental_lookup(lang)
+                    )
+                content = content.replace(fund_lookup_marker, fundamental_lookup[lang])
             write_file(
                 skills_root / lang / skill.rel_dir / "SKILL.md",
-                split_for_language(skill.content, lang),
+                content,
                 dry_run=args.dry_run,
             )
         print(f"Built '{skill.name}' from {skill.rel}")

--- a/skill-templates/universes/equity/fundamental-universes/SKILL.md
+++ b/skill-templates/universes/equity/fundamental-universes/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: fundamental-universes
+description: Use when reading Morningstar fundamental fields off a `Fundamental` object in a QuantConnect/LEAN algorithm — anything under py`f.financial_statements.*`cs`f.FinancialStatements.*`, py`f.operation_ratios.*`cs`f.OperationRatios.*`, py`f.valuation_ratios.*`cs`f.ValuationRatios.*`, py`f.earning_ratios.*`cs`f.EarningRatios.*`, etc. inside an py`add_universe(...)`cs`AddUniverse(...)` callback. Triggers — missing-attribute / compile error on a Fundamental property path; questions like "what's the path to net income / operating cash flow / shares outstanding"; coding the Piotroski F-Score, Altman Z-score, Magic Formula, Graham filters, or any custom screen off Morningstar fields. Skip when — the universe is index/ETF-constituent only (py`self.universe.etf(...)`cs`Universe.ETF(...)`).
+---
+
+# Fundamental Property Paths in QuantConnect / LEAN
+
+The Morningstar tree on `Fundamental` is large and deeply nested. py`f.financial_statements.net_income`cs`f.FinancialStatements.NetIncome` does not exist — net income lives on `IncomeStatement`, one level deeper. Use the lookup below instead of guessing from English names; a wrong path wastes a backtest run.
+
+<!-- python-only -->
+## Static type checking
+
+Type-hint your `Fundamental` parameters so the IDE autocompletes paths and flags typos like `netincom` before the backtest runs:
+
+- Callback parameter: `def select(self, fundamentals: list[Fundamental]) -> list[Symbol]:`.
+- Helpers that take one snapshot: `def get_metrics(self, f: Fundamental):`.
+<!-- /python-only -->
+
+## How to read the lookup
+
+- The first row, py`fundamental`cs`Fundamental`, is the root — call this `f` below. It's the object passed into your py`add_universe(...)`cs`AddUniverse(...)` selection callback, and you can also pull a snapshot per-security: py`f = self.securities["SPY"].fundamentals`cs`var f = Securities["SPY"].Fundamentals`. Every other path chains from `f`.
+- Each heading after the root is the accessor name from its parent. py`company_reference`cs`CompanyReference` means py`f.company_reference`cs`f.CompanyReference`; py`income_statement`cs`IncomeStatement` is reached as py`f.financial_statements.income_statement`cs`f.FinancialStatements.IncomeStatement`.
+- Comma-separated values are properties on that node. Chain them: under py`income_statement`cs`IncomeStatement`, py`net_income`cs`NetIncome` is py`f.financial_statements.income_statement.net_income`cs`f.FinancialStatements.IncomeStatement.NetIncome`.
+- A trailing `*` marks a `MultiPeriodField` wrapper — append a period accessor (most often py`.value`cs`.Value`) to read the number. Unmarked properties return their type directly (number / string, or another node listed).
+- The helper classes at the bottom (e.g. `MorningstarSectorCode`) hold named integer constants for comparison: py`f.asset_classification.morningstar_sector_code == MorningstarSectorCode.TECHNOLOGY`cs`f.AssetClassification.MorningstarSectorCode == MorningstarSectorCode.Technology`. 
+
+## Period accessors for `*` properties
+
+- py`.three_months`cs`.ThreeMonths`, py`.six_months`cs`.SixMonths`, py`.nine_months`cs`.NineMonths`, py`.twelve_months`cs`.TwelveMonths` — period-aggregated value (TTM at py`.twelve_months`cs`.TwelveMonths`).
+- py`.value`cs`.Value` — most recent reported period (quarterly or annual, whichever filed last).
+- py`.one_month`cs`.OneMonth`, py`.two_months`cs`.TwoMonths` — short-window aggregates (rare).
+
+How to choose:
+
+- **Income statement / cash flow**: prefer py`.twelve_months`cs`.TwelveMonths` for cross-company comparability. py`.value`cs`.Value` mixes quarterlies and annuals.
+- **Balance sheet**: py`.value`cs`.Value` — point-in-time snapshots; period aggregation is meaningless.
+- **Ratio groups**: also `MultiPeriodField` — py`.value`cs`.Value` unless you specifically want a longer window.
+
+Forgetting an accessor is silent: the leaf compares as truthy and inequalities against numbers produce nonsense without raising.
+
+<!-- fundamental-lookup -->
+
+## Year-over-year deltas
+
+`Fundamental` exposes only the latest reported period. Piotroski / Altman / changes-in-X screens need an earlier snapshot — store one per symbol keyed on py`f.financial_statements.period_ending_date.value`cs`f.FinancialStatements.PeriodEndingDate.Value` and compare against it on later bars.


### PR DESCRIPTION
## Summary

- Adds `skill-templates/universes/equity/fundamental-universes/SKILL.md` — a Morningstar property-path reference for `Fundamental` (financial statements, ratio groups, asset classification, Morningstar enum helpers) plus a Python type-hinting note.
- Extends `skill-templates/bundle-skills.py` with an inspector-driven lookup builder. When a SKILL.md contains `<!-- fundamental-lookup -->`, the bundler walks the Fundamental tree via the QC inspector (`/services/inspector?language=…&type=T:QuantConnect.Data.Fundamental.<TypeName>`) and replaces the marker per-language: root pinned to top, chainable types alphabetised (case-insensitive), `MultiPeriodField` wrappers flagged with `*`, and enum helper classes (`MorningstarSectorCode` etc.) listed at the bottom with their named integer constants.

## Test plan

- [x] `python3 skill-templates/bundle-skills.py` runs cleanly and reports "Built 6 skill(s)".
- [x] Built `skills/python/universes/equity/fundamental-universes/SKILL.md` contains the `## Static type checking` section (Python-only block).
- [x] Built `skills/csharp/universes/equity/fundamental-universes/SKILL.md` does not contain the `## Static type checking` section.
- [x] Both built files contain a `- **fundamental**` / `- **Fundamental**` row pinned at the top of the lookup, followed by chainable types alphabetically, then helper classes.
- [x] `MultiPeriodField` properties (e.g. `net_income*` / `NetIncome*`) carry the `*` suffix in both languages.
- [x] Enum helpers are emitted with the right casing: Python `BASIC_MATERIALS`, C# `BasicMaterials`.
- [x] `<!-- fundamental-lookup -->` marker is fully replaced (no leftover marker in built output).