### PR TITLE
Add project template: equity-bollinger-mean-reversion

### DIFF
--- a/project-templates/csharp/equity-bollinger-mean-reversion/Main.cs
+++ b/project-templates/csharp/equity-bollinger-mean-reversion/Main.cs
@@ -1,0 +1,92 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class EquityBollingerMeanReversionAlgorithm : QCAlgorithm
+{
+    private Equity _equity;
+    private BollingerBands _bb;
+
+    public override void Initialize()
+    {
+        SetStartDate(2024, 9, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+        Settings.SeedInitialPrices = true;
+        Settings.AutomaticIndicatorWarmUp = true;
+        _equity = AddEquity("SPY");
+        _bb = BB(_equity.Symbol, 20, 2, resolution: Resolution.Daily);
+        PlotIndicator("SPY", _bb.UpperBand, _bb.MiddleBand, _bb.LowerBand);
+        Schedule.On(DateRules.EveryDay(_equity.Symbol), TimeRules.At(8, 0), Rebalance);
+    }
+
+    private void Rebalance()
+    {
+        if (!Portfolio.Invested && _equity.Price < _bb.LowerBand.Current.Value)
+        {
+            SetHoldings(_equity.Symbol, 1m);
+        }
+        else if (Portfolio.Invested && _equity.Price >= _bb.MiddleBand.Current.Value)
+        {
+            Liquidate();
+        }
+    }
+}

--- a/project-templates/csharp/templates.json
+++ b/project-templates/csharp/templates.json
@@ -347,6 +347,12 @@
 			"folder": "live-trading-features",
 			"description": "Demonstrates live email and SMS notifications, brokerage disconnect/reconnect handling, and commands.",
 			"tags": ["live-trading", "sms", "notifications", "Equity", "emails", "commands", "brokerage-messages"]
+		},
+		{
+			"name": "Equity Bollinger Mean Reversion",
+			"folder": "equity-bollinger-mean-reversion",
+			"description": "Trades SPY on a 20-period, 2-standard-deviation Bollinger Bands mean-reversion signal — buys when price closes below the lower band and liquidates on a return to the middle band — with a daily scheduled rebalance.",
+			"tags": ["Equity", "indicators", "bollinger-bands", "mean-reversion", "z-score"]
 		}
 	]
 }

--- a/project-templates/python/equity-bollinger-mean-reversion/main.py
+++ b/project-templates/python/equity-bollinger-mean-reversion/main.py
@@ -1,0 +1,22 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class EquityBollingerMeanReversionAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+        self.settings.seed_initial_prices = True
+        self.settings.automatic_indicator_warm_up = True
+        self._equity = self.add_equity("SPY")
+        self._bb = self.bb(self._equity, 20, 2, resolution=Resolution.DAILY)
+        self.plot_indicator("SPY", self._bb.upper_band, self._bb.middle_band, self._bb.lower_band)
+        self.schedule.on(self.date_rules.every_day(self._equity), self.time_rules.at(8, 0), self._rebalance)
+
+    def _rebalance(self) -> None:
+        if not self.portfolio.invested and self._equity.price < self._bb.lower_band.current.value:
+            self.set_holdings(self._equity, 1)
+        elif self.portfolio.invested and self._equity.price >= self._bb.middle_band.current.value:
+            self.liquidate()

--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -347,6 +347,12 @@
 			"folder": "live-trading-features",
 			"description": "Demonstrates live email and SMS notifications, brokerage disconnect/reconnect handling, and commands.",
 			"tags": ["live-trading", "sms", "notifications", "Equity", "emails", "commands", "brokerage-messages"]
+		},
+		{
+			"name": "Equity Bollinger Mean Reversion",
+			"folder": "equity-bollinger-mean-reversion",
+			"description": "Trades SPY on a 20-period, 2-standard-deviation Bollinger Bands mean-reversion signal — buys when price closes below the lower band and liquidates on a return to the middle band — with a daily scheduled rebalance.",
+			"tags": ["Equity", "indicators", "bollinger-bands", "mean-reversion", "z-score"]
 		}
 	]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Add a template that 
> Trades SPY on a 20-period, 2-standard-deviation Bollinger Bands mean-reversion signal — buys when price closes below the lower band and liquidates on a return to the middle band — with a daily scheduled rebalance.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve AI project generation

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
