### PR TITLE
Fix scheduler comment in chain-universe templates (Python and C#)

### DIFF
--- a/project-templates/csharp/alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall/Main.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-brainsentimentindicatoruniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-brainsentimentindicatoruniverse/Main.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-brainstockrankinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-brainstockrankinguniverse/Main.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingdividends/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingdividends/Main.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingearnings/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingearnings/Main.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingipos/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingipos/Main.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingsplits/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-eodhdupcomingsplits/Main.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-quivercnbcsuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quivercnbcsuniverse/Main.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-quivergovernmentcontractuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quivergovernmentcontractuniverse/Main.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-quiverinsidertradinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quiverinsidertradinguniverse/Main.cs
@@ -52,7 +52,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-quiverlobbyinguniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quiverlobbyinguniverse/Main.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-quiverquantcongressuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-quiverquantcongressuniverse/Main.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-smartinsiderintentionuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-smartinsiderintentionuniverse/Main.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/csharp/alternative-data-chain-universe-smartinsidertransactionuniverse/Main.cs
+++ b/project-templates/csharp/alternative-data-chain-universe-smartinsidertransactionuniverse/Main.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
                 return _fundamental.Intersect(alt);
             });
 
-            // Rebalance shortly after the open so today's intersection is locked in.
+            // Rebalance before market open to trade today's intersection.
             Schedule.On(DateRules.EveryDay("SPY"), TimeRules.At(9, 0, 0), Rebalance);
         }
 

--- a/project-templates/python/alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall/main.py
+++ b/project-templates/python/alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall/main.py
@@ -17,7 +17,7 @@ class BrainCompanyFilingLanguageMetricsChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: positive sentiment in latest SEC filings, intersected with the fundamental list.
         self._universe = self.add_universe(BrainCompanyFilingLanguageMetricsUniverseAll, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-brainsentimentindicatoruniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-brainsentimentindicatoruniverse/main.py
@@ -16,7 +16,7 @@ class BrainSentimentIndicatorChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Add a Brain Sentiment universe, restricted to high-sentiment names within the fundamental list.
         self._universe = self.add_universe(BrainSentimentIndicatorUniverse, self._select_assets)
-        # Rebalance shortly after the open.
+        # Rebalance before market open.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-brainstockrankinguniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-brainstockrankinguniverse/main.py
@@ -17,7 +17,7 @@ class BrainStockRankingChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: positive Brain ML rankings across 2-, 3-, and 5-day horizons, intersected with the fundamental list.
         self._universe = self.add_universe(BrainStockRankingUniverse, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-eodhdupcomingdividends/main.py
+++ b/project-templates/python/alternative-data-chain-universe-eodhdupcomingdividends/main.py
@@ -17,7 +17,7 @@ class EODHDUpcomingDividendsChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: ex-dividend in the next day with a $0.05+ payout, intersected with the fundamental list.
         self._universe = self.add_universe(EODHDUpcomingDividends, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-eodhdupcomingearnings/main.py
+++ b/project-templates/python/alternative-data-chain-universe-eodhdupcomingearnings/main.py
@@ -17,7 +17,7 @@ class EODHDUpcomingEarningsChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: earnings in the next 3 days with a positive estimate, intersected with the fundamental list.
         self._universe = self.add_universe(EODHDUpcomingEarnings, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-eodhdupcomingipos/main.py
+++ b/project-templates/python/alternative-data-chain-universe-eodhdupcomingipos/main.py
@@ -17,7 +17,7 @@ class EODHDUpcomingIPOsChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: confirmed non-penny upcoming IPOs, intersected with the fundamental list.
         self._universe = self.add_universe(EODHDUpcomingIPOs, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-eodhdupcomingsplits/main.py
+++ b/project-templates/python/alternative-data-chain-universe-eodhdupcomingsplits/main.py
@@ -17,7 +17,7 @@ class EODHDUpcomingSplitsChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: forward stock split in the next 3 days, intersected with the fundamental list.
         self._universe = self.add_universe(EODHDUpcomingSplits, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-quivercnbcsuniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-quivercnbcsuniverse/main.py
@@ -17,7 +17,7 @@ class QuiverCNBCsChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: 3+ BUY CNBC opinions, intersected with the fundamental list.
         self._universe = self.add_universe(QuiverCNBCsUniverse, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-quivergovernmentcontractuniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-quivergovernmentcontractuniverse/main.py
@@ -17,7 +17,7 @@ class QuiverGovernmentContractChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: 3+ government contracts totalling over $50K, intersected with the fundamental list.
         self._universe = self.add_universe(QuiverGovernmentContractUniverse, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-quiverinsidertradinguniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-quiverinsidertradinguniverse/main.py
@@ -17,7 +17,7 @@ class QuiverInsiderTradingChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: 10 largest insider-trading dollar volumes, intersected with the fundamental list.
         self._universe = self.add_universe(QuiverInsiderTradingUniverse, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-quiverlobbyinguniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-quiverlobbyinguniverse/main.py
@@ -18,7 +18,7 @@ class QuiverLobbyingChainedUniverseAlgorithm(QCAlgorithm):
         # Second universe: $100K+ corporate lobbying spend, intersected with the fundamental list.
         self._universe = self.add_universe(QuiverLobbyingUniverse, "QuiverLobbyingUniverse",
                                            Resolution.DAILY, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-quiverquantcongressuniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-quiverquantcongressuniverse/main.py
@@ -17,7 +17,7 @@ class QuiverQuantCongressChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: US Congress BUY disclosures over $200K, intersected with the fundamental list.
         self._universe = self.add_universe(QuiverQuantCongressUniverse, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-smartinsiderintentionuniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-smartinsiderintentionuniverse/main.py
@@ -17,7 +17,7 @@ class SmartInsiderIntentionChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: $100M+ market-cap buyback intentions over 0.5%, intersected with the fundamental list.
         self._universe = self.add_universe(SmartInsiderIntentionUniverse, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),

--- a/project-templates/python/alternative-data-chain-universe-smartinsidertransactionuniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-smartinsidertransactionuniverse/main.py
@@ -17,7 +17,7 @@ class SmartInsiderTransactionChainedUniverseAlgorithm(QCAlgorithm):
         self.add_universe(self._fundamental_filter)
         # Second universe: $100M+ market-cap buybacks over 0.5%, intersected with the fundamental list.
         self._universe = self.add_universe(SmartInsiderTransactionUniverse, self._select_assets)
-        # Rebalance shortly after the open so today's intersection is locked in.
+        # Rebalance before market open to trade today's intersection.
         self.schedule.on(
             self.date_rules.every_day("SPY"),
             self.time_rules.at(9, 0),


### PR DESCRIPTION
## Summary

- Fix incorrect scheduler comment in all 28 chain-universe templates (14 Python, 14 C#)
- The scheduler fires at 9:00 AM — 30 minutes *before* market open at 9:30 AM, so "shortly after the open" was wrong
- New comment: `Rebalance before market open to trade today's intersection.`

## Test plan

- [ ] Verify comment in a representative chain-universe template matches the scheduler time (9:00 AM)