### PR TITLE
Document DateRules.QuarterStart and DateRules.QuarterEnd (Lean #9454)

### DIFF
--- a/03 Writing Algorithms/26 Scheduled Events/10 Examples.html
+++ b/03 Writing Algorithms/26 Scheduled Events/10 Examples.html
@@ -86,11 +86,25 @@
                 TimeRules.AfterMarketOpen("SPY", 5),
                 RebalancingCode);
 
-    // Schedule an event to fire at the end of the week, the symbol is optional. 
+    // Schedule an event to fire at the end of the week, the symbol is optional.
     // If specified, it will fire the last trading day for that symbol of the week.
     // Otherwise, it will fire on the first day of the week.
     Schedule.On(DateRules.WeekEnd("SPY"),
                 TimeRules.BeforeMarketClose("SPY", 5),
+                RebalancingCode);
+
+    // Schedule an event to fire at the beginning of the quarter, the symbol is optional.
+    // If specified, it will fire the first trading day for that symbol of the quarter.
+    // Otherwise, it will fire on the first day of the quarter.
+    Schedule.On(DateRules.QuarterStart("SPY"),
+                TimeRules.AfterMarketOpen("SPY"),
+                RebalancingCode);
+
+    // Schedule an event to fire at the end of the quarter, the symbol is optional.
+    // If specified, it will fire the last trading day for that symbol of the quarter.
+    // Otherwise, it will fire on the last day of the quarter.
+    Schedule.On(DateRules.QuarterEnd("SPY"),
+                TimeRules.BeforeMarketClose("SPY"),
                 RebalancingCode);
     }
 
@@ -191,6 +205,20 @@ private void RebalancingCode()
     # Otherwise, it will fire on the last day of the week.
     self.schedule.on(self.date_rules.week_end("SPY"),
                     self.time_rules.before_market_close("SPY", 5),
+                    self._rebalancing_code)
+
+    # Schedule an event to fire at the beginning of the quarter, the symbol is optional.
+    # If specified, it will fire the first trading day for that symbol of the quarter.
+    # Otherwise, it will fire on the first day of the quarter.
+    self.schedule.on(self.date_rules.quarter_start("SPY"),
+                    self.time_rules.after_market_open("SPY"),
+                    self._rebalancing_code)
+
+    # Schedule an event to fire at the end of the quarter, the symbol is optional.
+    # If specified, it will fire the last trading day for that symbol of the quarter.
+    # Otherwise, it will fire on the last day of the quarter.
+    self.schedule.on(self.date_rules.quarter_end("SPY"),
+                    self.time_rules.before_market_close("SPY"),
                     self._rebalancing_code)
 
 # The following methods from examples above should be defined in the algorithm body.

--- a/Resources/scheduled-events/date-rules.html
+++ b/Resources/scheduled-events/date-rules.html
@@ -79,6 +79,26 @@
         <td>Trigger an event on the last tradable date of each week for a specific symbol minus an offset.</td>
         </tr>
         <tr>
+            <td><code class="python">self.date_rules.quarter_start(days_offset: int = 0)</code>
+            <code class="csharp">DateRules.QuarterStart(int daysOffset = 0)</code></td>
+        <td>Trigger an event on the first day of each quarter plus an offset.</td>
+        </tr>
+        <tr>
+            <td><code class="python">self.date_rules.quarter_start(symbol: Symbol, days_offset: int = 0)</code>
+            <code class="csharp">DateRules.QuarterStart(Symbol symbol, int daysOffset = 0)</code></td>
+        <td>Trigger an event on the first tradable date of each quarter for a specific symbol plus an offset.</td>
+        </tr>
+        <tr>
+            <td><code class="python">self.date_rules.quarter_end(days_offset: int = 0)</code>
+            <code class="csharp">DateRules.QuarterEnd(int daysOffset = 0)</code></td>
+        <td>Trigger an event on the last day of each quarter minus an offset.</td>
+        </tr>
+        <tr>
+            <td><code class="python">self.date_rules.quarter_end(symbol: Symbol, days_offset: int = 0)</code>
+            <code class="csharp">DateRules.QuarterEnd(Symbol symbol, int daysOffset = 0)</code></td>
+        <td>Trigger an event on the last tradable date of each quarter for a specific symbol minus an offset.</td>
+        </tr>
+        <tr>
             <td><code class="python">self.date_rules.year_start(days_offset: int = 0)</code>
             <code class="csharp">DateRules.YearStart(int daysOffset = 0)</code></td>
         <td>Trigger an event on the first day of each year plus an offset.</td>


### PR DESCRIPTION
## Summary
- Add `QuarterStart` / `QuarterEnd` rows (no-symbol and symbol overloads, Python and C#) to the Scheduled Events Date Rules reference table.
- Add `QuarterStart("SPY")` and `QuarterEnd("SPY")` examples to the Scheduled Events Examples page, mirroring the existing Month/Week pattern.
- Documents the API added in [QuantConnect/Lean#9454](https://github.com/QuantConnect/Lean/pull/9454).

## Test plan
- [x] Render the Scheduled Events > Date Rules page and confirm four new rows appear between the Week and Year entries with the correct Python/C# signatures.
- [x] Render the Scheduled Events > Examples page and confirm the new C# and Python `QuarterStart`/`QuarterEnd` snippets appear after the Week examples.