### PR TITLE
Add Assistant Nodes resources page

### DIFF
--- a/01 Cloud Platform/04 Organizations/03 Resources/05 Assistant Nodes.php
+++ b/01 Cloud Platform/04 Organizations/03 Resources/05 Assistant Nodes.php
@@ -1,0 +1,1 @@
+<? include(DOCS_RESOURCES."/nodes/assistant.php"); ?>

--- a/Resources/nodes/assistant.php
+++ b/Resources/nodes/assistant.php
@@ -1,0 +1,19 @@
+<p>
+	Assistant nodes enable you to deploy assistant tasks.
+	The more assistant nodes your organization has, the more concurrent assistant tasks that you can run.
+	More powerful assistant nodes have more cores and RAM to handle larger, more demanding tasks.
+	The following table shows the specifications of the assistant node models:
+</p>
+
+<? include(DOCS_RESOURCES."/specs/assistant-nodes.html"); ?>
+
+<p>
+	Refer to the <a href="/pricing">Pricing</a> page to see the price of each assistant node model.
+	Your first organization includes one free A-MICRO assistant node, which is capped at 100,000 tokens per month.
+	The token cap is lifted and the node is replaced when you <a href='/docs/v2/cloud-platform/organizations/billing#07-Change-Organization-Tiers'>upgrade your organization to a paid tier</a> and <a href='/docs/v2/cloud-platform/organizations/resources#15-Add-Nodes'>add a new assistant node</a>.
+</p>
+
+<p>
+	To view the status of all of your organization's nodes, see the <a href='/docs/v2/cloud-platform/projects/ide#08-Manage-Nodes'>Resources panel</a> of the IDE.
+	When you launch an assistant task, it uses the best-performing resource by default, but you can <a href='/docs/v2/cloud-platform/projects/ide#08-Manage-Nodes'>select a specific resource to use</a>.
+</p>

--- a/Resources/specs/assistant-nodes.html
+++ b/Resources/specs/assistant-nodes.html
@@ -4,7 +4,7 @@
             <th>Name</th>
             <th>Number of Cores</th>
             <th>RAM (GB)</th>
-            <th>Concurrent Tasks</th>
+            <th>Agents</th>
         </tr>
     </thead>
     <tbody>

--- a/Resources/specs/assistant-nodes.html
+++ b/Resources/specs/assistant-nodes.html
@@ -1,0 +1,47 @@
+<table class="qc-table table" id='assistant-nodes-table'>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Number of Cores</th>
+            <th>RAM (GB)</th>
+            <th>Concurrent Tasks</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>A-MICRO</td>
+            <td>1</td>
+            <td>1</td>
+            <td>1</td>
+        </tr>
+        <tr>
+            <td>A1-1</td>
+            <td>1</td>
+            <td>1</td>
+            <td>1</td>
+        </tr>
+        <tr>
+            <td>A4-8</td>
+            <td>4</td>
+            <td>8</td>
+            <td>4</td>
+        </tr>
+        <tr>
+            <td>A16-32</td>
+            <td>16</td>
+            <td>32</td>
+            <td>16</td>
+        </tr>
+    </tbody>
+</table>
+
+<style>
+#assistant-nodes-table td:nth-child(2),
+#assistant-nodes-table th:nth-child(2),
+#assistant-nodes-table td:nth-child(3),
+#assistant-nodes-table th:nth-child(3),
+#assistant-nodes-table td:last-child,
+#assistant-nodes-table th:last-child {
+    text-align: right;
+}
+</style>


### PR DESCRIPTION
## Summary
- Adds a new `05 Assistant Nodes.php` page under `01 Cloud Platform/04 Organizations/03 Resources/`, following the same include pattern as Backtesting and Research Nodes.
- Adds the shared `Resources/nodes/assistant.php` description and `Resources/specs/assistant-nodes.html` spec table for the A-MICRO, A1-1, A4-8, and A16-32 models.
- Documents the free A-MICRO tier (1 CPU / 1 GB / 1 concurrent task, capped at 100K tokens per month) and notes that the cap is lifted when the organization upgrades and adds a paid assistant node.

## Test plan
- [ ] Verify the new page renders under Cloud Platform > Organizations > Resources > Assistant Nodes.
- [ ] Verify the specs table displays all four models with right-aligned numeric columns, matching the Backtesting/Research node tables.
- [ ] Verify the Pricing, Billing, Add Nodes, and Resources panel links in the description resolve correctly.