### PR TITLE
Document SetAccountCurrency behavior after SetCash (Lean #9457)

### DIFF
--- a/03 Writing Algorithms/02 Initialization/03 Set Account Currency.html
+++ b/03 Writing Algorithms/02 Initialization/03 Set Account Currency.html
@@ -1,4 +1,4 @@
-<p>The algorithm equity curve, benchmark, and performance statistics are denominated in the account currency. To set the account currency and your starting cash, call the <code class="csharp">SetAccountCurrency</code><code class="python">set_account_currency</code> method. By default, the account currency is USD and your starting cash is $100,000. If you call the <code class="csharp">SetAccountCurrency</code><code class="python">set_account_currency</code> method, you must call it before you call the <code class="csharp">SetCash</code><code class="python">set_cash</code> method or <a href="/docs/v2/writing-algorithms/initialization#08-Add-Data">add data</a>. If you call the <code class="csharp">SetAccountCurrency</code><code class="python">set_account_currency</code> method more than once, only the first call takes effect.</p>
+<p>The algorithm equity curve, benchmark, and performance statistics are denominated in the account currency. To set the account currency and your starting cash, call the <code class="csharp">SetAccountCurrency</code><code class="python">set_account_currency</code> method. By default, the account currency is USD and your starting cash is $100,000. You must call the <code class="csharp">SetAccountCurrency</code><code class="python">set_account_currency</code> method before you <a href="/docs/v2/writing-algorithms/initialization#08-Add-Data">add data</a>, and we recommend calling it before the <code class="csharp">SetCash</code><code class="python">set_cash</code> method. If you call the <code class="csharp">SetAccountCurrency</code><code class="python">set_account_currency</code> method more than once with different currencies, only the first call takes effect.</p>
 
 <div class="section-example-container">
 <pre class="csharp">// Set the account currency and your starting cash.
@@ -10,4 +10,46 @@ SetAccountCurrency("BTC", 10);  // Set the account currency to Bitcoin and its q
 self.set_account_currency("BTC") # Set the account currency to Bitcoin and its quantity to 100,000 BTC.
 self.set_account_currency("INR") # Set the account currency to Indian Rupees and its quantity to 100,000 INR.
 self.set_account_currency("BTC", 10) # Set the account currency to Bitcoin and its quantity to 10 BTC.</pre>
+</div>
+
+<p>If you call <code class="csharp">SetAccountCurrency</code><code class="python">set_account_currency</code> after <code class="csharp">SetCash</code><code class="python">set_cash</code>, one of the following applies:</p>
+
+<ul>
+    <li>If you previously called <code class="csharp">SetCash(amount)</code><code class="python">set_cash(amount)</code> and the new account currency differs, the amount carries over to the new account currency.</li>
+    <li>If you previously called <code class="csharp">SetCash(symbol, amount)</code><code class="python">set_cash(symbol, amount)</code> and the new account currency differs, the previous balance stays in its own <code>CashBook</code> entry and the new account currency starts at zero (or at <code class="csharp">startingCash</code><code class="python">starting_cash</code> if you provide it).</li>
+    <li>If the new account currency matches the previous one and you provide <code class="csharp">startingCash</code><code class="python">starting_cash</code>, the new amount overrides the previous one.</li>
+</ul>
+
+<div class="section-example-container">
+<pre class="csharp">// SetCash(amount) then a different account currency: the amount carries over to BTC.
+SetCash(1);
+SetAccountCurrency("BTC"); // CashBook: BTC = 1.
+
+// SetCash(symbol, amount) then a different account currency: USD balance is preserved, BTC starts at 0.
+SetCash("USD", 100000);
+SetAccountCurrency("BTC"); // CashBook: USD = 100000, BTC = 0.
+
+// SetCash(symbol, amount) then a different account currency with startingCash: USD is preserved, EUR starts at 50000.
+SetCash("USD", 100000);
+SetAccountCurrency("EUR", 50000); // CashBook: USD = 100000, EUR = 50000.
+
+// Same account currency with startingCash: the new amount overrides the previous one.
+SetCash(100000);
+SetAccountCurrency("USD", 200000); // CashBook: USD = 200000.
+</pre>
+<pre class="python"># set_cash(amount) then a different account currency: the amount carries over to BTC.
+self.set_cash(1)
+self.set_account_currency("BTC") # CashBook: BTC = 1.
+
+# set_cash(symbol, amount) then a different account currency: USD balance is preserved, BTC starts at 0.
+self.set_cash("USD", 100000)
+self.set_account_currency("BTC") # CashBook: USD = 100000, BTC = 0.
+
+# set_cash(symbol, amount) then a different account currency with starting_cash: USD is preserved, EUR starts at 50000.
+self.set_cash("USD", 100000)
+self.set_account_currency("EUR", 50000) # CashBook: USD = 100000, EUR = 50000.
+
+# Same account currency with starting_cash: the new amount overrides the previous one.
+self.set_cash(100000)
+self.set_account_currency("USD", 200000) # CashBook: USD = 200000.</pre>
 </div>


### PR DESCRIPTION
## Summary
- Update `Set Account Currency` page to reflect Lean PR #9457: `SetAccountCurrency` no longer throws when called after `SetCash`.
- Recommend calling `SetAccountCurrency` before `SetCash` and document the three outcomes when the order is reversed (amount carries over, previous balance preserved in its own `CashBook` entry, or same-currency `startingCash` override).
- Add a code example illustrating each case.

## Test plan
- [ ] Render the page locally and verify the new paragraph, bullet list, and example container display correctly in both C# and Python views.
- [ ] Confirm the Add Data link still resolves.