### PR TITLE
Fix mypy --strict errors in project templates pt 3

### DIFF
--- a/project-templates/python/alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall/main.py
+++ b/project-templates/python/alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall/main.py
@@ -20,7 +20,7 @@ class BrainCompanyFilingLanguageMetricsChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-brainsentimentindicatoruniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-brainsentimentindicatoruniverse/main.py
@@ -20,7 +20,7 @@ class BrainSentimentIndicatorChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-brainstockrankinguniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-brainstockrankinguniverse/main.py
@@ -20,7 +20,7 @@ class BrainStockRankingChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-eodhdupcomingdividends/main.py
+++ b/project-templates/python/alternative-data-chain-universe-eodhdupcomingdividends/main.py
@@ -20,7 +20,7 @@ class EODHDUpcomingDividendsChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-eodhdupcomingearnings/main.py
+++ b/project-templates/python/alternative-data-chain-universe-eodhdupcomingearnings/main.py
@@ -20,7 +20,7 @@ class EODHDUpcomingEarningsChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-eodhdupcomingipos/main.py
+++ b/project-templates/python/alternative-data-chain-universe-eodhdupcomingipos/main.py
@@ -20,7 +20,7 @@ class EODHDUpcomingIPOsChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-eodhdupcomingsplits/main.py
+++ b/project-templates/python/alternative-data-chain-universe-eodhdupcomingsplits/main.py
@@ -20,7 +20,7 @@ class EODHDUpcomingSplitsChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-quivercnbcsuniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-quivercnbcsuniverse/main.py
@@ -20,7 +20,7 @@ class QuiverCNBCsChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-quivergovernmentcontractuniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-quivergovernmentcontractuniverse/main.py
@@ -20,7 +20,7 @@ class QuiverGovernmentContractChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-quiverinsidertradinguniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-quiverinsidertradinguniverse/main.py
@@ -20,7 +20,7 @@ class QuiverInsiderTradingChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-quiverlobbyinguniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-quiverlobbyinguniverse/main.py
@@ -21,7 +21,7 @@ class QuiverLobbyingChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-smartinsiderintentionuniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-smartinsiderintentionuniverse/main.py
@@ -20,7 +20,7 @@ class SmartInsiderIntentionChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/alternative-data-chain-universe-smartinsidertransactionuniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-smartinsidertransactionuniverse/main.py
@@ -20,7 +20,7 @@ class SmartInsiderTransactionChainedUniverseAlgorithm(QCAlgorithm):
         # Rebalance shortly after the open so today's intersection is locked in.
         self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
         self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
         return Universe.UNCHANGED

--- a/project-templates/python/custom-consolidators/main.py
+++ b/project-templates/python/custom-consolidators/main.py
@@ -22,7 +22,7 @@ class CalendarConsolidatorExampleAlgorithm(QCAlgorithm):
         # Register the indicator for automatic updates with the consolidated bars.
         self.register_indicator(self._pair, self._pair.ema, consolidator)
         # Warm up the consolidator and indicator.
-        history = self.history[QuoteBar](self._pair, 29000, Resolution.MINUTE)
+        history = self.history[QuoteBar](self._pair.symbol, 29000, Resolution.MINUTE)
         for bar in history:
             consolidator.update(bar)
     

--- a/project-templates/python/forex/main.py
+++ b/project-templates/python/forex/main.py
@@ -14,7 +14,7 @@ class ForexExampleAlgorithm(QCAlgorithm):
             # Create a Minimum indicator to track the lowest bid-ask spread for the past 12 hours.
             forex.spread_low = Minimum(12*60)
             # Warm up the indicator so it's immediately ready to use.
-            for quote_bar in self.history[QuoteBar](forex, 12*60):
+            for quote_bar in self.history[QuoteBar](forex.symbol, 12*60):
                 forex.spread_low.update(quote_bar.end_time, quote_bar.ask.close - quote_bar.bid.close)
 
     def on_data(self, slice: Slice) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Two follow-up fixes for the `mypy --strict` syntax-test gate:

- **13 chain-universe templates** — change `_fundamental_filter`'s return type from `List[Symbol]` to `Universe.UnchangedUniverse`. The function always returns `Universe.UNCHANGED`, so the previous annotation was a lie that mypy correctly flagged with `[return-value]`.
- **2 history-overload templates** (`forex/main.py`, `custom-consolidators/main.py`) — pass `.symbol` instead of the security object to `self.history[QuoteBar](...)` so mypy resolves the single-symbol overload (`Iterable[QuoteBar]`) instead of the multi-symbol one (`Iterable[DataDictionary[QuoteBar]]`). Runtime behavior unchanged.

Verified locally with mypy 1.20.2 + quantconnect-stubs 17711 (the same versions CI installs).

#### Related Issue
N/A

#### Motivation and Context
After the first wave of annotation additions, two error patterns dominated the failure list:
1. `Incompatible return value type (got "UnchangedUniverse", expected "list[Symbol]")` — the agent annotated chain-universe filter functions as returning `List[Symbol]`, but those functions actually return `Universe.UNCHANGED` (a sentinel) and stash the symbol list on `self`. Annotating with the sentinel's type (`Universe.UnchangedUniverse`) matches reality.
2. `"DataDictionary[QuoteBar]" has no attribute "end_time"/"ask"/"bid"` and `Argument 1 to "update" of "PeriodCountConsolidatorBase" has incompatible type "DataDictionary[QuoteBar]"` — both come from `self.history[QuoteBar](security, ...)` resolving to the multi-symbol overload that returns slices keyed by Symbol. Passing `security.symbol` instead picks the single-symbol overload.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
