### PR TITLE
Add Alternative Data Universes SKILL with code generator

### DIFF
--- a/code-generators/Alternative-Datasets-Code-Generator.py
+++ b/code-generators/Alternative-Datasets-Code-Generator.py
@@ -82,17 +82,80 @@ def _parse_content(content):
         content = content.replace(old, new)      
     return content
 
+ALT_UNIVERSE_SKILL_PATH = 'skill-templates/universes/equity/alternative-data-universes/SKILL.md'
+
+ALT_UNIVERSE_SKILL_DESCRIPTION = (
+    "Use when selecting a dynamic Equity universe from an alternative-data class in a "
+    "QuantConnect/LEAN algorithm — calling py`add_universe(<AltClass>, selector)`"
+    "cs`AddUniverse<AltClass>(selector)` with Brain, CoinGecko, EOD Historical Data, "
+    "Quiver Quantitative, or Smart Insider universe classes. "
+    "Triggers — questions like \"which class do I pass to add_universe for Brain sentiment / "
+    "Quiver insider trades / Smart Insider buybacks / EODHD upcoming earnings / "
+    "CoinGecko market cap\", missing-class compile errors on names like "
+    "`BrainSentimentIndicatorUniverse` or `EODHDUpcomingEarnings`. "
+    "Skip when — the universe is Morningstar Fundamental (use `fundamental-universes`), "
+    "ETF constituents (use py`self.universe.etf(...)`cs`Universe.ETF(...)`), or pure "
+    "indicator-driven selection (use `indicator-universes`)."
+)
+
+def _alt_universe_snippet(cls):
+    return f"""```python
+def initialize(self) -> None:
+    self._universe = self.add_universe({cls}, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[{cls}]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{{
+    _universe = AddUniverse<{cls}>(UniverseSelection);
+}}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<{cls}> altCoarse)
+{{
+    return Universe.Unchanged;
+}}
+```"""
+
+def _build_alt_universe_skill(skill_data):
+    parts = [
+        "---",
+        "name: alternative-data-universes",
+        f"description: {ALT_UNIVERSE_SKILL_DESCRIPTION}",
+        "---",
+        "",
+        "# Available Alternative Data Universes",
+        "",
+        "The snippets below show how to call py`add_universe(<AltClass>, selector)`"
+        "cs`AddUniverse<AltClass>(selector)` with each alternative-data universe class. "
+        "Replace py`Universe.UNCHANGED`cs`Universe.Unchanged` with your selection logic.",
+        "",
+    ]
+    for dataset_name, classes in skill_data:
+        parts.append(f"## {dataset_name}")
+        parts.append("")
+        for cls in classes:
+            parts.append(_alt_universe_snippet(cls))
+            parts.append("")
+    return "\n".join(parts).rstrip() + "\n"
+
+
 if __name__ == '__main__':
-    url = "https://s3.amazonaws.com/cdn.quantconnect.com/web/docs/alternative-data-dump-v2024-01-02.json"    
-    docs = sorted(
-        json.loads(urlopen(url).read().decode('utf-8')), 
-        key=lambda x: x["vendorName"].strip()
-    )
+    url = "https://s3.amazonaws.com/cdn.quantconnect.com/web/docs/alternative-data-dump-v2024-01-02.json"
+    docs = json.loads(urlopen(url).read().decode('utf-8'))
+    for d in docs:
+        if d["vendorName"].strip() == "CoinAPI":
+            d["vendorName"] = "QuantConnect"
+    docs = sorted(docs, key=lambda x: x["vendorName"].strip())
 
     docs_by_vendor = {k : sorted(v, key=lambda x: x['name'].strip())
         for k,v in groupby(docs, lambda x: x["vendorName"].strip())}
 
-    priority = ["QuantConnect", "AlgoSeek", "Morningstar", "TickData", "CoinAPI", "OANDA"]
+    priority = ["QuantConnect", "AlgoSeek", "Morningstar", "TickData", "OANDA"]
     vendors = [x for x in priority if x in docs_by_vendor]
     vendors += [k for k in docs_by_vendor if k not in vendors]
 
@@ -122,7 +185,9 @@ if __name__ == '__main__':
     <tbody>
 """
     data_tree_attr_pattern = r'data-tree="([^"]*)"'
-    
+    add_universe_class_pattern = r'add_universe\(\s*([A-Z]\w+)'
+    alt_universe_skill_data = []
+
     for i, vendor in enumerate(vendors):
         path = f'{DATASET}/{i+2:02} {vendor}'
         vendor_folder = Path(path)
@@ -151,7 +216,9 @@ if __name__ == '__main__':
                 final_sections["Data Point Attributes"] = data_point_attributes
             all_sections.update(final_sections)
 
-            for k, (title, content) in enumerate(all_sections.items()):        
+            universe_section_fallback_classes = []
+
+            for k, (title, content) in enumerate(all_sections.items()):
                 content = _parse_content(content)
                 for old, new in languages.items():
                     content = content.replace(old, new)
@@ -188,12 +255,20 @@ if __name__ == '__main__':
         </tr>
 """
                 if title.strip() == "Universe Selection" and vendor not in priority:
+                    seen = set()
+                    universe_section_fallback_classes = [
+                        m for m in re.findall(add_universe_class_pattern, content)
+                        if not (m in seen or seen.add(m))
+                    ]
                     alt_universe_html_ = f"<a href=\"/docs/v2/writing-algorithms/datasets/{vendor.lower().replace(' ', '-')}/{name.lower().replace(' ', '-')}#{k+1:02}-Universe-Selection\">"
                     alt_universe_html += "    <li>" + alt_universe_html_ + f"{name}</a></li>" + "\n"
                     universe_html = universe_html.replace(alt_universe_html_.split('#')[0], alt_universe_html_)
 
                 with open(folder / f'{1+k:02} {title.strip()}.html', "w", encoding="utf-8") as html_file:
                     html_file.write(content)
+
+            if vendor not in priority and universe_section_fallback_classes:
+                alt_universe_skill_data.append((name, universe_section_fallback_classes))
 
             print(f'Documentation of {dataset["name"]} is generated and inplace!')
 
@@ -202,6 +277,11 @@ if __name__ == '__main__':
     
     with open('Resources/datasets/supported-alternative-dataset-universe.html', "w", encoding="utf-8") as html_file:
         html_file.write(alt_universe_html + "</ul>")
+
+    skill_path = Path(ALT_UNIVERSE_SKILL_PATH)
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(skill_path, "w", encoding="utf-8") as skill_file:
+        skill_file.write(_build_alt_universe_skill(alt_universe_skill_data))
         
     with open('Resources/datasets/available-universe.html', "w", encoding="utf-8") as html_file:
         html_file.write(universe_html + """</tbody>

--- a/skill-templates/universes/equity/alternative-data-universes/SKILL.md
+++ b/skill-templates/universes/equity/alternative-data-universes/SKILL.md
@@ -1,0 +1,390 @@
+---
+name: alternative-data-universes
+description: Use when selecting a dynamic Equity universe from an alternative-data class in a QuantConnect/LEAN algorithm — calling py`add_universe(<AltClass>, selector)`cs`AddUniverse<AltClass>(selector)` with Brain, CoinGecko, EOD Historical Data, Quiver Quantitative, or Smart Insider universe classes. Triggers — questions like "which class do I pass to add_universe for Brain sentiment / Quiver insider trades / Smart Insider buybacks / EODHD upcoming earnings / CoinGecko market cap", missing-class compile errors on names like `BrainSentimentIndicatorUniverse` or `EODHDUpcomingEarnings`. Skip when — the universe is Morningstar Fundamental (use `fundamental-universes`), ETF constituents (use py`self.universe.etf(...)`cs`Universe.ETF(...)`), or pure indicator-driven selection (use `indicator-universes`).
+---
+
+# Available Alternative Data Universes
+
+The snippets below show how to call py`add_universe(<AltClass>, selector)`cs`AddUniverse<AltClass>(selector)` with each alternative-data universe class. Replace py`Universe.UNCHANGED`cs`Universe.Unchanged` with your selection logic.
+
+## Brain Language Metrics on Company Filings
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(BrainCompanyFilingLanguageMetricsUniverseAll, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[BrainCompanyFilingLanguageMetricsUniverseAll]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<BrainCompanyFilingLanguageMetricsUniverseAll>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<BrainCompanyFilingLanguageMetricsUniverseAll> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## Brain ML Stock Ranking
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(BrainStockRankingUniverse, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[BrainStockRankingUniverse]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<BrainStockRankingUniverse>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<BrainStockRankingUniverse> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## Brain Sentiment Indicator
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(BrainSentimentIndicatorUniverse, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[BrainSentimentIndicatorUniverse]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<BrainSentimentIndicatorUniverse>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<BrainSentimentIndicatorUniverse> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## Crypto Market Cap
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(CoinGeckoUniverse, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[CoinGeckoUniverse]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<CoinGeckoUniverse>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<CoinGeckoUniverse> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## Upcoming Dividends
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(EODHDUpcomingDividends, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[EODHDUpcomingDividends]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<EODHDUpcomingDividends>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<EODHDUpcomingDividends> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## Upcoming Earnings
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(EODHDUpcomingEarnings, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[EODHDUpcomingEarnings]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<EODHDUpcomingEarnings>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<EODHDUpcomingEarnings> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## Upcoming IPOs
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(EODHDUpcomingIPOs, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[EODHDUpcomingIPOs]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<EODHDUpcomingIPOs>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<EODHDUpcomingIPOs> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## Upcoming Splits
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(EODHDUpcomingSplits, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[EODHDUpcomingSplits]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<EODHDUpcomingSplits>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<EODHDUpcomingSplits> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## CNBC Trading
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(QuiverCNBCsUniverse, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[QuiverCNBCsUniverse]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<QuiverCNBCsUniverse>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<QuiverCNBCsUniverse> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## Corporate Lobbying
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(QuiverLobbyingUniverse, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[QuiverLobbyingUniverse]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<QuiverLobbyingUniverse>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<QuiverLobbyingUniverse> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## Insider Trading
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(QuiverInsiderTradingUniverse, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[QuiverInsiderTradingUniverse]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<QuiverInsiderTradingUniverse>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<QuiverInsiderTradingUniverse> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## US Congress Trading
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(QuiverQuantCongressUniverse, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[QuiverQuantCongressUniverse]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<QuiverQuantCongressUniverse>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<QuiverQuantCongressUniverse> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## US Government Contracts
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(QuiverGovernmentContractUniverse, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[QuiverGovernmentContractUniverse]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<QuiverGovernmentContractUniverse>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<QuiverGovernmentContractUniverse> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## WallStreetBets
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(QuiverWallStreetBetsUniverse, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[QuiverWallStreetBetsUniverse]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<QuiverWallStreetBetsUniverse>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<QuiverWallStreetBetsUniverse> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+## Corporate Buybacks
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(SmartInsiderIntentionUniverse, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[SmartInsiderIntentionUniverse]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<SmartInsiderIntentionUniverse>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<SmartInsiderIntentionUniverse> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```
+
+```python
+def initialize(self) -> None:
+    self._universe = self.add_universe(SmartInsiderTransactionUniverse, self.universe_selection)
+
+def universe_selection(self, alt_coarse: List[SmartInsiderTransactionUniverse]) -> List[Symbol]:
+    return Universe.UNCHANGED
+```
+
+```csharp
+private Universe _universe;
+
+public override void Initialize()
+{
+    _universe = AddUniverse<SmartInsiderTransactionUniverse>(UniverseSelection);
+}
+
+private IEnumerable<Symbol> UniverseSelection(IEnumerable<SmartInsiderTransactionUniverse> altCoarse)
+{
+    return Universe.Unchanged;
+}
+```


### PR DESCRIPTION
## Summary

- Generates `skill-templates/universes/equity/alternative-data-universes/SKILL.md` from the alternative data dump. The SKILL.md is dual-language (Python + C#) and contains one `add_universe(<Class>, selector)` snippet per universe class extracted from each dataset's Universe Selection page.
- Reassigns CoinAPI datasets to the QuantConnect vendor by rewriting `vendorName` after loading the JSON, so they live under `02 QuantConnect/` instead of their own `06 CoinAPI/` folder; `priority` no longer needs the CoinAPI slot.

## Test plan

- [ ] Run `python3 code-generators/Alternative-Datasets-Code-Generator.py` and confirm `skill-templates/universes/equity/alternative-data-universes/SKILL.md` is generated with one section per alt-data dataset and Python + C# snippets per universe class.
- [ ] Confirm the existing `06 CoinAPI/` folder is removed and its datasets land under `02 QuantConnect/` with sequential numbering.
- [ ] Confirm `Resources/datasets/supported-alternative-dataset-universe.html` and `Resources/datasets/available-universe.html` regenerate without unintended diffs.
- [ ] Run `python3 skill-templates/bundle-skills.py` and confirm the new skill validates and bundles into `skills/python` and `skills/csharp`.