### PR TITLE
Add SeedInitialPrices and cosmetic changes to C# chain-universe templates

### DIFF
--- a/project-templates/csharp/alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall/Main.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall/Main.cs
@@ -17,6 +17,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -54,7 +55,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-brainsentimentindicatoruniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-brainsentimentindicatoruniverse/Main.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-brainsentimentindicatoruniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-brainsentimentindicatoruniverse/Main.cs
@@ -17,6 +17,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -53,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-brainstockrankinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-brainstockrankinguniverse/Main.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-brainstockrankinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-brainstockrankinguniverse/Main.cs
@@ -17,6 +17,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -53,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingdividends/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingdividends/Main.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingdividends/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingdividends/Main.cs
@@ -17,6 +17,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -53,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingearnings/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingearnings/Main.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingearnings/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingearnings/Main.cs
@@ -17,6 +17,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -53,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingipos/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingipos/Main.cs
@@ -19,6 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -58,7 +59,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingipos/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingipos/Main.cs
@@ -21,7 +21,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingsplits/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingsplits/Main.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingsplits/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingsplits/Main.cs
@@ -17,6 +17,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -53,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-quivercnbcsuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quivercnbcsuniverse/Main.cs
@@ -18,6 +18,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -54,7 +55,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-quivercnbcsuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quivercnbcsuniverse/Main.cs
@@ -20,7 +20,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-quivergovernmentcontractuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quivergovernmentcontractuniverse/Main.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-quivergovernmentcontractuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quivergovernmentcontractuniverse/Main.cs
@@ -17,6 +17,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -53,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-quiverinsidertradinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quiverinsidertradinguniverse/Main.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-quiverinsidertradinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quiverinsidertradinguniverse/Main.cs
@@ -17,6 +17,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -67,7 +68,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-quiverlobbyinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quiverlobbyinguniverse/Main.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-quiverlobbyinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quiverlobbyinguniverse/Main.cs
@@ -17,6 +17,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -53,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-quiverquantcongressuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quiverquantcongressuniverse/Main.cs
@@ -18,6 +18,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -54,7 +55,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-quiverquantcongressuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quiverquantcongressuniverse/Main.cs
@@ -20,7 +20,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-smartinsiderintentionuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-smartinsiderintentionuniverse/Main.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-smartinsiderintentionuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-smartinsiderintentionuniverse/Main.cs
@@ -17,6 +17,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -53,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/csharp/alternative-data-chain-universe-smartinsidertransactionuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-smartinsidertransactionuniverse/Main.cs
@@ -19,7 +19,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Settings.SeedInitialPrices = true;
 
-            UniverseSettings.Resolution = Resolution.Daily;
+            UniverseSettings.Resolution = Resolution.Minute;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
             AddUniverse(fundamental =>
             {

--- a/project-templates/csharp/alternative-data-chain-universe-smartinsidertransactionuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-smartinsidertransactionuniverse/Main.cs
@@ -17,6 +17,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2024, 9, 1);
             SetEndDate(2024, 12, 31);
             SetCash(100000);
+            Settings.SeedInitialPrices = true;
 
             UniverseSettings.Resolution = Resolution.Daily;
             // First universe: top 100 US Equities by dollar volume; emits Universe.Unchanged.
@@ -53,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(symbol => new PortfolioTarget(symbol, weight))
                 .ToList();
 
-            SetHoldings(targets, liquidateExistingHoldings: true);
+            SetHoldings(targets, true);
         }
     }
 }

--- a/project-templates/python/alternative-data-chain-universe-brainsentimentindicatoruniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-brainsentimentindicatoruniverse/main.py
@@ -2,41 +2,44 @@
 from AlgorithmImports import *
 # endregion
 
-class BrainSentimentIndicatorChainedUniverseAlgorithm(QCAlgorithm):
 
+class BrainSentimentIndicatorChainedUniverseAlgorithm(QCAlgorithm):
     _fundamental: list[Symbol] = []
 
     def initialize(self) -> None:
         self.set_start_date(2024, 9, 1)
         self.set_end_date(2024, 12, 31)
-        self.set_cash(100000)
-
+        self.set_cash(100_000)
+        self.settings.seed_initial_prices = True
         self.universe_settings.resolution = Resolution.DAILY
-        # First universe: top 100 US Equities by dollar volume; emits Universe.UNCHANGED.
+        # First universe: top US Equities by dollar volume.
         self.add_universe(self._fundamental_filter)
-        # Second universe: positive 7-day media sentiment with active mention coverage, intersected with the fundamental list.
+        # Second universe: positive sentiment with active mention coverage, intersected with the fundamental list.
         self._universe = self.add_universe(BrainSentimentIndicatorUniverse, self._select_assets)
-
         # Rebalance shortly after the open so today's intersection is locked in.
-        self.schedule.on(self.date_rules.every_day("SPY"), self.time_rules.at(9, 0, 0), self._rebalance)
+        self.schedule.on(
+            self.date_rules.every_day("SPY"), 
+            self.time_rules.at(9, 0), 
+            self._rebalance
+        )
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
-        sorted_by_dollar_volume = sorted(fundamental, key=lambda x: x.dollar_volume, reverse=True)
-        self._fundamental = [c.symbol for c in sorted_by_dollar_volume[:100]]
-        return Universe.UNCHANGED
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+        self._fundamental = [c.symbol for c in sorted(fundamental, key=lambda x: x.dollar_volume)[-100:]]
+        return []
 
     def _select_assets(self, alt_coarse: List[BrainSentimentIndicatorUniverse]) -> List[Symbol]:
-        # Keep names with both active mention coverage and positive 7-day sentiment.
+        # Keep only names with active mention coverage and positive sentiment.
         alt = [d.symbol for d in alt_coarse
-               if d.total_article_mentions_7_days and d.total_article_mentions_7_days > 0
-               and d.sentiment_7_days and d.sentiment_7_days > 0]
-        return list(set(self._fundamental) & set(alt))
+               if d.total_article_mentions_7_days and
+               d.total_article_mentions_7_days > 0 and
+               d.sentiment_7_days and
+               d.sentiment_7_days > 0]
+        return [s for s in self._fundamental if s in alt]
 
     def _rebalance(self) -> None:
         if not self._universe.selected:
             return
-
+        # Enter the universe equally weighted across all selected assets. 
         weight = 1 / len(self._universe.selected)
         targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
-
-        self.set_holdings(targets, liquidate_existing_holdings=True)
+        self.set_holdings(targets, True)

--- a/project-templates/python/alternative-data-chain-universe-brainsentimentindicatoruniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-brainsentimentindicatoruniverse/main.py
@@ -12,20 +12,20 @@ class BrainSentimentIndicatorChainedUniverseAlgorithm(QCAlgorithm):
         self.set_cash(100_000)
         self.settings.seed_initial_prices = True
         self.universe_settings.resolution = Resolution.DAILY
-        # First universe: top US Equities by dollar volume.
+        # Add a fundamental universe to track the most liquid US Equities by dollar volume.
         self.add_universe(self._fundamental_filter)
-        # Second universe: positive sentiment with active mention coverage, intersected with the fundamental list.
+        # Add a Brain Sentiment universe, restricted to high-sentiment names within the fundamental list.
         self._universe = self.add_universe(BrainSentimentIndicatorUniverse, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance shortly after the open.
         self.schedule.on(
             self.date_rules.every_day("SPY"), 
             self.time_rules.at(9, 0), 
             self._rebalance
         )
 
-    def _fundamental_filter(self, fundamental: List[Fundamental]) -> List[Symbol]:
+    def _fundamental_filter(self, fundamental: List[Fundamental]) -> Universe.UnchangedUniverse:
         self._fundamental = [c.symbol for c in sorted(fundamental, key=lambda x: x.dollar_volume)[-100:]]
-        return []
+        return Universe.UNCHANGED
 
     def _select_assets(self, alt_coarse: List[BrainSentimentIndicatorUniverse]) -> List[Symbol]:
         # Keep only names with active mention coverage and positive sentiment.
@@ -39,7 +39,7 @@ class BrainSentimentIndicatorChainedUniverseAlgorithm(QCAlgorithm):
     def _rebalance(self) -> None:
         if not self._universe.selected:
             return
-        # Enter the universe equally weighted across all selected assets. 
+        # Enter the universe equally weighted across all selected assets.
         weight = 1 / len(self._universe.selected)
         targets = [PortfolioTarget(symbol, weight) for symbol in self._universe.selected]
         self.set_holdings(targets, True)


### PR DESCRIPTION
## Summary

- Add `Settings.SeedInitialPrices = true;` after `SetCash` in all 14 C# chain-universe templates
- Cosmetic improvements: comment capitalisation and punctuation, `liquidateExistingHoldings: true` → positional `true`, `Equity`/`Equities` capitalised where referring to asset class
- XML doc comments (`///`) left untouched

## Test plan

- [ ] Spot-check a few chain templates for correct `SeedInitialPrices` and comment style