### PR TITLE
Switch project templates off Daily resolution

### DIFF
--- a/project-templates/csharp/common/research.ipynb
+++ b/project-templates/csharp/common/research.ipynb
@@ -81,20 +81,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "// Get historical data for a bank sector ETF and some banking companies over 2021.\n",
-    "var qb = new QuantBook();\n",
-    "var tickers = new[]\n",
-    "{\n",
-    "    \"XLF\",  // Financial Select Sector SPDR Fund\n",
-    "    \"COF\",  // Capital One Financial Corporation\n",
-    "    \"GS\",   // Goldman Sachs Group, Inc.\n",
-    "    \"JPM\",  // J P Morgan Chase & Co\n",
-    "    \"WFC\"   // Wells Fargo & Company\n",
-    "};\n",
-    "var symbols = tickers.Select(ticker => qb.AddEquity(ticker, Resolution.Daily).Symbol).ToList();\n",
-    "var history = qb.History(symbols, new DateTime(2021, 1, 1), new DateTime(2022, 1, 1)).ToList();"
-   ]
+   "source": "// Get historical data for a bank sector ETF and some banking companies over 2021.\nvar qb = new QuantBook();\nvar tickers = new[]\n{\n    \"XLF\",  // Financial Select Sector SPDR Fund\n    \"COF\",  // Capital One Financial Corporation\n    \"GS\",   // Goldman Sachs Group, Inc.\n    \"JPM\",  // J P Morgan Chase & Co\n    \"WFC\"   // Wells Fargo & Company\n};\nvar symbols = tickers.Select(ticker => qb.AddEquity(ticker).Symbol).ToList();\nvar history = qb.History(symbols, new DateTime(2021, 1, 1), new DateTime(2022, 1, 1)).ToList();"
   },
   {
    "cell_type": "markdown",

--- a/project-templates/csharp/equities-universe/Main.cs
+++ b/project-templates/csharp/equities-universe/Main.cs
@@ -85,7 +85,7 @@ public class EmaCrossUniverseSelectionAlgorithm : QCAlgorithm
         SetCash(100000);
         Settings.SeedInitialPrices = true;
         UniverseSettings.Leverage = 2.0m;
-        UniverseSettings.Resolution = Resolution.Daily;
+        UniverseSettings.Resolution = Resolution.Minute;
 
         _universe = AddUniverse(coarse =>
         {

--- a/project-templates/python/ai/main.py
+++ b/project-templates/python/ai/main.py
@@ -12,7 +12,7 @@ class TensorFlowAlgorithm(QCAlgorithm):
         self.set_cash(100_000)
         self.settings.seed_initial_prices = True
         # Request SPY data for model training, prediction and trading.
-        self._spy = self.add_equity("SPY", Resolution.DAILY)
+        self._spy = self.add_equity("SPY")
         # Hyperparameters to create the MLP model.
         num_factors = 5
         num_neurons_1 = 10

--- a/project-templates/python/common/research.ipynb
+++ b/project-templates/python/common/research.ipynb
@@ -34,17 +34,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Get historical data for a bank sector ETF and some banking companies over 2021.\n",
-    "qb = QuantBook()\n",
-    "tickers = [\"XLF\",   # Financial Select Sector SPDR Fund\n",
-    "           \"COF\",   # Capital One Financial Corporation\n",
-    "           \"GS\",    # Goldman Sachs Group, Inc.\n",
-    "           \"JPM\",   # J P Morgan Chase & Co\n",
-    "           \"WFC\"]   # Wells Fargo & Company\n",
-    "symbols = [qb.add_equity(ticker, Resolution.DAILY).symbol for ticker in tickers]\n",
-    "history = qb.history(symbols, datetime(2021, 1, 1), datetime(2022, 1, 1))"
-   ]
+   "source": "# Get historical data for a bank sector ETF and some banking companies over 2021.\nqb = QuantBook()\ntickers = [\"XLF\",   # Financial Select Sector SPDR Fund\n           \"COF\",   # Capital One Financial Corporation\n           \"GS\",    # Goldman Sachs Group, Inc.\n           \"JPM\",   # J P Morgan Chase & Co\n           \"WFC\"]   # Wells Fargo & Company\nsymbols = [qb.add_equity(ticker).symbol for ticker in tickers]\nhistory = qb.history(symbols, datetime(2021, 1, 1), datetime(2022, 1, 1))"
   },
   {
    "cell_type": "markdown",

--- a/project-templates/python/equities-universe/main.py
+++ b/project-templates/python/equities-universe/main.py
@@ -14,7 +14,7 @@ class EmaCrossUniverseSelectionAlgorithm(QCAlgorithm):
         self.set_cash(100000)
         self.settings.seed_initial_prices = True
         self.universe_settings.leverage = 2
-        self.universe_settings.resolution = Resolution.DAILY
+        self.universe_settings.resolution = Resolution.MINUTE
 
         def _filter(fundamentals: List[Fundamental]) -> List[Symbol]:
             selected = {}


### PR DESCRIPTION
## Summary
- Drop `Resolution.DAILY` from `add_equity` / `AddEquity` in the Python ai template and both Python and C# common research notebooks; Minute is the default.
- Set `UniverseSettings.Resolution = Resolution.Minute` on the equities-universe templates to match the explicit style used by the alt-data universe templates.
- Indicator constructors, indicator history, warm-up calls, and alt-data feeds (Smart Insider, Quiver, Brain, EODHD, CoinGecko, FRED, BitcoinMetadata, Bitstamp custom data) keep their Daily resolution.

## Test plan
- [ ] Backtest the ai template to confirm SPY trades on Minute data while the daily-based ROC training history still works.
- [ ] Run the equities-universe templates and confirm selected symbols subscribe at Minute resolution.
- [ ] Open both common research notebooks and verify the AddEquity / add_equity calls return Minute-resolution history.