### PR TITLE
Rewrite QuantConnect Assistants intro with links to Assistants and Research Pipeline

### DIFF
--- a/09 AI Assistance/01 Getting Started/01 Introduction.html
+++ b/09 AI Assistance/01 Getting Started/01 Introduction.html
@@ -11,9 +11,5 @@ The QuantConnect MCP server is a bridge for AIs to interact with our cloud platf
 </p>
 
 <h4>QuantConnect Assistants</h4>
-<p>
-  Assistants are specialized AI agents inside QuantConnect that perform the quant research process (agentic quant research). 
-  These assistants are available for all members and reduce or eliminate the need to learn our API.
-  For more information, see <a href="/docs/v2/ai-assistance/assistants/key-concepts">Key Concepts</a>. 
-</p>
-
+<p><a href="/docs/v2/ai-assistance/assistants/key-concepts">Assistants</a> are specialized AI agents that handle the distinct stages of building a trading strategy. They source ideas, validate them, code the backtest, and shepherd the result through paper trading. Each one is an expert in a single part of the workflow, with the tools to do the work rather than just describe it. Talk to an assistant directly, or hand the whole job to the Conductor and let it route the work through the team on your behalf.</p>
+<p>To supercharge your productivity, add assistants to your <a href="/docs/v2/cloud-platform/research-pipeline">Research Pipeline</a>, a kanban board that tracks your projects through the stages of research validation, backtesting, paper trading, and live trading.</p>


### PR DESCRIPTION
## Summary
- Rewrite the QuantConnect Assistants section in the AI Assistance Getting Started intro to summarize what assistants do and link to the [Assistants key concepts](/docs/v2/ai-assistance/assistants/key-concepts) page.
- Add a follow-up paragraph linking to the [Research Pipeline](/docs/v2/cloud-platform/research-pipeline) page so readers can see where assistants plug into the workflow.

## Test plan
- [ ] Open `/docs/v2/ai-assistance/getting-started` and confirm the QuantConnect Assistants section renders with both links resolving to the Assistants and Research Pipeline pages.