### PR TITLE
Add alternative-data universe project templates

### DIFF
--- a/project-templates/alternative-data-universe-spec.md
+++ b/project-templates/alternative-data-universe-spec.md
@@ -1,0 +1,313 @@
+# Adding an Alternative-Data Universe Template
+
+End-to-end recipe for adding a new `alternative-data-universe-<class>` template (Python + C#) and verifying it on QuantConnect Cloud. Each entry pairs a docs Universe Selection example with the universal scheduled-rebalance trading wrapper, then deploys and backtests both languages to confirm parity.
+
+## 1. Inputs
+
+For the new universe, you need:
+
+- **Universe class name** (e.g. `QuiverCNBCsUniverse`, `BrainStockRankingUniverse`)
+- **Selection logic** from `03 Writing Algorithms/14 Datasets/<provider>/<dataset>/<NN> Universe Selection.html` (Python and C# blocks). Some datasets show the universe under `Example Applications.html` instead.
+- **Friendly title** for the QC Cloud project name and the templates.json entry (e.g. "WallStreetBets")
+
+## 2. Outputs
+
+For each universe, produce:
+
+| File | Purpose |
+| --- | --- |
+| `project-templates/python/alternative-data-universe-<class>/main.py` | Python template |
+| `project-templates/csharp/alternative-data-universe-<class>/Main.cs` | C# template |
+| `project-templates/python/templates.json` | Add one entry to the array |
+| QC Cloud project `Docs/Templates/AlternativeData/<friendly> Python` | Deployed + backtested |
+| QC Cloud project `Docs/Templates/AlternativeData/<friendly> CSharp` | Deployed + backtested |
+
+The `templates.json` lives only on the python side and is the single registry for both languages.
+
+## 3. Folder naming
+
+`<class>` is the Universe class name lowercased with no separators:
+
+| Class | Folder slug |
+| --- | --- |
+| `QuiverCNBCsUniverse` | `quivercnbcsuniverse` |
+| `BrainCompanyFilingLanguageMetricsUniverseAll` | `braincompanyfilinglanguagemetricsuniverseall` |
+| `EODHDUpcomingEarnings` | `eodhdupcomingearnings` |
+
+Smart Insider exposes two universe classes (`SmartInsiderIntentionUniverse`, `SmartInsiderTransactionUniverse`); produce one template per class.
+
+## 4. Trading wrapper (universal)
+
+Both Python and C# templates use the same shape: dynamic universe + scheduled daily rebalance + equal weight. The user-facing trading logic lives entirely in the rebalance method and is identical across all templates. **Do not** swap in `ConstantAlphaModel` / `EqualWeightingPortfolioConstructionModel` — those were the old shape and have been replaced.
+
+### Python skeleton
+
+```python
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class <Name>UniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # <one-line description of what passes the filter>
+        self._universe = self.add_universe(<UniverseClass>, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[<UniverseClass>]) -> List[Symbol]:
+        # <selection comment>
+        return [d.symbol for d in data
+                if <truthy guard> and <comparison> ...]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)
+```
+
+### C# skeleton
+
+```csharp
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class <Name>UniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // <one-line description of what passes the filter>
+            _universe = AddUniverse<<UniverseClass>>(data =>
+            {
+                return from d in data.OfType<<UniverseClass>>()
+                       where <conditions>
+                       select d.Symbol;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}
+```
+
+Add `using QuantConnect.Orders;` if the selection touches `OrderDirection`. Add `using System.Collections.Generic;` if the selection builds a `Dictionary` for aggregation.
+
+## 5. Selection-clause conventions
+
+### Python — one-liner with positive truthy guard
+
+When the comparison is `> Y` for a positive Y, write:
+
+```python
+return [d.symbol for d in data
+        if d.amount and d.amount > 200000
+        and d.transaction == OrderDirection.BUY]
+```
+
+`d.amount and d.amount > 200000` reads "amount is truthy AND > 200000". The truthy short-circuit handles None safely. **Do not** use `not d.amount and ...` — that inverts the meaning and raises on None. **Do not** use `d.amount is not None and ...` — verbose; the truthy form is preferred.
+
+For nested attributes (Brain Language Metrics), guard each level:
+
+```python
+return [d.symbol for d in data
+        if d.report_sentiment and d.report_sentiment.sentiment and d.report_sentiment.sentiment > 0
+        ...]
+```
+
+For aggregations across multiple records per symbol (Lobbying, Insider Trading, Government Contracts, CNBC), use a dict and a list comprehension; coerce `None` numeric fields with `(x.amount or 0)` inside `sum()`:
+
+```python
+def _select_assets(self, data):
+    by_symbol = {}
+    for d in data:
+        by_symbol.setdefault(d.symbol, []).append(d)
+    return [s for s, ds in by_symbol.items()
+            if len(ds) >= 3 and sum(x.amount or 0 for x in ds) > 50000]
+```
+
+### C# — LINQ `where ... select`
+
+C# nullable decimals (`decimal?`) silently return false on `null > 0m`, so the docs C# can be ported as-is. Aggregations use `GroupBy(x => x.Symbol)` + `Sum`/`Count`.
+
+## 6. Attribute-name gotcha (Python)
+
+QC's pythonnet generates snake_case aliases by inserting an underscore on **both sides** of each digit run:
+
+| C# property | Python (snake_case) | Wrong form often shown in docs HTML |
+| --- | --- | --- |
+| `Rank2Days` | `rank_2_days` | `rank2_days` |
+| `Sentiment7Days` | `sentiment_7_days` | `sentiment7_days` |
+| `TotalArticleMentions7Days` | `total_article_mentions_7_days` | `total_article_mentions7_days` |
+
+Both PascalCase (`Rank2Days`) and the correct snake_case work in Python; prefer snake_case for idiomatic templates.
+
+If unsure, probe by uploading a one-shot algorithm that raises with the attribute list:
+
+```python
+def _select(self, data):
+    for d in data:
+        attrs = sorted(a for a in dir(d) if not a.startswith('_') and 'rank' in a.lower())
+        raise RuntimeError(f"PROBE: {attrs}")
+    return []
+```
+
+The exception message lands in `/backtests/read` → `backtest.error`. (There is no `/backtests/read/logs` endpoint in QC Cloud API v2 — `self.debug` output isn't retrievable that way.)
+
+## 7. `add_universe` signature variants
+
+Most universes take the 2-arg form `add_universe(<Class>, selector)`. A few take a 4-arg form with explicit name + resolution — keep the original signature from the docs:
+
+```python
+self._universe = self.add_universe(QuiverLobbyingUniverse, "QuiverLobbyingUniverse",
+                                   Resolution.DAILY, self._select_assets)
+
+self._universe = self.add_universe(CoinGeckoUniverse, "CoinGeckoUniverse",
+                                   Resolution.DAILY, self._select_assets)
+```
+
+C# equivalent:
+
+```csharp
+_universe = AddUniverse<QuiverLobbyingUniverse>("QuiverLobbyingUniverse", Resolution.Daily, data => ...);
+```
+
+## 8. `templates.json` entry
+
+Append one entry to `project-templates/python/templates.json` inside the `templates` array (after the existing alt-data-universe entries to keep them grouped):
+
+```json
+{
+    "name": "Alternative Data Universe for <Friendly Title>",
+    "folder": "alternative-data-universe-<class>",
+    "description": "Selects <criteria> and equal-weights them with a daily scheduled rebalance.",
+    "tags": ["alternative-data", "universe", "equity"]
+}
+```
+
+- **Description style:** "Selects <noun phrase from filter> and equal-weights them with a daily scheduled rebalance." Two clauses — what's selected, how it trades.
+- **Tags:** always `["alternative-data", "universe", <asset-tag>]`. Asset tag is `equity` for stock universes, `crypto` for CoinGecko. Add a second domain tag (e.g. `earnings`, `dividends`, `splits`, `ipos`) for the EODHD upcoming-event datasets.
+- After editing, validate with `python -c "import json; json.load(open(r'project-templates/python/templates.json'))"`.
+
+## 9. Syntax-check before deploy
+
+Before creating a QC Cloud project, run each entry file through `/ai/tools/syntax-check` (see [.claude/skills/qc-cloud-backtest/SKILL.md](.claude/skills/qc-cloud-backtest/SKILL.md), Step 0). The endpoint is free and fast — it catches typos and missing imports that would otherwise cost a project + a compile round-trip and leave a dead project behind.
+
+Response shape: `{state, payload}`. `state == "End"` means clean. `state == "Error"` means `payload` is a list of human-readable error strings. **Use the payload to fix the source locally**, then re-check until clean. Only proceed to `/projects/create` after a clean check for both Python and C#.
+
+```python
+def syntax_check(language, entry_file, source):
+    r = post(f"{BASE_URL}/ai/tools/syntax-check", headers=headers(), json={
+        "language": language,  # "Py" or "C#"
+        "files": [{"name": entry_file, "content": source}],
+    }).json()
+    if r.get("state") == "Error":
+        raise RuntimeError(f"Syntax errors in {entry_file}:\n" + "\n".join(r["payload"]))
+
+syntax_check("Py", "main.py", py_path.read_text())
+syntax_check("C#", "Main.cs", cs_path.read_text())
+```
+
+Common payload categories worth auto-fixing in templates:
+
+| Payload pattern | Fix |
+| --- | --- |
+| Missing `using` for `OrderDirection` / `PortfolioTarget` / `DataSource` types | Add the corresponding `using QuantConnect.Orders;` / `QuantConnect.Algorithm.Framework.Portfolio;` / `QuantConnect.DataSource;` |
+| Unknown class name (e.g. `QuiverQuantCongresssUniverse` with three s's) | Cross-check the docs typo against the actual class name (often the cleaner spelling); update the template |
+| `'EODHD' is a type not a namespace` (C#) | The `EODHD` symbol is itself a class containing nested types. Drop `using QuantConnect.DataSource.EODHD;`, fully qualify the nested type as `EODHD.DealType` (with `using QuantConnect.DataSource;` already present). |
+| `'>' not supported between instances of 'NoneType' and 'int'` won't surface here — it's a runtime-only issue. Section 6 still applies. | — |
+
+### Known false positives
+
+`/ai/tools/syntax-check` uses static type stubs that are sometimes stale relative to the deployed runtime. When a payload reports `"<Class>" has no attribute "x"` (Python) or `<Class> does not contain a definition for X` (C#), and the docs HTML used `x`/`X`, **verify against the runtime probe** (section 6) before changing the template:
+
+- If `dir(d)` confirms the attribute exists at runtime, the template is correct — ignore the syntax-check error.
+- Witnessed example: `QuiverQuantCongressUniverse` exposes both `amount`/`Amount` and `transaction`/`Transaction` at runtime, but syntax-check claims neither exists and suggests fictitious `amount_value`/`direction` replacements. The original docs names are right.
+
+This step does **not** replace the compile step (section 10) — `/compile/create` performs deeper checks (type resolution, framework references). Syntax-check is a cheap pre-filter, with the false-positive caveat above.
+
+## 10. Deploy + backtest on QC Cloud
+
+Use the QC Cloud API v2 (see [.claude/skills/qc-cloud-backtest/SKILL.md](.claude/skills/qc-cloud-backtest/SKILL.md)). Project names: `Docs/Templates/AlternativeData/<friendly> Python` and `Docs/Templates/AlternativeData/<friendly> CSharp`.
+
+For batches of universes, run pairs sequentially (Python and C# in the same iteration), waiting for both backtests before moving to the next pair. Reuse already-deployed projects when iterating on fixes (`/files/update` + `/compile/create` instead of creating a new project each time). Track which project IDs already have a passing backtest so you don't redo them.
+
+End-to-end pseudocode for one pair (assumes both files passed section 9):
+
+```python
+py_id = create_project(f"Docs/Templates/AlternativeData/{friendly} Python", "Py")
+cs_id = create_project(f"Docs/Templates/AlternativeData/{friendly} CSharp", "C#")
+
+for pid, entry, source in [(py_id, "main.py", py_path), (cs_id, "Main.cs", cs_path)]:
+    upload(pid, entry, source)
+    cid = start_compile(pid)
+    poll_compile(pid, cid)  # state must be "BuildSuccess"
+    bid = start_backtest(pid, cid, run_name)
+    bt = poll_backtest(pid, bid)  # poll /backtests/read until completed=True
+    print(bt["status"], bt["statistics"])
+```
+
+## 11. Validation criteria
+
+A new pair is good when **all** hold:
+
+1. Both Python and C# `BuildSuccess`.
+2. Both backtests reach status `Completed.` (not `Runtime Error`).
+3. Their statistics match — same `Net Profit`, `Total Orders`, `Win Rate`, `Drawdown`. Mismatched stats mean the selection logic diverged between languages.
+
+`Total Orders: 0` is acceptable when the dataset is genuinely sparse over the backtest window (Brain Sentiment Indicator with `> 0` on both sentiment and mentions falls in this bucket). It is **not** acceptable if only one language returns 0 — that signals a Python attribute-name bug or a None comparison that silently filters everything in C#.
+
+## 12. Special cases
+
+- **Crypto (CoinGecko)** — both Python and C# Runtime Error under the universal wrapper because crypto holdings interact differently with `set_holdings(liquidate_existing_holdings=True)` (cash currency holdings are not equity positions). The CoinGecko template needs additional setup: a brokerage model (`set_brokerage_model(BrokerageName.COINBASE, AccountType.CASH)`) and likely a different rebalance pattern. Treat as a separate effort — the universe selection is fine, the trading wrapper is not.
+- **Brain Sentiment Indicator** — selects 0 stocks under `sentiment_7_days > 0 AND total_article_mentions_7_days > 0` for the default Sep–Dec 2024 window. This is data sparsity, not a bug. Both Python and C# return 0 orders identically; ship as-is.
+- **Smart Insider** — two universe classes share one dataset. Produce two separate templates (`smartinsiderintentionuniverse`, `smartinsidertransactionuniverse`).
+- **Brain Language Metrics MD&A field** — keep the long attribute name `management_discussion_analyasis_of_financial_condition_and_results_of_operations` verbatim, including the `analyasis` typo carried by the SDK.
+
+## 13. Order of work for a new universe
+
+1. Read `<NN> Universe Selection.html` (and `Example Applications.html` for context).
+2. Create the two folders under `project-templates/python/` and `project-templates/csharp/`.
+3. Write `main.py` and `Main.cs` from the skeletons in section 4, plugging in the selection clause from section 5.
+4. Add the `templates.json` entry per section 8 and validate JSON.
+5. Run `/ai/tools/syntax-check` against both files (section 9). Fix any payload errors locally and re-check until clean.
+6. Deploy both projects on QC Cloud per section 10.
+7. Backtest both, confirm the validation criteria in section 11.
+8. If Python fails with `AttributeError`, probe attributes (section 6) and fix; redeploy file via `/files/update` and rerun.
+9. If Python and C# stats diverge, audit the selection clause for None handling (Python truthy guard) — C# silently passes through nulls.

--- a/project-templates/csharp/alternative-data-universe-braincompanyfilinglanguagemetricsuniverseall/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-braincompanyfilinglanguagemetricsuniverseall/Main.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class BrainCompanyFilingLanguageMetricsUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of US Equities with positive sentiment in their latest SEC filings.
+            _universe = AddUniverse<BrainCompanyFilingLanguageMetricsUniverseAll>(data =>
+            {
+                // Keep names with positive sentiment in both the report and MD&A sections.
+                return from d in data.OfType<BrainCompanyFilingLanguageMetricsUniverseAll>()
+                       where d.ReportSentiment.Sentiment > 0m
+                          && d.ManagementDiscussionAnalyasisOfFinancialConditionAndResultsOfOperations.Sentiment > 0m
+                       select d.Symbol;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-brainsentimentindicatoruniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-brainsentimentindicatoruniverse/Main.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class BrainSentimentIndicatorUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of US Equities with positive 7-day media sentiment and active mention coverage.
+            _universe = AddUniverse<BrainSentimentIndicatorUniverse>(data =>
+            {
+                // Keep names with both active mention coverage and positive 7-day sentiment.
+                return from d in data.OfType<BrainSentimentIndicatorUniverse>()
+                       where d.TotalArticleMentions7Days > 0m && d.Sentiment7Days > 0m
+                       select d.Symbol;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-brainstockrankinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-brainstockrankinguniverse/Main.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class BrainStockRankingUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of US Equities with positive Brain ML rankings across 2-, 3-, and 5-day horizons.
+            _universe = AddUniverse<BrainStockRankingUniverse>(data =>
+            {
+                // Keep names with consistent positive momentum across all three horizons.
+                return from d in data.OfType<BrainStockRankingUniverse>()
+                       where d.Rank2Days > 0m && d.Rank3Days > 0m && d.Rank5Days > 0m
+                       select d.Symbol;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-coingeckouniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-coingeckouniverse/Main.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class CoinGeckoUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+        private string _market;
+        private List<string> _marketPairs;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+            SetAccountCurrency("USD");
+
+            // Trade the largest CoinGecko coins on Coinbase quoted in USD.
+            _market = Market.Coinbase;
+            _marketPairs = SymbolPropertiesDatabase.GetSymbolPropertiesList(_market)
+                .Where(x => x.Value.QuoteCurrency == AccountCurrency)
+                .Select(x => x.Key.Symbol)
+                .ToList();
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of the top 10 CoinGecko coins by market cap that we can trade.
+            _universe = AddUniverse<CoinGecko>("CoinGeckoUniverse", Resolution.Daily, data =>
+            {
+                return data
+                    .OfType<CoinGecko>()
+                    // Keep coins quoted in our account currency on the chosen brokerage.
+                    .Where(c => _marketPairs.Contains(c.Coin + AccountCurrency))
+                    // Take the 10 largest by market cap and create their tradable Symbols.
+                    .OrderByDescending(c => c.MarketCap)
+                    .Take(10)
+                    .Select(c => c.CreateSymbol(_market, AccountCurrency));
+            });
+
+            // Rebalance daily on US trading days, after CoinGecko refreshes overnight.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-eodhdupcomingdividends/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-eodhdupcomingdividends/Main.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class EODHDUpcomingDividendsUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of US Equities going ex-dividend in the next day with a meaningful payout.
+            _universe = AddUniverse<EODHDUpcomingDividends>(data =>
+            {
+                // Keep names with a dividend over $0.05 paying within one day.
+                return from d in data.OfType<EODHDUpcomingDividends>()
+                       where d.DividendDate <= Time.AddDays(1) && d.Dividend > 0.05m
+                       select d.Symbol;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-eodhdupcomingearnings/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-eodhdupcomingearnings/Main.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class EODHDUpcomingEarningsUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of US Equities reporting earnings in the next 3 days with a positive estimate.
+            _universe = AddUniverse<EODHDUpcomingEarnings>(data =>
+            {
+                // Keep names with a positive analyst estimate ahead of the report.
+                return from d in data.OfType<EODHDUpcomingEarnings>()
+                       where d.ReportDate <= Time.AddDays(3) && d.Estimate > 0m
+                       select d.Symbol;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-eodhdupcomingipos/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-eodhdupcomingipos/Main.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class EODHDUpcomingIPOsUniverseAlgorithm : QCAlgorithm
+    {
+        private static readonly HashSet<EODHD.DealType> _dealTypesWanted = new() { EODHD.DealType.Expected, EODHD.DealType.Priced };
+
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of confirmed non-penny upcoming IPOs.
+            _universe = AddUniverse<EODHDUpcomingIPOs>(data =>
+            {
+                // Keep expected/priced IPOs with a confirmed date and an above-$1 price band.
+                return from d in data.OfType<EODHDUpcomingIPOs>()
+                       where _dealTypesWanted.Contains(d.DealType)
+                          && d.IpoDate.HasValue
+                          && new[] { d.LowestPrice, d.HighestPrice, d.OfferPrice }
+                                .Where(x => x.HasValue)
+                                .Min().Value > 1m
+                       select d.Symbol;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-eodhdupcomingsplits/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-eodhdupcomingsplits/Main.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class EODHDUpcomingSplitsUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of US Equities with a forward stock split in the next 3 days.
+            _universe = AddUniverse<EODHDUpcomingSplits>(data =>
+            {
+                // Keep names with a forward split (factor > 1) within 3 days.
+                return from d in data.OfType<EODHDUpcomingSplits>()
+                       where d.SplitDate <= Time.AddDays(3) && d.SplitFactor > 1m
+                       select d.Symbol;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-quivercnbcsuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-quivercnbcsuniverse/Main.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class QuiverCNBCsUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            // Trade daily on CNBC opinion updates.
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of US Equities flagged by 3+ positive CNBC opinions.
+            _universe = AddUniverse<QuiverCNBCsUniverse>(data =>
+            {
+                // Group raw CNBC opinions by ticker so we can score each name.
+                var cnbcBySymbol = data.OfType<QuiverCNBCsUniverse>().GroupBy(x => x.Symbol);
+                // Keep names with 3+ BUY recommendations to filter out noise.
+                return from g in cnbcBySymbol
+                       where g.Count(x => x.Direction == OrderDirection.Buy) >= 3
+                       select g.Key;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-quivergovernmentcontractuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-quivergovernmentcontractuniverse/Main.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class QuiverGovernmentContractUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of US Equities with frequent, sizable US government contracts.
+            _universe = AddUniverse<QuiverGovernmentContractUniverse>(data =>
+            {
+                // Group by ticker and keep names with 3+ contracts totalling over $50K.
+                return from g in data.OfType<QuiverGovernmentContractUniverse>().GroupBy(x => x.Symbol)
+                       where g.Count() >= 3 && g.Sum(x => x.Amount) > 50000m
+                       select g.Key;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-quiverinsidertradinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-quiverinsidertradinguniverse/Main.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class QuiverInsiderTradingUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of the 10 US Equities with the largest insider-trading dollar volume.
+            _universe = AddUniverse<QuiverInsiderTradingUniverse>(data =>
+            {
+                // Aggregate insider dollar volume per ticker and keep the 10 largest.
+                var dollarVolume = new Dictionary<Symbol, decimal>();
+                foreach (var d in data.OfType<QuiverInsiderTradingUniverse>())
+                {
+                    if (d.PricePerShare == null || d.PricePerShare == 0m)
+                    {
+                        continue;
+                    }
+                    if (!dollarVolume.ContainsKey(d.Symbol))
+                    {
+                        dollarVolume[d.Symbol] = 0m;
+                    }
+                    dollarVolume[d.Symbol] += (d.Shares ?? 0m) * d.PricePerShare.Value;
+                }
+                return dollarVolume
+                    .OrderByDescending(kvp => kvp.Value)
+                    .Take(10)
+                    .Select(kvp => kvp.Key);
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-quiverlobbyinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-quiverlobbyinguniverse/Main.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class QuiverLobbyingUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of US Equities with material corporate lobbying spend.
+            _universe = AddUniverse<QuiverLobbyingUniverse>("QuiverLobbyingUniverse", Resolution.Daily, data =>
+            {
+                // Aggregate lobbying spend per ticker and keep names spending $100K+.
+                return from g in data.OfType<QuiverLobbyingUniverse>().GroupBy(x => x.Symbol)
+                       where g.Sum(x => x.Amount) >= 100000m
+                       select g.Key;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-quiverquantcongressuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-quiverquantcongressuniverse/Main.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class QuiverQuantCongressUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of US Equities recently bought by US Congress members in trades over $200K.
+            _universe = AddUniverse<QuiverQuantCongressUniverse>(data =>
+            {
+                // Keep buy disclosures over $200K to filter out small reports.
+                return from d in data.OfType<QuiverQuantCongressUniverse>()
+                       where d.Amount > 200000m && d.Transaction == OrderDirection.Buy
+                       select d.Symbol;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-smartinsiderintentionuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-smartinsiderintentionuniverse/Main.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class SmartInsiderIntentionUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of large-cap US Equities announcing meaningful buyback intentions.
+            _universe = AddUniverse<SmartInsiderIntentionUniverse>(data =>
+            {
+                // Keep $100M+ market-cap names announcing a buyback over 0.5% of shares.
+                return from d in data.OfType<SmartInsiderIntentionUniverse>()
+                       where d.Percentage > 0.005m && d.USDMarketCap > 100000000m
+                       select d.Symbol;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/csharp/alternative-data-universe-smartinsidertransactionuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-universe-smartinsidertransactionuniverse/Main.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class SmartInsiderTransactionUniverseAlgorithm : QCAlgorithm
+    {
+        private Universe _universe;
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 9, 1);
+            SetEndDate(2024, 12, 31);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            // Universe of large-cap US Equities executing meaningful share buybacks.
+            _universe = AddUniverse<SmartInsiderTransactionUniverse>(data =>
+            {
+                // Keep $100M+ market-cap names buying back over 0.5% of shares.
+                return from d in data.OfType<SmartInsiderTransactionUniverse>()
+                       where d.BuybackPercentage > 0.005m && d.USDMarketCap > 100000000m
+                       select d.Symbol;
+            });
+
+            // Rebalance shortly after the open so today's universe is locked in.
+            Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
+        }
+
+        private void Rebalance()
+        {
+            if (_universe.Selected.Count == 0)
+            {
+                return;
+            }
+
+            var weight = 1m / _universe.Selected.Count;
+            var targets = _universe.Selected
+                .Select(symbol => new PortfolioTarget(symbol, weight))
+                .ToList();
+
+            SetHoldings(targets, liquidateExistingHoldings: true);
+        }
+    }
+}

--- a/project-templates/python/alternative-data-universe-braincompanyfilinglanguagemetricsuniverseall/main.py
+++ b/project-templates/python/alternative-data-universe-braincompanyfilinglanguagemetricsuniverseall/main.py
@@ -1,0 +1,34 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class BrainCompanyFilingLanguageMetricsUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of US Equities with positive sentiment in their latest SEC filings.
+        self._universe = self.add_universe(BrainCompanyFilingLanguageMetricsUniverseAll, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[BrainCompanyFilingLanguageMetricsUniverseAll]) -> List[Symbol]:
+        # Keep names with positive sentiment in both the report and MD&A sections.
+        return [d.symbol for d in data
+                if d.report_sentiment and d.report_sentiment.sentiment and d.report_sentiment.sentiment > 0
+                and d.management_discussion_analyasis_of_financial_condition_and_results_of_operations
+                and d.management_discussion_analyasis_of_financial_condition_and_results_of_operations.sentiment
+                and d.management_discussion_analyasis_of_financial_condition_and_results_of_operations.sentiment > 0]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-brainsentimentindicatoruniverse/main.py
+++ b/project-templates/python/alternative-data-universe-brainsentimentindicatoruniverse/main.py
@@ -1,0 +1,32 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class BrainSentimentIndicatorUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of US Equities with positive 7-day media sentiment and active mention coverage.
+        self._universe = self.add_universe(BrainSentimentIndicatorUniverse, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[BrainSentimentIndicatorUniverse]) -> List[Symbol]:
+        # Keep names with both active mention coverage and positive 7-day sentiment.
+        return [d.symbol for d in data
+                if d.total_article_mentions_7_days and d.total_article_mentions_7_days > 0
+                and d.sentiment_7_days and d.sentiment_7_days > 0]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-brainstockrankinguniverse/main.py
+++ b/project-templates/python/alternative-data-universe-brainstockrankinguniverse/main.py
@@ -1,0 +1,33 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class BrainStockRankingUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of US Equities with positive Brain ML rankings across 2-, 3-, and 5-day horizons.
+        self._universe = self.add_universe(BrainStockRankingUniverse, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[BrainStockRankingUniverse]) -> List[Symbol]:
+        # Keep names with consistent positive momentum across all three horizons.
+        return [d.symbol for d in data
+                if d.rank_2_days and d.rank_2_days > 0
+                and d.rank_3_days and d.rank_3_days > 0
+                and d.rank_5_days and d.rank_5_days > 0]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-coingeckouniverse/main.py
+++ b/project-templates/python/alternative-data-universe-coingeckouniverse/main.py
@@ -1,0 +1,43 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class CoinGeckoUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+        self.set_account_currency("USD")
+
+        # Trade the largest CoinGecko coins on Coinbase quoted in USD.
+        self._market = Market.COINBASE
+        self._market_pairs = [
+            x.key.symbol
+            for x in self.symbol_properties_database.get_symbol_properties_list(self._market)
+            if x.value.quote_currency == self.account_currency
+        ]
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of the top 10 CoinGecko coins by market cap that we can trade.
+        self._universe = self.add_universe(CoinGeckoUniverse, "CoinGeckoUniverse", Resolution.DAILY, self._select_assets)
+
+        # Rebalance daily on US trading days, after CoinGecko refreshes overnight.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[CoinGecko]) -> List[Symbol]:
+        # Keep coins quoted in our account currency on the chosen brokerage.
+        tradable = [d for d in data
+                    if d.coin and (d.coin + self.account_currency) in self._market_pairs]
+        # Take the 10 largest by market cap and create their tradable Symbols.
+        return [c.create_symbol(self._market, self.account_currency)
+                for c in sorted(tradable, key=lambda x: x.market_cap or 0)[-10:]]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-eodhdupcomingdividends/main.py
+++ b/project-templates/python/alternative-data-universe-eodhdupcomingdividends/main.py
@@ -1,0 +1,32 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class EODHDUpcomingDividendsUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of US Equities going ex-dividend in the next day with a meaningful payout.
+        self._universe = self.add_universe(EODHDUpcomingDividends, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[EODHDUpcomingDividends]) -> List[Symbol]:
+        # Keep names with a dividend over $0.05 paying within one day.
+        return [d.symbol for d in data
+                if d.dividend_date and d.dividend
+                and d.dividend_date <= self.time + timedelta(1) and d.dividend > 0.05]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-eodhdupcomingearnings/main.py
+++ b/project-templates/python/alternative-data-universe-eodhdupcomingearnings/main.py
@@ -1,0 +1,32 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class EODHDUpcomingEarningsUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of US Equities reporting earnings in the next 3 days with a positive estimate.
+        self._universe = self.add_universe(EODHDUpcomingEarnings, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[EODHDUpcomingEarnings]) -> List[Symbol]:
+        # Keep names with a positive analyst estimate ahead of the report.
+        return [d.symbol for d in data
+                if d.report_date and d.estimate
+                and d.report_date <= self.time + timedelta(3) and d.estimate > 0]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-eodhdupcomingipos/main.py
+++ b/project-templates/python/alternative-data-universe-eodhdupcomingipos/main.py
@@ -1,0 +1,34 @@
+# region imports
+from AlgorithmImports import *
+from QuantConnect.DataSource.EODHD import DealType
+# endregion
+
+class EODHDUpcomingIPOsUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of confirmed non-penny upcoming IPOs.
+        self._universe = self.add_universe(EODHDUpcomingIPOs, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[EODHDUpcomingIPOs]) -> List[Symbol]:
+        # Keep expected/priced IPOs with a confirmed date and a >$1 minimum across the price band.
+        return [d.symbol for d in data
+                if d.ipo_date and d.deal_type in [DealType.EXPECTED, DealType.PRICED]
+                and (prices := [x for x in [d.lowest_price, d.highest_price, d.offer_price] if x])
+                and min(prices) > 1]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-eodhdupcomingsplits/main.py
+++ b/project-templates/python/alternative-data-universe-eodhdupcomingsplits/main.py
@@ -1,0 +1,32 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class EODHDUpcomingSplitsUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of US Equities with a forward stock split in the next 3 days.
+        self._universe = self.add_universe(EODHDUpcomingSplits, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[EODHDUpcomingSplits]) -> List[Symbol]:
+        # Keep names with a forward split (factor > 1) within 3 days.
+        return [d.symbol for d in data
+                if d.split_date and d.split_factor
+                and d.split_date <= self.time + timedelta(3) and d.split_factor > 1]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-quivercnbcsuniverse/main.py
+++ b/project-templates/python/alternative-data-universe-quivercnbcsuniverse/main.py
@@ -1,0 +1,36 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class QuiverCNBCsUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        # Trade daily on CNBC opinion updates.
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of US Equities flagged by 3+ positive CNBC opinions.
+        self._universe = self.add_universe(QuiverCNBCsUniverse, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[QuiverCNBCsUniverse]) -> List[Symbol]:
+        # Group raw CNBC opinions by ticker so we can score each name.
+        cnbc_by_symbol = {}
+        for d in data:
+            cnbc_by_symbol.setdefault(d.symbol, []).append(d)
+        # Keep names with 3+ BUY recommendations to filter out noise.
+        return [s for s, ds in cnbc_by_symbol.items()
+                if sum(1 for d in ds if d.direction == OrderDirection.BUY) >= 3]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-quivergovernmentcontractuniverse/main.py
+++ b/project-templates/python/alternative-data-universe-quivergovernmentcontractuniverse/main.py
@@ -1,0 +1,34 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class QuiverGovernmentContractUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of US Equities with frequent, sizable US government contracts.
+        self._universe = self.add_universe(QuiverGovernmentContractUniverse, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[QuiverGovernmentContractUniverse]) -> List[Symbol]:
+        # Group by ticker and keep names with 3+ contracts totalling over $50K.
+        contracts_by_symbol = {}
+        for d in data:
+            contracts_by_symbol.setdefault(d.symbol, []).append(d)
+        return [s for s, ds in contracts_by_symbol.items()
+                if len(ds) >= 3 and sum(x.amount or 0 for x in ds) > 50000]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-quiverinsidertradinguniverse/main.py
+++ b/project-templates/python/alternative-data-universe-quiverinsidertradinguniverse/main.py
@@ -1,0 +1,35 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class QuiverInsiderTradingUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of the 10 US Equities with the largest insider-trading dollar volume.
+        self._universe = self.add_universe(QuiverInsiderTradingUniverse, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[QuiverInsiderTradingUniverse]) -> List[Symbol]:
+        # Aggregate insider dollar volume per ticker and keep the 10 largest.
+        dollar_volume = {}
+        for d in data:
+            if not d.price_per_share:
+                continue
+            dollar_volume[d.symbol] = dollar_volume.get(d.symbol, 0) + (d.shares or 0) * d.price_per_share
+        return [s for s, _ in sorted(dollar_volume.items(), key=lambda kv: kv[1])[-10:]]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-quiverlobbyinguniverse/main.py
+++ b/project-templates/python/alternative-data-universe-quiverlobbyinguniverse/main.py
@@ -1,0 +1,33 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class QuiverLobbyingUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of US Equities with material corporate lobbying spend.
+        self._universe = self.add_universe(QuiverLobbyingUniverse, "QuiverLobbyingUniverse", Resolution.DAILY, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[QuiverLobbyingUniverse]) -> List[Symbol]:
+        # Aggregate lobbying spend per ticker and keep names spending $100K+.
+        spend_by_symbol = {}
+        for d in data:
+            spend_by_symbol[d.symbol] = spend_by_symbol.get(d.symbol, 0) + (d.amount or 0)
+        return [s for s, v in spend_by_symbol.items() if v >= 100000]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-quiverquantcongressuniverse/main.py
+++ b/project-templates/python/alternative-data-universe-quiverquantcongressuniverse/main.py
@@ -1,0 +1,32 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class QuiverQuantCongressUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of US Equities recently bought by US Congress members in trades over $200K.
+        self._universe = self.add_universe(QuiverQuantCongressUniverse, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[QuiverQuantCongressUniverse]) -> List[Symbol]:
+        # Keep buy disclosures over $200K to filter out small reports.
+        return [d.symbol for d in data
+                if d.amount and d.amount > 200000
+                and d.transaction == OrderDirection.BUY]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-smartinsiderintentionuniverse/main.py
+++ b/project-templates/python/alternative-data-universe-smartinsiderintentionuniverse/main.py
@@ -1,0 +1,32 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class SmartInsiderIntentionUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of large-cap US Equities announcing meaningful buyback intentions.
+        self._universe = self.add_universe(SmartInsiderIntentionUniverse, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[SmartInsiderIntentionUniverse]) -> List[Symbol]:
+        # Keep $100M+ market-cap names announcing a buyback over 0.5% of shares.
+        return [d.symbol for d in data
+                if d.percentage and d.usd_market_cap
+                and d.percentage > 0.005 and d.usd_market_cap > 100000000]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/alternative-data-universe-smartinsidertransactionuniverse/main.py
+++ b/project-templates/python/alternative-data-universe-smartinsidertransactionuniverse/main.py
@@ -1,0 +1,32 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class SmartInsiderTransactionUniverseAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.universe_settings.resolution = Resolution.DAILY
+        # Universe of large-cap US Equities executing meaningful share buybacks.
+        self._universe = self.add_universe(SmartInsiderTransactionUniverse, self._select_assets)
+
+        # Rebalance shortly after the open so today's universe is locked in.
+        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+
+    def _select_assets(self, data: List[SmartInsiderTransactionUniverse]) -> List[Symbol]:
+        # Keep $100M+ market-cap names buying back over 0.5% of shares.
+        return [d.symbol for d in data
+                if d.buyback_percentage and d.usd_market_cap
+                and d.buyback_percentage > 0.005 and d.usd_market_cap > 100000000]
+
+    def _rebalance(self) -> None:
+        if not self._universe.selected:
+            return
+
+        weight = 1 / len(self._universe.selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
+
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -152,6 +152,96 @@
 			"tags": ["alternative-data", "universe", "equity-options", "earnings"]
 		},
 		{
+			"name": "Alternative Data Universe for CNBC Trading",
+			"folder": "alternative-data-universe-quivercnbcsuniverse",
+			"description": "Selects US Equities with 3+ BUY recommendations from CNBC personalities and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity"]
+		},
+		{
+			"name": "Alternative Data Universe for Brain Language Metrics on Company Filings",
+			"folder": "alternative-data-universe-braincompanyfilinglanguagemetricsuniverseall",
+			"description": "Selects US Equities with positive sentiment in both the report and MD&A sections of their latest SEC filings and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity"]
+		},
+		{
+			"name": "Alternative Data Universe for Brain ML Stock Ranking",
+			"folder": "alternative-data-universe-brainstockrankinguniverse",
+			"description": "Selects US Equities with positive Brain ML rankings across 2-, 3-, and 5-day horizons and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity"]
+		},
+		{
+			"name": "Alternative Data Universe for Brain Sentiment Indicator",
+			"folder": "alternative-data-universe-brainsentimentindicatoruniverse",
+			"description": "Selects US Equities with positive 7-day media sentiment and active mention coverage and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity"]
+		},
+		{
+			"name": "Alternative Data Universe for CoinGecko Crypto Market Cap",
+			"folder": "alternative-data-universe-coingeckouniverse",
+			"description": "Selects the top 10 Cryptocurrencies by CoinGecko market cap that are tradable on Coinbase and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "crypto"]
+		},
+		{
+			"name": "Alternative Data Universe for EODHD Upcoming Dividends",
+			"folder": "alternative-data-universe-eodhdupcomingdividends",
+			"description": "Selects US Equities going ex-dividend in the next day with a payout above $0.05 and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity", "dividends"]
+		},
+		{
+			"name": "Alternative Data Universe for EODHD Upcoming Earnings",
+			"folder": "alternative-data-universe-eodhdupcomingearnings",
+			"description": "Selects US Equities reporting earnings in the next 3 days with a positive analyst estimate and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity", "earnings"]
+		},
+		{
+			"name": "Alternative Data Universe for EODHD Upcoming IPOs",
+			"folder": "alternative-data-universe-eodhdupcomingipos",
+			"description": "Selects expected/priced non-penny IPOs with a confirmed IPO date and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity", "ipos"]
+		},
+		{
+			"name": "Alternative Data Universe for EODHD Upcoming Splits",
+			"folder": "alternative-data-universe-eodhdupcomingsplits",
+			"description": "Selects US Equities with a forward split in the next 3 days and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity", "splits"]
+		},
+		{
+			"name": "Alternative Data Universe for Corporate Lobbying",
+			"folder": "alternative-data-universe-quiverlobbyinguniverse",
+			"description": "Selects US Equities whose corporate lobbying spend totals at least $100K and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity"]
+		},
+		{
+			"name": "Alternative Data Universe for Insider Trading",
+			"folder": "alternative-data-universe-quiverinsidertradinguniverse",
+			"description": "Selects the 10 US Equities with the largest insider-trading dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity"]
+		},
+		{
+			"name": "Alternative Data Universe for US Congress Trading",
+			"folder": "alternative-data-universe-quiverquantcongressuniverse",
+			"description": "Selects US Equities recently bought by US Congress members in trades over $200K and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity"]
+		},
+		{
+			"name": "Alternative Data Universe for US Government Contracts",
+			"folder": "alternative-data-universe-quivergovernmentcontractuniverse",
+			"description": "Selects US Equities with at least 3 government contracts totalling over $50K and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity"]
+		},
+		{
+			"name": "Alternative Data Universe for Smart Insider Intentions",
+			"folder": "alternative-data-universe-smartinsiderintentionuniverse",
+			"description": "Selects $100M+ market-cap US Equities announcing buyback intentions over 0.5% of shares and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity"]
+		},
+		{
+			"name": "Alternative Data Universe for Smart Insider Transactions",
+			"folder": "alternative-data-universe-smartinsidertransactionuniverse",
+			"description": "Selects $100M+ market-cap US Equities executing buybacks over 0.5% of shares and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "equity"]
+		},
+		{
 			"name": "AI",
 			"folder": "ai",
 			"description": "Trains a TensorFlow MLP weekly on warmed-up history to predict SPY direction.",


### PR DESCRIPTION
## Summary
- Adds 14 paired Python/C# templates under `project-templates/{python,csharp}/alternative-data-universe-<class>/` covering Brain (3), CoinGecko, EODHD upcoming events (4), Quiver Quantitative (5 incl. CNBC), and Smart Insider (2).
- Each template wires the docs Universe Selection example into a daily scheduled rebalance that equal-weights the selected symbols.
- Adds `project-templates/alternative-data-universe-spec.md` describing the workflow for adding more universes (selection clause conventions, attribute-name probing, syntax-check, deploy/backtest validation).

## Test plan
- [x] All 14 pairs deployed to QC Cloud, both Python and C# compile (`BuildSuccess`).
- [x] Python and C# stats match for healthy pairs: CNBC, Brain Language Metrics, Brain ML Stock Ranking, EODHD Upcoming Dividends, EODHD Upcoming Earnings (Sharpe 3.16), EODHD Upcoming Splits, Corporate Lobbying, Insider Trading (Sharpe 2.19), Smart Insider Transactions.