### PR TITLE
Reduce mypy pool size and unbuffer stdout in syntax-tests CI

### DIFF
--- a/.github/workflows/syntax-tests.yml
+++ b/.github/workflows/syntax-tests.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Run Syntax Test
         run: |
           runInContainer bash -c "pip install --no-cache-dir quantconnect-stubs types-requests==2.32.* types-pytz==2025.2.0.* mypy==1.20.2"
-          runInContainer python project-templates/python/run_syntax_check.py
+          runInContainer python -u project-templates/python/run_syntax_check.py

--- a/project-templates/python/run_syntax_check.py
+++ b/project-templates/python/run_syntax_check.py
@@ -148,7 +148,7 @@ def run_syntax_check(target_file: str):
 if __name__ == '__main__':
     freeze_support()
 
-    with Pool(12, initializer=init_pool, initargs=(Lock(),)) as pool:
+    with Pool(4, initializer=init_pool, initargs=(Lock(),)) as pool:
         if len(sys.argv) > 1:
             target_files = [target for target in target_files if sys.argv[1] in target]
         result = pool.map(run_syntax_check, target_files)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Two small tunes to the syntax-test CI added in #2372:
- `Pool(12) → Pool(4)` in `run_syntax_check.py` so worker count matches the 4 vCPUs on `ubuntu-24.04` runners.
- `python → python -u` in the workflow so stdout is unbuffered.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The first run of the new `Syntax Tests` workflow on master overran 30 minutes before being cancelled, while LEAN's equivalent job finishes in ~4 minutes against more files. Two compounding causes:
1. `Pool(12)` oversubscribes the runner's 4 vCPUs by 3x. Under `--strict`, mypy writes much larger `.mypy_cache` entries and the 12 concurrent processes contend on the cache directory, multiplying the overhead.
2. CPython's stdout is block-buffered when piped, so per-template failures didn't appear in the Actions log until the script exited — making it impossible to see progress mid-run.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
