### PR TITLE
Fix mypy type annotations in Python project templates

### DIFF
--- a/project-templates/python/ai/main.py
+++ b/project-templates/python/ai/main.py
@@ -39,7 +39,7 @@ class TensorFlowAlgorithm(QCAlgorithm):
         # Recalibrate the model weekly to ensure its accuracy on the updated domain.
         self.train(self.date_rules.week_start(), self.time_rules.at(8, 0), self._my_training_method)
 
-    def _get_features_and_labels(self, lookback=5):
+    def _get_features_and_labels(self, lookback: int = 5) -> tuple[np.ndarray, np.ndarray]:
         lookback_series = []
         # Train and predict on N-period differencing data which is more normalized and stationary.
         data = pd.Series([bar.close for bar in self._spy.session][::-1])
@@ -55,7 +55,7 @@ class TensorFlowAlgorithm(QCAlgorithm):
         # Prepare the processed training data.
         features, labels = self._get_features_and_labels()
         # Define the loss function using MSE for this example.
-        def loss_mse(target_y, predicted_y):
+        def loss_mse(target_y: np.ndarray, predicted_y: tf.Tensor) -> tf.Tensor:
             return tf.reduce_mean(tf.square(target_y - predicted_y))
         # Train the model with Adam optimizer.
         optimizer = tf.keras.optimizers.Adam(learning_rate=self._learning_rate)
@@ -65,7 +65,7 @@ class TensorFlowAlgorithm(QCAlgorithm):
             jac = t.gradient(loss, self._model.trainable_weights)
             optimizer.apply_gradients(zip(jac, self._model.trainable_weights))
 
-    def on_data(self, data) -> None:
+    def on_data(self, data: Slice) -> None:
         if data.bars:
             # Get prediction using the updated features.
             new_features = self._get_features_and_labels()[0]

--- a/project-templates/python/alternative-data-chain-universe-quiverquantcongressuniverse/main.py
+++ b/project-templates/python/alternative-data-chain-universe-quiverquantcongressuniverse/main.py
@@ -5,7 +5,7 @@ from AlgorithmImports import *
 
 class QuiverQuantCongressChainedUniverseAlgorithm(QCAlgorithm):
 
-    _fundamental = []
+    _fundamental: list[Symbol] = []
 
     def initialize(self) -> None:
         self.set_start_date(2024, 9, 1)

--- a/project-templates/python/custom-models/main.py
+++ b/project-templates/python/custom-models/main.py
@@ -123,7 +123,7 @@ class SimpleCustomFillModel(FillModel):
         return fill
 
     def _get_trade_bar(self, asset: Security, order_direction: OrderDirection) -> TradeBar:
-        trade_bar = asset.cache.get_data(TradeBar)
+        trade_bar = asset.cache.get_data[TradeBar]()
         if trade_bar: return trade_bar
 
         # Tick-resolution data doesn't have TradeBar, use the asset price


### PR DESCRIPTION
## Summary

- Annotate `_fundamental: list[Symbol]` in the QuiverQuantCongress chained-universe template so mypy can infer the element type.
- Use the pythonnet generic-indexer form `cache.get_data[TradeBar]()` in the custom-models template so the `TradeBar` return type carries through (avoids `no-any-return`).
- Annotate `_get_features_and_labels`, the inner `loss_mse`, and `on_data` in the ai template so the file passes strict mypy.

## Test plan

- [x] `python project-templates/python/run_syntax_check.py` — 100% pass across all 72 templates.