### PR TITLE
Add equity pairs trading, momentum decile, and ROC rank templates

### DIFF
--- a/project-templates/csharp/equity-momentum-cross-sectional-decile/Main.cs
+++ b/project-templates/csharp/equity-momentum-cross-sectional-decile/Main.cs
@@ -1,0 +1,140 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+
+public class SP500Momentum : QCAlgorithm
+{
+    private Universe _universe;
+
+    private readonly int _lookback = 252;
+    private readonly int _universeCap = 100;
+    private readonly double _topDecilePct = 0.1;
+
+    // One momentum indicator per constituent, fed from the universe stream.
+    private readonly Dictionary<Symbol, MomentumPercent> _momentumBySymbol = new();
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(250000);
+
+        Settings.SeedInitialPrices = true;
+        Settings.MinimumOrderMarginPortfolioPercentage = 0m;
+
+        // Chain SPY ETF constituents into a fundamental universe.
+        UniverseSettings.Resolution = Resolution.Minute;
+        _universe = AddUniverse(Universe.ETF("SPY"), SelectAssets);
+
+        // Warm up the per-symbol momentum indicators with daily bars.
+        SetWarmUp(_lookback + 1, Resolution.Daily);
+
+        // Monthly rebalance shortly after the open
+        Schedule.On(DateRules.MonthStart("SPY"), TimeRules.At(9, 31), Rebalance);
+    }
+
+    private IEnumerable<Symbol> SelectAssets(IEnumerable<Fundamental> fundamentals)
+    {
+        var constituents = fundamentals.ToList();
+
+        // Stream each constituent's adjusted price into its momentum indicator.
+        var topByVolume = constituents
+            .Where(f => 
+            {
+                if (!_momentumBySymbol.TryGetValue(f.Symbol, out var momentum))
+                {
+                    momentum = new MomentumPercent(_lookback);
+                    _momentumBySymbol[f.Symbol] = momentum;
+                }
+                return momentum.Update(f.EndTime, f.AdjustedPrice);
+            })
+            // Cap the universe at the top 100 constituents by fundamental dollar volume.
+            .OrderByDescending(f => f.DollarVolume)
+            .Take(_universeCap)
+            .ToList();
+
+        if (IsWarmingUp || topByVolume.Count == 0)
+        {
+            return Universe.Unchanged;
+        }
+
+        // Select the top decile by momentum.
+        var decileCount = Math.Max(1, (int)(topByVolume.Count * _topDecilePct));
+        return topByVolume
+            .OrderByDescending(f => _momentumBySymbol[f.Symbol])
+            .Take(decileCount)
+            .Select(f => f.Symbol);
+    }
+
+    private void Rebalance()
+    {
+        if (_universe.Selected.Count == 0)
+        {
+            return;
+        }
+        var weight = 1m / _universe.Selected.Count;
+        var targets = _universe.Selected
+            .Select(symbol => new PortfolioTarget(symbol, weight))
+            .ToList();
+        SetHoldings(targets, liquidateExistingHoldings: true);
+    }
+}

--- a/project-templates/csharp/equity-pairs-trading-cointegration/Main.cs
+++ b/project-templates/csharp/equity-pairs-trading-cointegration/Main.cs
@@ -1,0 +1,199 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class KOPepPairsTrading : QCAlgorithm
+{
+    private Symbol _ko;
+    private Symbol _pep;
+
+    private double _alpha = 0.0;
+    private double _beta = 1.0;
+    private double _spreadMean = 0.0;
+    private double _spreadStd = 1.0;
+    private int _state = 0;  // 0: flat, 1: long spread, -1: short spread
+
+    // Demonstrate RollingWindow usage by tracking recent z-scores
+    private readonly RollingWindow<double> _zWindow = new RollingWindow<double>(5);
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+
+        var ko = AddEquity("KO", Resolution.Minute);
+        var pep = AddEquity("PEP", Resolution.Minute);
+        _ko = ko.Symbol;
+        _pep = pep.Symbol;
+
+        // Cache 60 daily market sessions per security to fit the OLS
+        // hedge ratio without making history requests.
+        ko.Session.Size = 60;
+        pep.Session.Size = 60;
+
+        SetWarmUp(60, Resolution.Daily);
+
+        // Re-fit the hedge ratio weekly on the first trading day of the week
+        Schedule.On(DateRules.WeekStart(), TimeRules.At(9, 31), UpdateModel);
+
+        // Evaluate the spread signal daily shortly after the open
+        Schedule.On(DateRules.EveryDay(), TimeRules.At(10, 0), TradeLogic);
+    }
+
+    public override void OnWarmupFinished()
+    {
+        UpdateModel();
+    }
+
+    private void UpdateModel()
+    {
+        // Fit the OLS hedge ratio from the cached daily market sessions.
+        var koSession = Securities[_ko].Session;
+        var pepSession = Securities[_pep].Session;
+        if (koSession.Count < 60 || pepSession.Count < 60)
+        {
+            return;
+        }
+
+        // Session windows iterate newest-first; reverse to chronological order.
+        var koCloses = koSession.Select(x => (double)x.Close).Reverse().ToList();
+        var pepCloses = pepSession.Select(x => (double)x.Close).Reverse().ToList();
+
+        // OLS: KO = beta * PEP + alpha
+        var n = pepCloses.Count;
+        var pepMean = pepCloses.Average();
+        var koMean = koCloses.Average();
+        var covariance = 0.0;
+        var variance = 0.0;
+        for (var i = 0; i < n; i++)
+        {
+            covariance += (pepCloses[i] - pepMean) * (koCloses[i] - koMean);
+            variance += (pepCloses[i] - pepMean) * (pepCloses[i] - pepMean);
+        }
+        _beta = covariance / variance;
+        _alpha = koMean - _beta * pepMean;
+
+        var spread = new double[n];
+        for (var i = 0; i < n; i++)
+        {
+            spread[i] = koCloses[i] - (_beta * pepCloses[i] + _alpha);
+        }
+        _spreadMean = spread.Average();
+        var sumSquares = 0.0;
+        foreach (var value in spread)
+        {
+            sumSquares += (value - _spreadMean) * (value - _spreadMean);
+        }
+        _spreadStd = Math.Sqrt(sumSquares / n);
+
+        if (_spreadStd == 0)
+        {
+            _spreadStd = 1e-6;
+        }
+    }
+
+    private void TradeLogic()
+    {
+        if (IsWarmingUp || _spreadStd == 0)
+        {
+            return;
+        }
+
+        var koPrice = (double)Securities[_ko].Close;
+        var pepPrice = (double)Securities[_pep].Close;
+
+        var currentSpread = koPrice - (_beta * pepPrice + _alpha);
+        var zScore = (currentSpread - _spreadMean) / _spreadStd;
+        _zWindow.Add(zScore);
+
+        if (zScore < -2 && _state != 1)
+        {
+            // Long spread -> long KO, short PEP (dollar-neutral)
+            SetHoldings(new List<PortfolioTarget>
+            {
+                new PortfolioTarget(_ko, 0.5m),
+                new PortfolioTarget(_pep, -0.5m)
+            }, liquidateExistingHoldings: true);
+            _state = 1;
+        }
+        else if (zScore > 2 && _state != -1)
+        {
+            // Short spread -> short KO, long PEP (dollar-neutral)
+            SetHoldings(new List<PortfolioTarget>
+            {
+                new PortfolioTarget(_ko, -0.5m),
+                new PortfolioTarget(_pep, 0.5m)
+            }, liquidateExistingHoldings: true);
+            _state = -1;
+        }
+        else if (Math.Abs(zScore) < 0.5 && _state != 0)
+        {
+            Liquidate();
+            _state = 0;
+        }
+    }
+
+    public override void OnEndOfAlgorithm()
+    {
+        Liquidate();
+    }
+}

--- a/project-templates/csharp/equity-roc-momentum-rank/Main.cs
+++ b/project-templates/csharp/equity-roc-momentum-rank/Main.cs
@@ -1,0 +1,109 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+
+public class SectorRotationAlgorithm : QCAlgorithm
+{
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(200000);
+        Settings.AutomaticIndicatorWarmUp = true;
+
+        var tickers = new string[]
+        {
+            "XLK", "XLF", "XLE", "XLV", "XLI",
+            "XLB", "XLY", "XLP", "XLU", "XLRE"
+        };
+        foreach (var ticker in tickers)
+        {
+            // Minute-resolution data, but rank on a daily ROC indicator.
+            dynamic equity = AddEquity(ticker);
+            equity.Roc = ROC(equity, 60, Resolution.Daily);
+        }
+
+        Schedule.On(
+            DateRules.MonthStart("XLK"),
+            TimeRules.AfterMarketOpen("XLK", 1),
+            Rebalance);
+    }
+
+    private void Rebalance()
+    {
+        var securities = Securities.Values.ToList();
+        if (!securities.All(security => (bool)((dynamic)security).Roc.IsReady))
+        {
+            return;
+        }
+
+        var top3 = securities
+            .OrderByDescending(security => (decimal)((dynamic)security).Roc.Current.Value)
+            .Take(3)
+            .ToList();
+
+        var targets = top3
+            .Select(security => new PortfolioTarget(security.Symbol, (decimal)(1.0 / 3.0)))
+            .ToList();
+        SetHoldings(targets, liquidateExistingHoldings: true);
+    }
+}

--- a/project-templates/csharp/templates.json
+++ b/project-templates/csharp/templates.json
@@ -431,6 +431,30 @@
 			"folder": "crypto-fred-rates-toggle",
 			"description": "Rotates between BTCUSD and gold-backed PAXGUSD on Kraken based on the 3-month change in the FRED Fed Funds Rate — long BTC when easing, gold when hiking or flat.",
 			"tags": ["Crypto", "alternative-data", "macro", "regime-switch", "indicators", "history", "fred", "us-federal-reserve"]
+		},
+		{
+			"folder": "equity-pairs-trading-cointegration",
+			"name": "Equity Pairs Trading (Cointegration)",
+			"description": "Trades the spread between KO and PEP using a 60-day OLS hedge ratio and z-score thresholds for entries/exits.",
+			"spec": "Assets: KO, PEP. Minute resolution. 2022-01-01 to 2024-12-31, $100k. Compute hedge ratio via 60-day rolling OLS on closes; z-score the spread; long-spread when z<-2 (long KO, short PEP); short-spread when z>2; exit when |z|<0.5. Demonstrates: history requests for OLS, RollingWindow, dollar-neutral sizing. Edge case: re-fit hedge ratio weekly.",
+			"tags": ["Equity", "pairs-trading", "statistical-arbitrage", "history"],
+			"reference_template": "history-and-etf-universe"
+		},
+		{
+			"folder": "equity-momentum-cross-sectional-decile",
+			"name": "Equity Cross-Sectional Momentum Decile",
+			"description": "Selects the top decile of S&P 500 stocks by 12-1 month momentum and rebalances monthly into an equal-weight long portfolio.",
+			"spec": "Universe: S&P 500 (etf-constituents on SPY) capped at 100 by dollar volume. Minute. 2022-01-01 to 2024-12-31, $250k. Compute 252-21 day return (12-1 momentum) via history. Monthly schedule selects top decile (~10 names) and equal-weights. Demonstrates: ETF universe, history-based factor, monthly rebalance, set_holdings on top decile.",
+			"tags": ["Equity", "momentum", "etf-universe", "factor"],
+			"reference_template": "history-and-etf-universe"
+		},
+		{
+			"folder": "equity-roc-momentum-rank",
+			"name": "Equity ROC Momentum Rank",
+			"description": "Ranks 10 sector ETFs by 60-day ROC monthly and equal-weights the top 3 with a scheduled rebalance.",
+			"spec": "Assets: XLK,XLF,XLE,XLV,XLI,XLB,XLY,XLP,XLU,XLRE. Daily. 2022-01-01 to 2024-12-31, $200k. ROC(60). Monthly schedule (first trading day) ranks ETFs and equal-weights the top 3. Demonstrates: multi-symbol indicator dictionary, sector rotation, scheduled monthly rebalance. Edge case: liquidate names that drop out of the top 3.",
+			"tags": ["Equity", "indicators", "roc", "sector-rotation"],
+			"reference_template": "equities-static-universe"
 		}
 	]
 }

--- a/project-templates/python/equity-momentum-cross-sectional-decile/main.py
+++ b/project-templates/python/equity-momentum-cross-sectional-decile/main.py
@@ -1,0 +1,69 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+
+class SP500Momentum(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(250_000)
+
+        self.settings.seed_initial_prices = True
+        self.settings.minimum_order_margin_portfolio_percentage = 0
+
+        self._lookback = 252
+        self._universe_cap = 100
+        self._top_decile_pct = 0.1
+
+        # One momentum indicator per constituent, fed from the universe stream.
+        self._momentum_by_symbol = {}
+
+        # Chain SPY ETF constituents into a fundamental universe.
+        self.universe_settings.resolution = Resolution.MINUTE
+        self._universe = self.add_universe(
+            self.universe.etf("SPY"),
+            self._select_assets,
+        )
+        # Warm up the per-symbol momentum indicators with daily bars.
+        self.set_warm_up(self._lookback + 1, Resolution.DAILY)
+
+        # Monthly rebalance shortly after the open
+        self.schedule.on(
+            self.date_rules.month_start("SPY"),
+            self.time_rules.at(9, 31),
+            self._rebalance,
+        )
+
+    def _select_assets(self, fundamentals: list[Fundamental]):
+        # Stream each constituent's adjusted price into its momentum indicator.
+        ready = [
+            f for f in fundamentals
+            if self._momentum_by_symbol.setdefault(
+                f.symbol, MomentumPercent(self._lookback)
+            ).update(f.end_time, f.adjusted_price)
+        ]
+        if self.is_warming_up:
+            return Universe.UNCHANGED
+
+        # Cap the universe at the top 100 constituents by fundamental dollar volume.
+        top_by_volume = sorted(ready, reverse=True,
+            key=lambda f: f.dollar_volume
+        )[:self._universe_cap]
+        if not top_by_volume:
+            return Universe.UNCHANGED
+
+        # Select the top decile by momentum.
+        decile_count = max(1, int(len(top_by_volume) * self._top_decile_pct))
+        ranked = sorted(top_by_volume, reverse=True,
+            key=lambda f: self._momentum_by_symbol[f.symbol].current.value
+        )
+        return [f.symbol for f in ranked[:decile_count]]
+
+    def _rebalance(self) -> None:
+        selected = list(self._universe.selected)
+        if not selected:
+            return
+        weight = 1.0 / len(selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in selected]
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/equity-pairs-trading-cointegration/main.py
+++ b/project-templates/python/equity-pairs-trading-cointegration/main.py
@@ -1,0 +1,111 @@
+# region imports
+from AlgorithmImports import *
+import numpy as np
+# endregion
+
+
+class KOPepPairsTrading(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100_000)
+
+        ko = self.add_equity("KO", Resolution.MINUTE)
+        pep = self.add_equity("PEP", Resolution.MINUTE)
+        self._ko = ko.symbol
+        self._pep = pep.symbol
+
+        # Cache 60 daily market sessions per security to fit the OLS
+        # hedge ratio without making history requests.
+        ko.session.size = 60
+        pep.session.size = 60
+
+        self._alpha = 0.0
+        self._beta = 1.0
+        self._spread_mean = 0.0
+        self._spread_std = 1.0
+        self._state = 0  # 0: flat, 1: long spread, -1: short spread
+
+        # Demonstrate RollingWindow usage by tracking recent z-scores
+        self._z_window = RollingWindow[float](5)
+
+        self.set_warm_up(60, Resolution.DAILY)
+
+        # Re-fit the hedge ratio weekly on the first trading day of the week
+        self.schedule.on(
+            self.date_rules.week_start(),
+            self.time_rules.at(9, 31),
+            self._update_model,
+        )
+
+        # Evaluate the spread signal daily shortly after the open
+        self.schedule.on(
+            self.date_rules.every_day(),
+            self.time_rules.at(10, 0),
+            self._trade_logic,
+        )
+
+    def on_warmup_finished(self) -> None:
+        self._update_model()
+
+    def _update_model(self) -> None:
+        """Fit the OLS hedge ratio from the cached daily market sessions."""
+        ko_session = self.securities[self._ko].session
+        pep_session = self.securities[self._pep].session
+        if ko_session.count < 60 or pep_session.count < 60:
+            return
+
+        # Session windows iterate newest-first; reverse to chronological order.
+        ko_closes = np.array([x.close for x in ko_session][::-1], dtype=float)
+        pep_closes = np.array([x.close for x in pep_session][::-1], dtype=float)
+
+        # OLS: KO = beta * PEP + alpha
+        A = np.vstack([pep_closes, np.ones(len(pep_closes))]).T
+        result = np.linalg.lstsq(A, ko_closes, rcond=None)[0]
+        self._beta = float(result[0])
+        self._alpha = float(result[1])
+
+        spread = ko_closes - (self._beta * pep_closes + self._alpha)
+        self._spread_mean = float(np.mean(spread))
+        self._spread_std = float(np.std(spread))
+
+        if self._spread_std == 0:
+            self._spread_std = 1e-6
+
+    def _trade_logic(self) -> None:
+        if self.is_warming_up or self._spread_std == 0:
+            return
+
+        ko_price = self.securities[self._ko].close
+        pep_price = self.securities[self._pep].close
+
+        current_spread = ko_price - (self._beta * pep_price + self._alpha)
+        z_score = (current_spread - self._spread_mean) / self._spread_std
+        self._z_window.add(float(z_score))
+
+        if z_score < -2 and self._state != 1:
+            # Long spread -> long KO, short PEP (dollar-neutral)
+            self.set_holdings(
+                [
+                    PortfolioTarget(self._ko, 0.5),
+                    PortfolioTarget(self._pep, -0.5),
+                ],
+                liquidate_existing_holdings=True,
+            )
+            self._state = 1
+        elif z_score > 2 and self._state != -1:
+            # Short spread -> short KO, long PEP (dollar-neutral)
+            self.set_holdings(
+                [
+                    PortfolioTarget(self._ko, -0.5),
+                    PortfolioTarget(self._pep, 0.5),
+                ],
+                liquidate_existing_holdings=True,
+            )
+            self._state = -1
+        elif abs(z_score) < 0.5 and self._state != 0:
+            self.liquidate()
+            self._state = 0
+
+    def on_end_of_algorithm(self) -> None:
+        self.liquidate()

--- a/project-templates/python/equity-roc-momentum-rank/main.py
+++ b/project-templates/python/equity-roc-momentum-rank/main.py
@@ -1,0 +1,41 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+
+class SectorRotationAlgorithm(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(200000)
+        self.settings.automatic_indicator_warm_up = True
+
+        tickers = [
+            "XLK", "XLF", "XLE", "XLV", "XLI",
+            "XLB", "XLY", "XLP", "XLU", "XLRE"
+        ]
+        for ticker in tickers:
+            # Minute-resolution data, but rank on a daily ROC indicator.
+            equity = self.add_equity(ticker)
+            equity.roc = self.roc(equity, 60, Resolution.DAILY)
+
+        self.schedule.on(
+            self.date_rules.month_start("XLK"),
+            self.time_rules.after_market_open("XLK", 1),
+            self._rebalance
+        )
+
+    def _rebalance(self) -> None:
+        securities = list(self.securities.values())
+        if not all(security.roc.is_ready for security in securities):
+            return
+
+        ranked = sorted(
+            securities,
+            key=lambda security: security.roc.current.value,
+            reverse=True
+        )
+
+        top_3 = ranked[:3]
+        targets = [PortfolioTarget(security.symbol, 1.0 / 3.0) for security in top_3]
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -431,6 +431,30 @@
 			"folder": "crypto-fred-rates-toggle",
 			"description": "Rotates between BTCUSD and gold-backed PAXGUSD on Kraken based on the 3-month change in the FRED Fed Funds Rate — long BTC when easing, gold when hiking or flat.",
 			"tags": ["Crypto", "alternative-data", "macro", "regime-switch", "indicators", "history", "fred", "us-federal-reserve"]
+		},
+		{
+			"folder": "equity-pairs-trading-cointegration",
+			"name": "Equity Pairs Trading (Cointegration)",
+			"description": "Trades the spread between KO and PEP using a 60-day OLS hedge ratio and z-score thresholds for entries/exits.",
+			"spec": "Assets: KO, PEP. Minute resolution. 2022-01-01 to 2024-12-31, $100k. Compute hedge ratio via 60-day rolling OLS on closes; z-score the spread; long-spread when z<-2 (long KO, short PEP); short-spread when z>2; exit when |z|<0.5. Demonstrates: history requests for OLS, RollingWindow, dollar-neutral sizing. Edge case: re-fit hedge ratio weekly.",
+			"tags": ["Equity", "pairs-trading", "statistical-arbitrage", "history"],
+			"reference_template": "history-and-etf-universe"
+		},
+		{
+			"folder": "equity-momentum-cross-sectional-decile",
+			"name": "Equity Cross-Sectional Momentum Decile",
+			"description": "Selects the top decile of S&P 500 stocks by 12-1 month momentum and rebalances monthly into an equal-weight long portfolio.",
+			"spec": "Universe: S&P 500 (etf-constituents on SPY) capped at 100 by dollar volume. Minute. 2022-01-01 to 2024-12-31, $250k. Compute 252-21 day return (12-1 momentum) via history. Monthly schedule selects top decile (~10 names) and equal-weights. Demonstrates: ETF universe, history-based factor, monthly rebalance, set_holdings on top decile.",
+			"tags": ["Equity", "momentum", "etf-universe", "factor"],
+			"reference_template": "history-and-etf-universe"
+		},
+		{
+			"folder": "equity-roc-momentum-rank",
+			"name": "Equity ROC Momentum Rank",
+			"description": "Ranks 10 sector ETFs by 60-day ROC monthly and equal-weights the top 3 with a scheduled rebalance.",
+			"spec": "Assets: XLK,XLF,XLE,XLV,XLI,XLB,XLY,XLP,XLU,XLRE. Daily. 2022-01-01 to 2024-12-31, $200k. ROC(60). Monthly schedule (first trading day) ranks ETFs and equal-weights the top 3. Demonstrates: multi-symbol indicator dictionary, sector rotation, scheduled monthly rebalance. Edge case: liquidate names that drop out of the top 3.",
+			"tags": ["Equity", "indicators", "roc", "sector-rotation"],
+			"reference_template": "equities-static-universe"
 		}
 	]
 }

--- a/project-templates/template-ideas.json
+++ b/project-templates/template-ideas.json
@@ -1,0 +1,4034 @@
+{
+  "ideas": [
+    {
+      "folder": "equity-atr-volatility-stop",
+      "name": "Equity ATR Volatility Stop",
+      "description": "Holds SPY long with an ATR(14) chandelier-style trailing stop set 3x ATR below the trailing high.",
+      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. ATR(14). Buy on first bar; maintain trailing high; if close < trailing_high - 3*ATR, liquidate and re-enter on next bar. Demonstrates: ATR indicator, manual trailing-stop pattern, plotting stop level. Edge case: reset trailing high after each liquidation.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "atr",
+        "trailing-stop"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-obv-divergence",
+      "name": "Equity OBV Divergence",
+      "description": "Detects bullish/bearish On-Balance Volume divergence on SPY versus a 20-day price ROC and trades reversals.",
+      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. OBV indicator and ROC(20) on price. Bullish divergence: price ROC < 0 but OBV ROC > 0 -> long. Bearish opposite -> short. Demonstrates: OBV automatic indicator, IndicatorExtensions to compute ROC of OBV, divergence logic. Edge case: require 5-day confirmation.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "obv",
+        "divergence"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-cmf-money-flow",
+      "name": "Equity Chaikin Money Flow",
+      "description": "Trades XLF using ChaikinMoneyFlow(20) — long when CMF > 0.1 and short when CMF < -0.1, flat in between.",
+      "spec": "Asset: XLF. Daily resolution. 2022-01-01 to 2024-12-31, $100k. ChaikinMoneyFlow(20). Long when CMF > 0.10; short when CMF < -0.10; flat in the dead zone. Demonstrates: CMF volume indicator, threshold-based regime, plotting indicator on subchart. Edge case: rebalance only on signal change.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "cmf",
+        "volume"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-fisher-transform-reversal",
+      "name": "Equity Fisher Transform Reversal",
+      "description": "Trades NDX-tracking QQQ on FisherTransform extreme readings, fading values above 2.0 and below -2.0.",
+      "spec": "Asset: QQQ. Daily resolution. 2022-01-01 to 2024-12-31, $100k. FisherTransform(10). Short when value > 2 and turning down; long when < -2 and turning up; exit on cross of 0. Demonstrates: FisherTransform indicator, RollingWindow on indicator value to detect turns. Edge case: only one position at a time.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "fisher-transform",
+        "reversal"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-aroon-trend",
+      "name": "Equity Aroon Trend",
+      "description": "Trades SPY using AroonOscillator(25); enters long on cross above +50 and exits on cross below -50.",
+      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. AroonOscillator(25). Long when oscillator crosses above 50; exit when it crosses below -50. Demonstrates: Aroon indicator, threshold crossing pattern, plotting oscillator on subchart. Edge case: do not flip short — long-only.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "aroon",
+        "trend"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-williams-percent-r",
+      "name": "Equity Williams %R",
+      "description": "Trades IWM with WilliamsPercentR(14): long entries below -80 and exits above -20.",
+      "spec": "Asset: IWM. Daily resolution. 2022-01-01 to 2024-12-31, $100k. WilliamsPercentR(14). Long when %R < -80; exit when %R > -20. Demonstrates: Williams %R indicator, oversold reversion logic, plotting against -80/-20 reference lines. Edge case: hold cap of 5 trading days.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "williams-r",
+        "oscillator"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-cci-overbought",
+      "name": "Equity Commodity Channel Index",
+      "description": "Trades XLE on CCI(20) — long when CCI < -100 and exit at 0; short when CCI > 100 and cover at 0.",
+      "spec": "Asset: XLE. Daily resolution. 2022-01-01 to 2024-12-31, $100k. CommodityChannelIndex(20). Long when CCI < -100; short when CCI > 100; both exit at 0. Demonstrates: CCI indicator, mean-reversion with explicit short side, sector ETF. Edge case: skip orders during low-volatility (ATR filter).",
+      "tags": [
+        "Equity",
+        "indicators",
+        "cci",
+        "mean-reversion"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-mfi-divergence",
+      "name": "Equity Money Flow Index",
+      "description": "Uses the built-in MFI(14) on SPY for overbought/oversold reversion — distinct from the existing custom-indicator template.",
+      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. Built-in MoneyFlowIndex(14) (NOT custom). Long when MFI < 20; short when MFI > 80; exit at 50. Demonstrates: built-in MFI indicator (vs custom), automatic warm-up, plotting against thresholds. Edge case: do nothing while indicator is_ready False.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "mfi",
+        "automatic-indicator"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-tom-demark-sequential",
+      "name": "Equity Tom DeMark Sequential",
+      "description": "Trades SPY using TDSequential setup counts — buy on a 9-count buy setup and sell on a 9-count sell setup.",
+      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. Built-in TDSequential indicator (or custom 9-count if unavailable). Long on completed buy-setup of 9; flat/short on completed sell-setup. Demonstrates: pattern-based indicator, RollingWindow over closes, indicator plotting with annotations. Edge case: cancel partial setups on opposite-side bar.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "td-sequential",
+        "pattern"
+      ],
+      "reference_template": "custom-indicator"
+    },
+    {
+      "folder": "equity-kama-adaptive-trend",
+      "name": "Equity Kaufman Adaptive Moving Average",
+      "description": "Trades QQQ using KaufmanAdaptiveMovingAverage(10,2,30) crossover with the close price.",
+      "spec": "Asset: QQQ. Daily resolution. 2022-01-01 to 2024-12-31, $100k. KaufmanAdaptiveMovingAverage(10,2,30). Long when close crosses above KAMA; flat when close crosses below. Demonstrates: KAMA indicator, adaptive smoothing, plotting overlay. Edge case: ignore signals during the warm-up period.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "kama",
+        "adaptive"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-hull-moving-average-cross",
+      "name": "Equity Hull Moving Average Cross",
+      "description": "Trades SPY using HullMovingAverage(20) and HullMovingAverage(50) crossover signals.",
+      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. HullMovingAverage(20) and HullMovingAverage(50). Long on HMA20 cross above HMA50; flat/short on HMA20 cross below HMA50. Demonstrates: Hull MA indicator (low-lag MA), classical dual-MA cross. Edge case: minimum 1-bar gap between flips.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "hull-ma",
+        "moving-average-cross"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-fractal-adaptive-ma",
+      "name": "Equity Fractal Adaptive Moving Average",
+      "description": "Trades SPY using FractalAdaptiveMovingAverage(16) crossover with closing price.",
+      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. FractalAdaptiveMovingAverage(16). Long when close > FRAMA; flat when close < FRAMA. Demonstrates: FRAMA indicator (Hurst-based adaptive), plotting overlay, automatic warm-up. Edge case: only rebalance once per day.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "frama",
+        "adaptive"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-trix-momentum",
+      "name": "Equity TRIX Momentum",
+      "description": "Trades AAPL with TRIX(15) signal-line crossings — long on TRIX cross above 0, exit on cross below 0.",
+      "spec": "Asset: AAPL. Daily resolution. 2022-01-01 to 2024-12-31, $100k. TRIX(15) and a 9-period SMA signal. Long on TRIX cross above signal AND TRIX > 0; exit on cross below signal. Demonstrates: TRIX indicator, IndicatorExtensions.SMA on indicator output. Edge case: skip orders within first 30 bars.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "trix",
+        "momentum"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-vwap-intraday-fade",
+      "name": "Equity Intraday VWAP Fade",
+      "description": "Fades 1-minute VWAP deviations on SPY — long when price drops 0.5% below VWAP; flat at VWAP touch.",
+      "spec": "Asset: SPY. Minute resolution. 2024-09-01 to 2024-12-31, $100k. Build session VWAP (built-in VolumeWeightedAveragePriceIndicator). Long when (price - vwap)/vwap < -0.005; flat when price >= vwap. Reset VWAP daily. Demonstrates: minute-resolution intraday, session VWAP, scheduled reset at market open. Edge case: do not trade in last 15 minutes.",
+      "tags": [
+        "Equity",
+        "indicators",
+        "vwap",
+        "intraday"
+      ],
+      "reference_template": "intraday-indicator-scans"
+    },
+    {
+      "folder": "equity-low-volatility-factor",
+      "name": "Equity Low-Volatility Factor",
+      "description": "Selects the bottom decile of S&P 500 names by 60-day realized volatility and equal-weights them monthly.",
+      "spec": "Universe: SPY constituents. Daily. 2022-01-01 to 2024-12-31, $250k. Use history(60, Resolution.DAILY) per name to compute std of returns. Monthly schedule selects 30 lowest-vol names; equal-weight long. Demonstrates: history requests inside universe selector, factor-based selection, monthly rebalance. Edge case: drop names with insufficient history.",
+      "tags": [
+        "Equity",
+        "low-volatility",
+        "factor",
+        "etf-universe"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "equity-value-pe-pb-quality",
+      "name": "Equity Value/Quality Composite",
+      "description": "Selects S&P 500 names by a composite of low PE, low PB, and high ROE; equal-weights the top 20 monthly.",
+      "spec": "Universe: fundamental. Daily. 2022-01-01 to 2024-12-31, $250k. Rank by z-score of (-PE, -PB, +ROE) and combine equally; pick top 20 names. Monthly rebalance. Demonstrates: fundamental data, multi-factor composite, equal-weight. Edge case: skip names with missing fundamentals (use is_finite checks).",
+      "tags": [
+        "Equity",
+        "value-factor",
+        "quality-factor",
+        "fundamentals"
+      ],
+      "reference_template": "equities-universe"
+    },
+    {
+      "folder": "equity-dual-momentum-asset-class",
+      "name": "Equity Dual Momentum",
+      "description": "Implements Antonacci dual momentum across SPY, EFA, and AGG: pick the top 12-month return, fall back to AGG if absolute momentum is negative.",
+      "spec": "Assets: SPY, EFA, AGG. Daily resolution. 2022-01-01 to 2024-12-31, $100k. Monthly: compute 12-month return for each; pick the highest; if highest <= AGG return then hold AGG; else hold winner 100%. Demonstrates: history-based momentum, monthly schedule, conditional hold. Edge case: rebalance only on first trading day of month.",
+      "tags": [
+        "Equity",
+        "dual-momentum",
+        "asset-allocation",
+        "history"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "equity-sixty-forty-portfolio",
+      "name": "Equity 60/40 Portfolio",
+      "description": "Holds a static 60% SPY / 40% TLT allocation with quarterly rebalance back to target weights.",
+      "spec": "Assets: SPY, TLT. Daily. 2022-01-01 to 2024-12-31, $100k. Set holdings 60/40 on first bar; schedule a quarterly rebalance (first business day of Jan/Apr/Jul/Oct) to retarget. Demonstrates: scheduled events with month_start rule, portfolio rebalancing logic, simple set_holdings. Edge case: drift threshold of 5% to skip no-op rebalances.",
+      "tags": [
+        "Equity",
+        "asset-allocation",
+        "scheduled-event",
+        "rebalance"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-permanent-portfolio",
+      "name": "Equity Permanent Portfolio",
+      "description": "Holds 25% each of SPY, TLT, GLD, and SHY with annual rebalance — Browne's Permanent Portfolio.",
+      "spec": "Assets: SPY, TLT, GLD, SHY. Daily. 2022-01-01 to 2024-12-31, $100k. Equal-weight 25% on first bar; annual rebalance every January 2nd. Demonstrates: 4-asset allocation, annual scheduled event, scheduled-event rule chaining. Edge case: skip rebalance if drift < 3% from target.",
+      "tags": [
+        "Equity",
+        "permanent-portfolio",
+        "asset-allocation",
+        "scheduled-event"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-all-weather-portfolio",
+      "name": "Equity All-Weather Portfolio",
+      "description": "Implements Ray Dalio's All-Weather: 30% SPY, 40% TLT, 15% IEF, 7.5% GLD, 7.5% DBC with annual rebalance.",
+      "spec": "Assets: SPY, TLT, IEF, GLD, DBC. Daily. 2022-01-01 to 2024-12-31, $200k. Set target weights on first bar; annual schedule retargets. Demonstrates: multi-asset allocation, scheduled annual rebalance, holdings drift monitoring. Edge case: skip GLD/DBC if missing in early data.",
+      "tags": [
+        "Equity",
+        "all-weather",
+        "asset-allocation",
+        "etf"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-vix-timed-spy",
+      "name": "Equity VIX-Timed SPY",
+      "description": "Holds SPY when CBOE VIX index is below 20 and switches to SHY when VIX is above 25 (hysteresis band).",
+      "spec": "Assets: SPY, SHY, VIX (use add_index('VIX')). Daily. 2022-01-01 to 2024-12-31, $100k. Daily schedule: if VIX>25 hold SHY, if VIX<20 hold SPY, else stay (hysteresis). Demonstrates: index data subscription, regime-switching, hysteresis logic, scheduled events. Edge case: ensure VIX has data before trading.",
+      "tags": [
+        "Equity",
+        "vix",
+        "regime-switch",
+        "scheduled-event"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-leveraged-etf-switch",
+      "name": "Equity Leveraged ETF Switch",
+      "description": "Switches between SPY and SPXL based on a 200-day SMA filter — leverage in uptrends, cash equivalent in downtrends.",
+      "spec": "Assets: SPXL, SPY, SHV. Daily. 2022-01-01 to 2024-12-31, $100k. SMA(200) on SPY. If SPY > SMA200, hold SPXL 100%; else hold SHV 100%. Daily schedule check. Demonstrates: leveraged ETF, simple regime filter via SMA, conditional set_holdings. Edge case: warm-up SMA via history(200).",
+      "tags": [
+        "Equity",
+        "leveraged-etf",
+        "regime-switch",
+        "indicators"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-dollar-cost-averaging",
+      "name": "Equity Dollar Cost Averaging",
+      "description": "Buys $5,000 worth of VOO every Monday morning regardless of price, accumulating shares over the backtest.",
+      "spec": "Asset: VOO. Daily. 2022-01-01 to 2024-12-31, $200k starting cash. Schedule: every Monday after market open buy VOO with $5,000 of cash via market_order using calculate_order_quantity. Demonstrates: weekly schedule, fixed-dollar buys, calculate_order_quantity, no liquidation. Edge case: skip if insufficient cash; never sell.",
+      "tags": [
+        "Equity",
+        "dca",
+        "scheduled-event",
+        "buy-and-hold"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-opening-range-breakout",
+      "name": "Equity Opening Range Breakout",
+      "description": "Trades SPY breakouts of the 30-minute opening range, going long above the high and short below the low until end of day.",
+      "spec": "Asset: SPY. Minute resolution. 2024-09-01 to 2024-12-31, $100k. Build opening range 9:30-10:00; long on first cross above range high; short on first cross below range low. Force liquidate at 15:55. Demonstrates: minute resolution, scheduled events for ORB window, end-of-day flat. Edge case: only one trade per day.",
+      "tags": [
+        "Equity",
+        "opening-range-breakout",
+        "intraday",
+        "scheduled-event"
+      ],
+      "reference_template": "intraday-indicator-scans"
+    },
+    {
+      "folder": "equity-gap-and-go",
+      "name": "Equity Gap and Go",
+      "description": "Buys S&P 500 names that gap up >2% on the open and rides them to 15:55 with a 1% trailing stop.",
+      "spec": "Universe: SPY constituents (etf-constituents). Minute. 2024-09-01 to 2024-12-31, $200k. Pre-market scan via daily history compares prior close vs open; long names gapping up >2%. 1% trailing stop, force flat at 15:55. Demonstrates: ETF universe, minute resolution, gap detection at open, end-of-day flat. Edge case: cap to top 5 by gap size.",
+      "tags": [
+        "Equity",
+        "gap-trading",
+        "intraday",
+        "etf-universe"
+      ],
+      "reference_template": "intraday-indicator-scans"
+    },
+    {
+      "folder": "equity-turn-of-month-effect",
+      "name": "Equity Turn-of-Month Effect",
+      "description": "Holds SPY only on the last 4 and first 3 trading days of each month and stays in cash otherwise.",
+      "spec": "Asset: SPY. Daily. 2022-01-01 to 2024-12-31, $100k. Use trading calendar to identify last 4 and first 3 trading days of each month; hold SPY on those days, otherwise liquidate. Demonstrates: trading calendar API, scheduled events with custom date logic. Edge case: handle month boundary spanning weekends/holidays.",
+      "tags": [
+        "Equity",
+        "calendar-anomaly",
+        "scheduled-event",
+        "trading-calendar"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-mean-reversion-zscore",
+      "name": "Equity Mean Reversion Z-Score Basket",
+      "description": "Buys S&P 100 names whose 5-day return z-score relative to a 60-day window is below -2, exits at z=0.",
+      "spec": "Universe: top 100 S&P by dollar volume. Daily. 2022-01-01 to 2024-12-31, $200k. For each name: 5-day return, z-scored over 60 days. Long top 5 most-negative z; exit when z >= 0. Demonstrates: history-based factor, RollingWindow, equal-weight long. Edge case: skip names without 60 days of history.",
+      "tags": [
+        "Equity",
+        "mean-reversion",
+        "zscore",
+        "history"
+      ],
+      "reference_template": "equities-universe"
+    },
+    {
+      "folder": "equity-monthly-roc-rotation",
+      "name": "Equity Monthly ROC Rotation",
+      "description": "Rotates monthly into the 3 ETFs (SPY, EFA, EEM, AGG, GLD) with the highest 60-day ROC, equal-weighted.",
+      "spec": "Assets: SPY, EFA, EEM, AGG, GLD. Daily. 2022-01-01 to 2024-12-31, $100k. ROC(60) per ETF. Monthly schedule picks top 3 and equal-weights; liquidates the others. Demonstrates: ROC across asset classes, monthly schedule, set_holdings 1/3 each. Edge case: hold cash if all ROCs negative.",
+      "tags": [
+        "Equity",
+        "asset-rotation",
+        "roc",
+        "scheduled-event"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-relative-strength-leaders",
+      "name": "Equity Relative Strength Leaders",
+      "description": "Holds the 10 S&P 500 names with the highest 90-day return relative to SPY, equal-weighted, monthly rebalance.",
+      "spec": "Universe: SPY constituents. Daily. 2022-01-01 to 2024-12-31, $200k. For each name compute 90-day return minus SPY 90-day return; pick top 10. Monthly rebalance equal-weight long. Demonstrates: relative-strength factor with benchmark, ETF universe + history per security. Edge case: drop names without full 90-day history.",
+      "tags": [
+        "Equity",
+        "relative-strength",
+        "etf-universe",
+        "history"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "equity-quality-roe-margin",
+      "name": "Equity Quality (ROE/Margin) Selector",
+      "description": "Selects fundamental universe by combining ROE > 15% AND gross margin > 40% AND debt/equity < 1; equal-weights.",
+      "spec": "Universe: fundamental. Daily. 2023-01-01 to 2024-12-31, $200k. In FineFundamental selector require ROE>0.15, GrossProfitMargin>0.4, TotalDebtEquityRatio<1. Equal-weight long; rebalance monthly. Demonstrates: fundamental filtering on multiple ratios, monthly schedule. Edge case: cap final basket size at 25 names.",
+      "tags": [
+        "Equity",
+        "quality-factor",
+        "fundamentals",
+        "monthly-rebalance"
+      ],
+      "reference_template": "equities-universe"
+    },
+    {
+      "folder": "equity-low-pe-high-yield",
+      "name": "Equity Low PE High Dividend Yield",
+      "description": "Selects fundamental names with PE<15 and dividend yield>2% in the top 500 by dollar volume; rebalanced monthly.",
+      "spec": "Universe: fundamental, top 500 by dollar volume. Daily. 2023-01-01 to 2024-12-31, $200k. Filter PE<15 AND DividendYield>0.02; equal-weight top 25 by yield. Monthly rebalance. Demonstrates: fundamental data multi-filter, dividend yield ranking. Edge case: handle missing PE (negative earnings) by exclusion.",
+      "tags": [
+        "Equity",
+        "value-factor",
+        "dividend-yield",
+        "fundamentals"
+      ],
+      "reference_template": "equities-universe"
+    },
+    {
+      "folder": "equity-beta-neutral-long-short",
+      "name": "Equity Beta-Neutral Long/Short",
+      "description": "Builds a beta-neutral long/short basket of high-momentum vs low-momentum S&P 500 names sized by 60-day Beta to SPY.",
+      "spec": "Universe: SPY constituents. Daily. 2022-01-01 to 2024-12-31, $250k. Compute 12-1 momentum and Beta(60) to SPY per name. Long top 10 momentum, short bottom 10. Size shorts to neutralize portfolio beta. Demonstrates: Beta indicator, dollar-neutral with beta adjustment, multi-leg sizing. Edge case: re-balance monthly only.",
+      "tags": [
+        "Equity",
+        "long-short",
+        "beta-neutral",
+        "indicators"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "equity-russell-1000-etf-universe",
+      "name": "Equity Russell 1000 ETF Constituents",
+      "description": "Selects IWB (Russell 1000) constituents and rebalances monthly into the top 50 by dollar volume.",
+      "spec": "Universe: IWB ETF constituents. Daily. 2023-01-01 to 2024-12-31, $200k. Monthly schedule: rank constituents by dollar volume, equal-weight top 50. Demonstrates: ETF-constituents universe with a non-SPY/QQQ ETF, monthly rebalance, set_holdings. Edge case: liquidate names that drop out of the top 50.",
+      "tags": [
+        "Equity",
+        "etf-universe",
+        "russell-1000",
+        "monthly-rebalance"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "equity-russell-2000-etf-universe",
+      "name": "Equity Russell 2000 Small Caps",
+      "description": "Selects IWM (Russell 2000) constituents weighted by inverse market cap to tilt toward smaller names.",
+      "spec": "Universe: IWM ETF constituents. Daily. 2023-01-01 to 2024-12-31, $200k. Each constituent: weight = 1/MarketCap normalized to sum 1; cap top 100 names. Monthly rebalance. Demonstrates: ETF universe with inverse-cap weighting, fundamental MarketCap field. Edge case: drop names without market cap.",
+      "tags": [
+        "Equity",
+        "etf-universe",
+        "russell-2000",
+        "small-cap"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "equity-sector-etf-universe-tech",
+      "name": "Equity Tech Sector ETF Constituents",
+      "description": "Selects XLK constituents and trades the top 25 by 21-day momentum on a monthly schedule.",
+      "spec": "Universe: XLK ETF constituents. Daily. 2023-01-01 to 2024-12-31, $200k. ROC(21) per name; monthly schedule picks top 25 by ROC and equal-weights. Demonstrates: sector ETF universe, ROC ranking, monthly rebalance. Edge case: stay flat if XLK constituents incomplete on selection day.",
+      "tags": [
+        "Equity",
+        "etf-universe",
+        "sector-tech",
+        "momentum"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "equity-sector-etf-universe-energy",
+      "name": "Equity Energy Sector ETF Constituents",
+      "description": "Selects XLE constituents and equal-weights the 10 largest by market cap with quarterly rebalance.",
+      "spec": "Universe: XLE ETF constituents. Daily. 2023-01-01 to 2024-12-31, $200k. Quarterly schedule picks top 10 by MarketCap; equal-weight. Demonstrates: sector ETF universe (energy), quarterly rebalance, fundamental MarketCap ranking. Edge case: skip days without selection data.",
+      "tags": [
+        "Equity",
+        "etf-universe",
+        "sector-energy",
+        "quarterly"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "equity-bond-etf-universe",
+      "name": "Equity Bond ETF Universe",
+      "description": "Builds a static bond ETF universe (TLT, IEF, SHY, LQD, HYG, TIP) and rotates monthly to the top 2 by 60-day return.",
+      "spec": "Assets: TLT, IEF, SHY, LQD, HYG, TIP. Daily. 2023-01-01 to 2024-12-31, $100k. ROC(60) per ETF. Monthly schedule picks top 2 and equal-weights; liquidates the rest. Demonstrates: bond ETF universe, top-N rotation, ROC indicator across fixed-income proxies. Edge case: hold cash if all ROCs negative.",
+      "tags": [
+        "Equity",
+        "bond-etf",
+        "asset-rotation",
+        "scheduled-event"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-adr-universe",
+      "name": "Equity ADR Universe",
+      "description": "Selects fundamental US-listed ADRs (foreign companies trading on NYSE/NASDAQ) and equal-weights the top 25 by dollar volume.",
+      "spec": "Universe: fundamental, where SecurityReference.IsDepositaryReceipt is True (or a curated ADR list). Daily. 2023-01-01 to 2024-12-31, $200k. Top 25 by dollar volume, equal-weight, monthly. Demonstrates: filtering CoarseFundamental on flags, ADR-specific selection. Edge case: ensure HasFundamentalData is True.",
+      "tags": [
+        "Equity",
+        "adr",
+        "fundamentals",
+        "universe"
+      ],
+      "reference_template": "equities-universe"
+    },
+    {
+      "folder": "equity-dataless-scheduled-universe",
+      "name": "Equity Dataless Scheduled Universe",
+      "description": "Uses a Dataless Scheduled Universe to add SPY only on Tuesdays each week and remove it on Wednesdays.",
+      "spec": "Asset: SPY (added via DateRules.every(DayOfWeek.TUESDAY)). Daily. 2023-01-01 to 2024-12-31, $100k. Use add_universe(DateRules.every(DayOfWeek.TUESDAY), lambda dt: ['SPY']). Long SPY when added; auto-removed by next selection. Demonstrates: dataless scheduled universe, calendar-driven membership. Edge case: handle Tuesday holidays.",
+      "tags": [
+        "Equity",
+        "dataless-universe",
+        "scheduled-universe",
+        "calendar"
+      ],
+      "reference_template": "chained-universe"
+    },
+    {
+      "folder": "equity-volatility-targeting-universe",
+      "name": "Equity Volatility-Targeting Universe",
+      "description": "Selects S&P 500 names with 30-day realized vol below 15% (annualized) and equal-weights the lowest-vol 30.",
+      "spec": "Universe: SPY constituents. Daily. 2022-01-01 to 2024-12-31, $200k. Compute 30-day annualized stdev of returns via history; require <15%; rank ascending; equal-weight lowest-vol 30. Monthly rebalance. Demonstrates: history inside selector, vol filter, monthly. Edge case: drop names with insufficient history.",
+      "tags": [
+        "Equity",
+        "low-volatility",
+        "etf-universe",
+        "history"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "equity-beta-to-spy-universe",
+      "name": "Equity High-Beta to SPY Universe",
+      "description": "Selects S&P 500 names with 60-day Beta(SPY) above 1.5; equal-weights the top 25 by beta on a monthly schedule.",
+      "spec": "Universe: SPY constituents. Daily. 2022-01-01 to 2024-12-31, $200k. Beta(60) per name vs SPY. Monthly select Beta>1.5; cap top 25 by beta; equal-weight. Demonstrates: Beta indicator inside universe selector, multi-symbol indicator dictionary, monthly schedule. Edge case: warm up Beta with history(60).",
+      "tags": [
+        "Equity",
+        "beta-factor",
+        "etf-universe",
+        "indicators"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "equity-liquidity-dollar-volume-top-100",
+      "name": "Equity Top-100 Dollar Volume Universe",
+      "description": "Selects the top 100 US Equities by 21-day average dollar volume, monthly rebalance into the top 25.",
+      "spec": "Universe: CoarseFundamental ranked by 21-day dollar volume (use rolling history). Daily. 2023-01-01 to 2024-12-31, $200k. Monthly schedule picks top 100 -> top 25 (deeper filter via Fine if desired). Demonstrates: coarse-only universe, dollar-volume ranking, scheduled rebalance. Edge case: drop fundamental requirement to keep coarse-only.",
+      "tags": [
+        "Equity",
+        "liquidity",
+        "coarse-universe",
+        "scheduled-event"
+      ],
+      "reference_template": "equities-universe"
+    },
+    {
+      "folder": "equity-spac-universe",
+      "name": "Equity SPAC Universe",
+      "description": "Selects SPAC tickers by SecurityReference.IsSpacAtIpo (or a curated SPAC list) and trades them with mean-reversion.",
+      "spec": "Universe: fundamental filtered on SecurityReference indicator-of-SPAC. Daily. 2023-01-01 to 2024-12-31, $100k. Equal-weight top 10 by 5-day RSI<30; monthly rebalance. Demonstrates: niche fundamental flag (SPAC), narrow universe, RSI selection. Edge case: handle empty selection days gracefully.",
+      "tags": [
+        "Equity",
+        "spac",
+        "fundamentals",
+        "universe"
+      ],
+      "reference_template": "equities-universe"
+    },
+    {
+      "folder": "equity-sector-rotation-momentum",
+      "name": "Equity Sector Rotation Momentum",
+      "description": "Rotates between 11 SPDR sector ETFs based on 90-day momentum, holding the top 3 equal-weight monthly.",
+      "spec": "Assets: XLK, XLF, XLE, XLV, XLI, XLB, XLY, XLP, XLU, XLRE, XLC. Daily. 2022-01-01 to 2024-12-31, $200k. ROC(90); monthly select top 3 by ROC, equal-weight. Demonstrates: full sector ETF set, ROC ranking, monthly schedule. Edge case: hold cash if all ROCs negative.",
+      "tags": [
+        "Equity",
+        "sector-rotation",
+        "etf",
+        "monthly-rebalance"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "equity-coarse-only-universe",
+      "name": "Equity Coarse-Only Universe",
+      "description": "Selects a coarse-only universe (no fundamental data) of the top 50 US Equities by price-times-volume.",
+      "spec": "Universe: CoarseFundamental only (HasFundamentalData=False allowed). Daily. 2023-01-01 to 2024-12-31, $200k. Daily select top 50 by price*volume; equal-weight; weekly rebalance. Demonstrates: coarse-only selection (no Fine), low-overhead universe, weekly schedule. Edge case: handle pink-sheet/illiquid names by filtering price>5.",
+      "tags": [
+        "Equity",
+        "coarse-universe",
+        "liquidity",
+        "weekly"
+      ],
+      "reference_template": "equities-universe"
+    },
+    {
+      "folder": "equity-thematic-watchlist-universe",
+      "name": "Equity Thematic Watchlist Universe",
+      "description": "Builds a static thematic watchlist (AI/semis: NVDA, AMD, INTC, TSM, AVGO, ASML, QCOM, MRVL, MU) and equal-weights monthly.",
+      "spec": "Assets: NVDA, AMD, INTC, TSM, AVGO, ASML, QCOM, MRVL, MU. Daily. 2023-01-01 to 2024-12-31, $200k. Equal-weight 1/9 with monthly rebalance to target. Demonstrates: thematic static basket, monthly rebalance to target weights, no universe selector. Edge case: drift threshold of 5% to avoid no-op rebalances.",
+      "tags": [
+        "Equity",
+        "thematic",
+        "watchlist",
+        "monthly-rebalance"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "framework-classic-four-modules",
+      "name": "Framework: Classic 4-Module Algorithm",
+      "description": "Wires ManualUniverseSelectionModel, EmaCrossAlphaModel, EqualWeightingPortfolioConstructionModel, ImmediateExecutionModel, NullRiskManagementModel.",
+      "spec": "Assets: SPY, QQQ, IWM. Daily. 2023-01-01 to 2024-12-31, $100k. Use ManualUniverseSelectionModel(symbols), EmaCrossAlphaModel(12,26, Resolution.DAILY), EqualWeightingPortfolioConstructionModel, ImmediateExecutionModel, NullRiskManagementModel. Demonstrates: classic 5-module Algorithm Framework. Edge case: rebalance only when insights expire.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "ema-cross-alpha",
+        "equal-weighting"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "framework-rsi-alpha-mean-reversion",
+      "name": "Framework: RSI Alpha Model",
+      "description": "Uses RsiAlphaModel(14, MovingAverageType.WILDERS, Resolution.DAILY) on QQQ constituents with confidence-weighted PCM.",
+      "spec": "Universe: QQQ constituents (etf-constituents). Daily. 2023-01-01 to 2024-12-31, $200k. RsiAlphaModel(14), ConfidenceWeightedPortfolioConstructionModel, ImmediateExecutionModel. Demonstrates: built-in RSI alpha module, confidence-weighted PCM, ETF universe in framework. Edge case: insight period of 5 days.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "rsi-alpha",
+        "confidence-weighting"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "framework-macd-trend-alpha",
+      "name": "Framework: MACD Trend Alpha",
+      "description": "Wires MacdAlphaModel on a 5-name basket with InsightWeightingPortfolioConstructionModel and ImmediateExecution.",
+      "spec": "Assets: SPY, QQQ, IWM, EFA, EEM. Daily. 2023-01-01 to 2024-12-31, $100k. MacdAlphaModel(12,26,9, MovingAverageType.EXPONENTIAL, Resolution.DAILY), InsightWeightingPortfolioConstructionModel, ImmediateExecutionModel. Demonstrates: MACD alpha, weighted-by-insight-magnitude PCM. Edge case: ensure insights have non-zero magnitude.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "macd-alpha",
+        "insight-weighting"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "framework-mean-variance-optimization",
+      "name": "Framework: Mean-Variance Optimization PCM",
+      "description": "Combines a constant alpha on a 5-name basket with MeanVarianceOptimizationPortfolioConstructionModel for monthly weights.",
+      "spec": "Assets: SPY, AGG, GLD, EFA, EEM. Daily. 2022-01-01 to 2024-12-31, $200k. ConstantAlphaModel emitting equal up insights, MeanVarianceOptimizationPortfolioConstructionModel(lookback=63, period=Resolution.DAILY, target_return=0.02), ImmediateExecutionModel. Demonstrates: MVO PCM, lookback parameterization. Edge case: handle non-positive-definite covariance.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "mean-variance",
+        "portfolio-construction"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "framework-black-litterman",
+      "name": "Framework: Black-Litterman PCM",
+      "description": "Wires BlackLittermanOptimizationPortfolioConstructionModel with subjective views from a custom alpha on a global ETF basket.",
+      "spec": "Assets: SPY, EFA, EEM, AGG, GLD. Daily. 2022-01-01 to 2024-12-31, $200k. Custom alpha emits Insight.Up/Down with magnitudes (views); BlackLittermanOptimizationPortfolioConstructionModel(lookback=63). Demonstrates: Black-Litterman PCM, subjective views via insight magnitudes. Edge case: confidence-of-views via insight confidence.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "black-litterman",
+        "portfolio-construction"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "framework-risk-parity",
+      "name": "Framework: Risk-Parity PCM",
+      "description": "Builds a custom risk-parity portfolio construction model that inverse-vol weights insights from a constant up alpha.",
+      "spec": "Assets: SPY, TLT, GLD, EFA, EEM. Daily. 2022-01-01 to 2024-12-31, $200k. ConstantAlphaModel up; custom RiskParityPCM that weights 1/sigma for each insight using a 60-day rolling history. Demonstrates: writing a custom PCM by overriding determine_target_percent, history-based vol. Edge case: cap weights at 50%.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "risk-parity",
+        "custom-pcm"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "framework-max-drawdown-risk",
+      "name": "Framework: Max Drawdown Risk Module",
+      "description": "Wires MaximumDrawdownPercentPerSecurity(0.05) risk model with EmaCrossAlpha to enforce a 5% per-security stop.",
+      "spec": "Assets: SPY, QQQ, IWM. Daily. 2023-01-01 to 2024-12-31, $100k. ManualUniverse + EmaCrossAlphaModel(12,26) + EqualWeightingPCM + ImmediateExecution + MaximumDrawdownPercentPerSecurity(0.05). Demonstrates: built-in risk module, per-security drawdown stop. Edge case: ensure flatten triggers reverse target.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "drawdown-risk",
+        "ema-cross-alpha"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "framework-sector-exposure-risk",
+      "name": "Framework: Sector Exposure Risk Module",
+      "description": "Wires MaximumSectorExposureRiskManagementModel(0.30) on a fundamental momentum alpha to cap sector concentration.",
+      "spec": "Universe: fundamental top 100 by dollar volume. Daily. 2023-01-01 to 2024-12-31, $200k. MomentumAlphaModel (custom) emits ROC>0 insights; EqualWeightingPCM; MaximumSectorExposureRiskManagementModel(0.30). Demonstrates: sector-cap risk module, fundamental universe in framework. Edge case: drop names without fundamental sector code.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "sector-risk",
+        "fundamentals"
+      ],
+      "reference_template": "equities-universe"
+    },
+    {
+      "folder": "framework-vwap-execution",
+      "name": "Framework: VWAP Execution",
+      "description": "Wires VolumeWeightedAveragePriceExecutionModel with a momentum alpha on minute-resolution liquid ETFs.",
+      "spec": "Assets: SPY, QQQ, IWM. Minute. 2024-09-01 to 2024-12-31, $100k. EmaCrossAlphaModel(60,180, Resolution.MINUTE); EqualWeightingPCM; VolumeWeightedAveragePriceExecutionModel. Demonstrates: VWAP execution model, minute-resolution framework. Edge case: insights with very short period to avoid stale targets.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "vwap-execution",
+        "intraday"
+      ],
+      "reference_template": "intraday-indicator-scans"
+    },
+    {
+      "folder": "framework-immediate-vs-twap-execution",
+      "name": "Framework: TWAP Execution",
+      "description": "Wires StandardDeviationExecutionModel (TWAP-like) for minute-resolution scheduled rebalances on liquid ETFs.",
+      "spec": "Assets: SPY, QQQ, IWM. Minute. 2024-09-01 to 2024-12-31, $100k. ConstantAlphaModel; EqualWeightingPCM; StandardDeviationExecutionModel(period=60, deviations=2.0, resolution=Resolution.MINUTE). Demonstrates: TWAP-style stddev execution, minute-resolution. Edge case: short insight period to force frequent rebalances.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "twap-execution",
+        "intraday"
+      ],
+      "reference_template": "intraday-indicator-scans"
+    },
+    {
+      "folder": "framework-custom-alpha-emit-insights",
+      "name": "Framework: Custom Alpha Emitting Insights",
+      "description": "Implements a custom AlphaModel that emits Insight.Price up/down per security on a Bollinger band cross.",
+      "spec": "Universe: SPY, QQQ, IWM. Daily. 2023-01-01 to 2024-12-31, $100k. Custom AlphaModel with .update producing Insight on BB(20,2) cross of close; period=5 days, magnitude=0.01. EqualWeightingPCM, ImmediateExecution. Demonstrates: writing a custom AlphaModel, insight period/magnitude/confidence. Edge case: handle universe additions/removals.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "custom-alpha",
+        "bollinger-bands"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "framework-hybrid-manual-and-framework",
+      "name": "Framework: Hybrid Manual + Framework",
+      "description": "Combines manual on_data trades on AAPL with framework-managed long/short ETF basket via EmaCrossAlpha.",
+      "spec": "Assets: AAPL (manual), SPY/QQQ/IWM (framework). Daily. 2023-01-01 to 2024-12-31, $200k. Manual: AAPL EMA50/200 cross via on_data. Framework: ManualUniverseSelectionModel(spy,qqq,iwm) + EmaCrossAlphaModel + EqualWeightingPCM + ImmediateExecution. Demonstrates: hybrid algorithm pattern. Edge case: keep manual + framework holdings logically separated.",
+      "tags": [
+        "Equity",
+        "algorithm-framework",
+        "hybrid-algorithm",
+        "manual-trading"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "custom-data-csv-from-url",
+      "name": "Custom Data CSV From URL",
+      "description": "Defines a PythonData type that reads a daily CSV of US 10Y yields from a public URL and trades TLT against it.",
+      "spec": "Asset: TLT plus a custom PythonData (US10Y CSV). Daily. 2023-01-01 to 2024-12-31, $100k. Implement get_source returning Subscription with the CSV URL; Reader parses date+yield. If yield rises above prior close: short TLT; falls: long TLT. Demonstrates: PythonData with remote CSV, custom data on_data dispatch. Edge case: handle holiday gaps in URL data.",
+      "tags": [
+        "Equity",
+        "custom-data",
+        "python-data",
+        "csv"
+      ],
+      "reference_template": "custom-data"
+    },
+    {
+      "folder": "custom-data-json-from-url",
+      "name": "Custom Data JSON From URL",
+      "description": "Defines a PythonData type that reads daily JSON of FRED CPI YoY and trades GLD on inflation surprises.",
+      "spec": "Asset: GLD plus a custom PythonData (CPI JSON). Daily. 2023-01-01 to 2024-12-31, $100k. PythonData get_source returning JSON Subscription; Reader parses CPI YoY value. Long GLD when CPI YoY rises; flat otherwise. Demonstrates: PythonData with JSON parsing, scheduled trade on custom data tick. Edge case: monthly release schedule, no daily updates.",
+      "tags": [
+        "Equity",
+        "custom-data",
+        "python-data",
+        "json"
+      ],
+      "reference_template": "custom-data"
+    },
+    {
+      "folder": "custom-data-as-universe-selector",
+      "name": "Custom Data as Universe Selector",
+      "description": "Uses a PythonData CSV of monthly stock recommendations as a Custom Universe selecting only the listed tickers.",
+      "spec": "Custom data: CSV of date+ticker(s). Daily. 2023-01-01 to 2024-12-31, $100k. add_universe(MyData, lambda data: [d.symbol for d in data]) returns ticker list each day. Equal-weight long the resulting universe. Demonstrates: custom data driving universe membership, dynamic add/remove. Edge case: handle days with empty file.",
+      "tags": [
+        "Equity",
+        "custom-data",
+        "custom-universe",
+        "universe"
+      ],
+      "reference_template": "custom-data"
+    },
+    {
+      "folder": "custom-data-linked-to-equity",
+      "name": "Custom Data Linked To Equity",
+      "description": "Defines a custom data type linked to an Equity Symbol so on_data delivers TradeBars and the custom value together.",
+      "spec": "Asset: AAPL with custom 'sentiment' PythonData linked via add_data(MyData, equity.symbol). Daily. 2023-01-01 to 2024-12-31, $100k. Long AAPL when sentiment > 0.5; flat otherwise. Demonstrates: linking custom data to an Equity Symbol so they share security cache. Edge case: ensure SecurityIdentifier matches.",
+      "tags": [
+        "Equity",
+        "custom-data",
+        "linked-data",
+        "python-data"
+      ],
+      "reference_template": "custom-data-ticker-mapping"
+    },
+    {
+      "folder": "custom-data-from-object-store",
+      "name": "Custom Data From Object Store",
+      "description": "Reads a CSV uploaded to the Object Store as a PythonData source — useful for proprietary signal files.",
+      "spec": "Asset: SPY with custom signal PythonData reading from object_store URI ('object_store://my-key.csv'). Daily. 2023-01-01 to 2024-12-31, $100k. Long SPY when signal>0; short<0. Demonstrates: PythonData get_source returning ObjectStore key, no external HTTP needed. Edge case: prepopulate Object Store via QuantConnect.RegressionTest helper or skip if missing.",
+      "tags": [
+        "Equity",
+        "custom-data",
+        "object-store",
+        "python-data"
+      ],
+      "reference_template": "custom-data-ticker-mapping"
+    },
+    {
+      "folder": "object-store-model-persistence",
+      "name": "Object Store Model Persistence",
+      "description": "Pickles a fitted scikit-learn LogisticRegression to the Object Store and reuses it across deployments.",
+      "spec": "Asset: SPY. Daily. 2023-01-01 to 2024-12-31, $100k. Train sklearn LogisticRegression on warm-up returns; pickle to object_store under 'spy-model.pkl'; on subsequent runs read pickle if exists. Trade SPY long/flat on predict. Demonstrates: object_store.save_bytes / read_bytes, pickle/unpickle, conditional re-training. Edge case: re-train monthly.",
+      "tags": [
+        "Equity",
+        "object-store",
+        "machine-learning",
+        "scikit-learn"
+      ],
+      "reference_template": "ai"
+    },
+    {
+      "folder": "object-store-parameter-cache",
+      "name": "Object Store Parameter Cache",
+      "description": "Caches an OLS hedge ratio between KO and PEP in Object Store and reuses it daily until staleness > 5 days.",
+      "spec": "Assets: KO, PEP. Daily. 2023-01-01 to 2024-12-31, $100k. Each Monday: fit OLS on 60-day history; save coeffs to object_store. Trade pair using cached coeffs. Demonstrates: object_store.save / read for parameter dict (json), cache invalidation logic. Edge case: handle missing cache by re-fitting.",
+      "tags": [
+        "Equity",
+        "object-store",
+        "pairs-trading",
+        "history"
+      ],
+      "reference_template": "custom-data-ticker-mapping"
+    },
+    {
+      "folder": "object-store-rolling-window-restore",
+      "name": "Object Store Rolling Window Restore",
+      "description": "Persists a RollingWindow of EMA values to Object Store at the end of day and restores it on startup to skip warm-up.",
+      "spec": "Asset: SPY. Daily. 2023-01-01 to 2024-12-31, $100k. EMA(20) with RollingWindow(20). On end-of-day write list to object_store; on Initialize read list and seed RollingWindow. Trade SPY on EMA cross. Demonstrates: object_store for state persistence, restoring indicator-derived state on cold start. Edge case: skip restore if data is older than 5 days.",
+      "tags": [
+        "Equity",
+        "object-store",
+        "warm-up",
+        "rolling-window"
+      ],
+      "reference_template": "custom-data-ticker-mapping"
+    },
+    {
+      "folder": "object-store-shared-universe-cache",
+      "name": "Object Store Shared Universe Cache",
+      "description": "Persists yesterday's universe membership to Object Store and reads it on the next day to skip a full rescan.",
+      "spec": "Universe: top 50 fundamental by dollar volume. Daily. 2023-01-01 to 2024-12-31, $200k. End of day: write list of symbols to object_store; on universe selector first call: read previous list and merge with today's selection. Demonstrates: caching universe results across days, object_store.save / read. Edge case: handle first run (no cache yet).",
+      "tags": [
+        "Equity",
+        "object-store",
+        "universe",
+        "fundamentals"
+      ],
+      "reference_template": "custom-data-ticker-mapping"
+    },
+    {
+      "folder": "ml-sklearn-logistic-regression",
+      "name": "ML: Sklearn Logistic Regression",
+      "description": "Trains a scikit-learn LogisticRegression weekly to predict next-day SPY direction from the last 5 daily returns.",
+      "spec": "Asset: SPY. Daily. 2022-01-01 to 2024-12-31, $100k. Weekly training: features = lagged 5-day returns; label = sign of next-day return. LogisticRegression. Trade long if proba>0.55, short<0.45, flat else. Demonstrates: scikit-learn binary classifier, weekly retraining, warm-up via history. Edge case: skip if class imbalance > 90/10.",
+      "tags": [
+        "Equity",
+        "machine-learning",
+        "scikit-learn",
+        "logistic-regression"
+      ],
+      "reference_template": "ai"
+    },
+    {
+      "folder": "ml-sklearn-random-forest",
+      "name": "ML: Sklearn Random Forest",
+      "description": "Trains a sklearn RandomForestClassifier weekly on technical features to trade SPY long/flat.",
+      "spec": "Asset: SPY. Daily. 2022-01-01 to 2024-12-31, $100k. Features: RSI(14), MACD signal/hist, ATR(14), 5-day return. Label: sign(next-day return). RandomForestClassifier(n_estimators=100). Long if proba>0.55. Weekly retrain. Demonstrates: tree ensemble, multi-feature pipeline. Edge case: drop NaNs before fit.",
+      "tags": [
+        "Equity",
+        "machine-learning",
+        "scikit-learn",
+        "random-forest"
+      ],
+      "reference_template": "ai"
+    },
+    {
+      "folder": "ml-xgboost-fundamentals",
+      "name": "ML: XGBoost on Fundamentals",
+      "description": "Trains XGBRegressor monthly on fundamental features (PE, PB, ROE, momentum) to predict 21-day forward returns.",
+      "spec": "Universe: SPY constituents. Daily. 2022-01-01 to 2024-12-31, $200k. Monthly: features = PE, PB, ROE, ROC(63); label = 21-day forward return. XGBRegressor(n_estimators=200). Long top 10 predictions. Demonstrates: XGBoost regressor, fundamental + price features, monthly retrain. Edge case: drop NaNs and outliers.",
+      "tags": [
+        "Equity",
+        "machine-learning",
+        "xgboost",
+        "fundamentals"
+      ],
+      "reference_template": "ai"
+    },
+    {
+      "folder": "ml-pytorch-lstm-prices",
+      "name": "ML: PyTorch LSTM Prices",
+      "description": "Trains a PyTorch LSTM weekly on a 60-bar window of SPY returns to predict the next return sign.",
+      "spec": "Asset: SPY. Daily. 2022-01-01 to 2024-12-31, $100k. PyTorch LSTM(input_size=1, hidden_size=8, num_layers=1). Features: 60-day returns; label sign(next). Weekly retrain. Long when predict>0; short when <0. Demonstrates: PyTorch LSTM training inside QCAlgorithm, GPU not required. Edge case: train_history kept small (~500 windows).",
+      "tags": [
+        "Equity",
+        "machine-learning",
+        "pytorch",
+        "lstm"
+      ],
+      "reference_template": "ai"
+    },
+    {
+      "folder": "ml-online-sgd-classifier",
+      "name": "ML: Online SGD Classifier",
+      "description": "Uses sklearn SGDClassifier with partial_fit to update weights daily on the latest features without full retrains.",
+      "spec": "Asset: SPY. Daily. 2023-01-01 to 2024-12-31, $100k. SGDClassifier(loss='log_loss'); features = RSI, ROC(5), ATR. Each new bar: compute features for previous bar, label, partial_fit. Trade long when predict_proba>0.55. Demonstrates: online learning with partial_fit, no batch retraining. Edge case: warm up with first 60 bars batch.",
+      "tags": [
+        "Equity",
+        "machine-learning",
+        "scikit-learn",
+        "online-learning"
+      ],
+      "reference_template": "ai"
+    },
+    {
+      "folder": "ml-pca-risk-decomposition",
+      "name": "ML: PCA Risk Decomposition",
+      "description": "Runs sklearn PCA on a basket of S&P sector ETFs and shorts the highest-loading PC1 stocks vs SPY for hedging.",
+      "spec": "Assets: 11 SPDR sectors + SPY. Daily. 2022-01-01 to 2024-12-31, $200k. Monthly: PCA on 60-day daily returns; identify PC1; size sectors as PC1 loadings (long/short). Demonstrates: PCA, factor risk decomposition, dollar-neutral basket. Edge case: enforce sum of weights = 0 (dollar neutral).",
+      "tags": [
+        "Equity",
+        "machine-learning",
+        "pca",
+        "risk"
+      ],
+      "reference_template": "ai"
+    },
+    {
+      "folder": "ml-kmeans-pairs-selector",
+      "name": "ML: K-Means Pairs Selector",
+      "description": "Uses sklearn KMeans on 60-day return vectors of S&P 500 names to cluster look-alikes and trade the spread of the closest two.",
+      "spec": "Universe: top 100 SPY constituents. Daily. 2022-01-01 to 2024-12-31, $200k. Monthly: KMeans(n_clusters=10) on 60-day returns; pick the 2 closest names in the largest cluster as the pair; trade spread on z-score. Demonstrates: clustering for pair discovery, fit + nearest-pair logic. Edge case: skip months with fewer than 2 names per cluster.",
+      "tags": [
+        "Equity",
+        "machine-learning",
+        "kmeans",
+        "pairs-trading"
+      ],
+      "reference_template": "ai"
+    },
+    {
+      "folder": "ml-huggingface-sentiment",
+      "name": "ML: HuggingFace Sentiment",
+      "description": "Loads a HuggingFace sentiment pipeline (FinBERT) and scores the latest Tiingo News headlines on AAPL each day.",
+      "spec": "Asset: AAPL with TiingoNews subscription. Daily. 2023-01-01 to 2024-12-31, $100k. transformers.pipeline('sentiment-analysis', model='ProsusAI/finbert'); score titles delivered via on_data; long AAPL when daily mean score>0.6 else flat. Demonstrates: HuggingFace pipeline inside QCAlgorithm, news data integration. Edge case: handle empty news days.",
+      "tags": [
+        "Equity",
+        "machine-learning",
+        "huggingface",
+        "news-sentiment"
+      ],
+      "reference_template": "ai"
+    },
+    {
+      "folder": "charting-multi-pane-pnl-drawdown",
+      "name": "Charting: Multi-Pane PnL + Drawdown",
+      "description": "Plots equity curve and rolling drawdown on separate subcharts of a custom Chart with two Series.",
+      "spec": "Asset: SPY. Daily. 2023-01-01 to 2024-12-31, $100k. Buy-and-hold SPY. Each EOD compute portfolio value and drawdown vs running max; plot('Performance', 'Equity', value), plot('Performance', 'Drawdown', dd) on a multi-series chart. Demonstrates: Chart + Series API, multi-pane visualization, EOD scheduled charting. Edge case: avoid plotting before warm-up.",
+      "tags": [
+        "Equity",
+        "charting",
+        "multi-pane",
+        "scheduled-event"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "charting-candlestick-overlay-indicator",
+      "name": "Charting: Candlestick + Indicator Overlay",
+      "description": "Renders SPY price as candlesticks on a custom Chart with EMA(50) and EMA(200) overlaid.",
+      "spec": "Asset: SPY. Daily. 2023-01-01 to 2024-12-31, $100k. EMA(50), EMA(200). Custom Chart('SPY') with CandlestickSeries(SPY OHLC) and two Series('EMA50','EMA200'). Plot per bar in on_data. Demonstrates: CandlestickSeries, multi-series overlay, indicator plotting. Edge case: only plot when indicator is_ready.",
+      "tags": [
+        "Equity",
+        "charting",
+        "candlestick",
+        "indicators"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "charting-scatter-returns",
+      "name": "Charting: Scatter of Returns",
+      "description": "Builds a scatter chart of daily returns of SPY vs QQQ to visualize correlation.",
+      "spec": "Assets: SPY, QQQ. Daily. 2023-01-01 to 2024-12-31, $100k. EOD compute daily return per asset; ScatterSeries with one point per day (x=SPY, y=QQQ). No trading; chart-only. Demonstrates: ScatterSeries, EOD chart updates, correlation visualization. Edge case: cap scatter to last 252 points.",
+      "tags": [
+        "Equity",
+        "charting",
+        "scatter-series",
+        "no-trading"
+      ],
+      "reference_template": "equities-static-universe"
+    },
+    {
+      "folder": "charting-export-to-object-store",
+      "name": "Charting: Export Chart to Object Store",
+      "description": "Records a custom Chart of trade signals and saves a CSV snapshot to the Object Store at end of algorithm.",
+      "spec": "Asset: SPY. Daily. 2023-01-01 to 2024-12-31, $100k. EMA(50) cross signals plotted on custom Chart; on on_end_of_algorithm dump (date,signal,value) to CSV string and object_store.save. Demonstrates: chart + persistent export via Object Store, end-of-algorithm hook. Edge case: handle empty signal list.",
+      "tags": [
+        "Equity",
+        "charting",
+        "object-store",
+        "end-of-algorithm"
+      ],
+      "reference_template": "custom-data-ticker-mapping"
+    },
+    {
+      "folder": "orders-stop-limit",
+      "name": "Orders: Stop-Limit Entry",
+      "description": "Submits stop-limit orders to enter SPY only on a confirmed breakout above the prior 20-day high.",
+      "spec": "Asset: SPY. Daily. 2023-01-01 to 2024-12-31, $100k. RollingWindow(20) of highs. Each EOD: place stop_limit_order(SPY, qty, stop=high20+0.10, limit=high20+0.30). Cancel un-filled at next EOD. Demonstrates: stop-limit order type, daily order recycling, RollingWindow. Edge case: cancel via transactions.cancel_open_orders before re-submitting.",
+      "tags": [
+        "Equity",
+        "order-types",
+        "stop-limit",
+        "trade-management"
+      ],
+      "reference_template": "trade-management"
+    },
+    {
+      "folder": "orders-trailing-stop",
+      "name": "Orders: Trailing Stop",
+      "description": "Holds AAPL with a trailing_stop_order set 5% below the highest fill since entry.",
+      "spec": "Asset: AAPL. Daily. 2023-01-01 to 2024-12-31, $100k. On entry: market_order; trailing_stop_order(AAPL, -qty, 0.05, trailing_as_percentage=True). When stop fills, re-enter on next EOD. Demonstrates: trailing_stop_order built-in, OrderEvent monitoring, re-entry. Edge case: cancel any open trailing stop before re-entering.",
+      "tags": [
+        "Equity",
+        "order-types",
+        "trailing-stop",
+        "trade-management"
+      ],
+      "reference_template": "trade-management"
+    },
+    {
+      "folder": "orders-market-on-open",
+      "name": "Orders: Market On Open",
+      "description": "Submits market_on_open_order on QQQ each Monday at 09:00 to fill at the official open.",
+      "spec": "Asset: QQQ. Daily. 2023-01-01 to 2024-12-31, $100k. Schedule Monday 09:00: market_on_open_order(QQQ, qty). Liquidate Friday afternoon via market_on_close_order. Demonstrates: MOO/MOC order types, weekly scheduling around exchange auctions. Edge case: skip Mondays that are exchange holidays.",
+      "tags": [
+        "Equity",
+        "order-types",
+        "moo-order",
+        "scheduled-event"
+      ],
+      "reference_template": "trade-management"
+    },
+    {
+      "folder": "orders-market-on-close",
+      "name": "Orders: Market On Close",
+      "description": "Submits market_on_close_order on SPY 30 minutes before close to flatten an intraday position.",
+      "spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. Buy SPY at 10:00 each day. At 15:30 submit market_on_close_order(SPY, -shares). Demonstrates: MOC order with required cutoff, intraday close-out via auction. Edge case: ensure buy filled before MOC submission.",
+      "tags": [
+        "Equity",
+        "order-types",
+        "moc-order",
+        "intraday"
+      ],
+      "reference_template": "trade-management"
+    },
+    {
+      "folder": "orders-bracket",
+      "name": "Orders: Bracket Orders",
+      "description": "Wraps each market entry on AAPL with a paired limit profit-target and stop-loss using OrderProperties.",
+      "spec": "Asset: AAPL. Daily. 2023-01-01 to 2024-12-31, $100k. On entry: market_order, then limit_order(qty=-shares, +5% target) and stop_market_order(qty=-shares, -3% stop) — cancel-on-other-fill. Demonstrates: bracket pattern (variation of trade-management's OCO), 3-leg group. Edge case: cancel both children if entry rejected.",
+      "tags": [
+        "Equity",
+        "order-types",
+        "bracket-orders",
+        "oco-orders"
+      ],
+      "reference_template": "trade-management"
+    },
+    {
+      "folder": "orders-update-price-quantity",
+      "name": "Orders: Update Price/Quantity",
+      "description": "Submits a limit order on SPY and updates its limit price every minute toward the bid until filled or canceled at EOD.",
+      "spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. Limit buy at last_close - 0.50; each minute scan open limit and update_limit_price closer to NBB. EOD cancel. Demonstrates: order updates via UpdateOrderFields, intraday tick-and-improve loop. Edge case: cap updates to 50/day.",
+      "tags": [
+        "Equity",
+        "order-types",
+        "order-updates",
+        "intraday"
+      ],
+      "reference_template": "trade-management"
+    },
+    {
+      "folder": "orders-cancel-stale",
+      "name": "Orders: Cancel Stale Orders",
+      "description": "Submits opening limit orders on a 5-name basket and cancels any unfilled orders after 30 minutes.",
+      "spec": "Assets: SPY,QQQ,IWM,EFA,EEM. Minute. 2024-09-01 to 2024-12-31, $100k. At 09:30 submit limit at NBB - 0.10 per name; at 10:00 cancel any open. Demonstrates: scheduled cancellation, transactions.get_open_orders, time-based order management. Edge case: only cancel orders submitted same day.",
+      "tags": [
+        "Equity",
+        "order-types",
+        "order-management",
+        "intraday"
+      ],
+      "reference_template": "trade-management"
+    },
+    {
+      "folder": "orders-iceberg-via-batched",
+      "name": "Orders: Iceberg via Batched Market Orders",
+      "description": "Splits a target SPY position of 1,000 shares into 10 batches of 100 over the trading day to mimic iceberg behavior.",
+      "spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. Daily target = 1,000 shares; submit 100 shares every 30 minutes between 10:00 and 15:00; flatten at 15:55. Demonstrates: scheduled order slicing, partial accumulation, end-of-day flatten. Edge case: cap total to target if accumulated.",
+      "tags": [
+        "Equity",
+        "order-types",
+        "iceberg",
+        "intraday"
+      ],
+      "reference_template": "trade-management"
+    },
+    {
+      "folder": "reality-percent-volume-slippage",
+      "name": "Reality: Percent-of-Volume Slippage",
+      "description": "Replaces the default slippage model on SPY with a custom percent-of-volume model that scales with order size vs ADV.",
+      "spec": "Asset: SPY. Daily. 2023-01-01 to 2024-12-31, $100k. Custom SlippageModel: slippage = price * 0.0001 * (order_size / ADV20). Apply via security_initializer. Trade SPY long-only on EMA cross (50/200). Demonstrates: custom slippage model, security_initializer, ADV computation. Edge case: floor slippage to 1bp.",
+      "tags": [
+        "Equity",
+        "reality-models",
+        "slippage",
+        "security-initializer"
+      ],
+      "reference_template": "custom-models"
+    },
+    {
+      "folder": "reality-tiered-fee-schedule",
+      "name": "Reality: Tiered Fee Schedule",
+      "description": "Implements a tiered IB-style fee model (per-share rate decreasing with monthly volume) on a 5-name basket.",
+      "spec": "Assets: SPY, QQQ, IWM, AAPL, MSFT. Daily. 2023-01-01 to 2024-12-31, $200k. Custom FeeModel tracks monthly notional volume; rate is $0.005/share for first $300k, $0.003 for next, $0.002 thereafter. EMA50/200 cross signals. Demonstrates: stateful custom fee model, monthly volume reset. Edge case: reset state on month rollover.",
+      "tags": [
+        "Equity",
+        "reality-models",
+        "fee-model",
+        "security-initializer"
+      ],
+      "reference_template": "custom-models"
+    },
+    {
+      "folder": "reality-cash-account-settlement",
+      "name": "Reality: Cash Account Settlement (T+1)",
+      "description": "Configures a cash account with T+1 settlement and demonstrates that cash from sells is locked until settled.",
+      "spec": "Asset: SPY. Daily. 2023-01-01 to 2024-12-31, $100k. set_brokerage_model(BrokerageName.DEFAULT, AccountType.CASH); set_settlement_model(DelayedSettlementModel(1, time(8,0))). Buy/sell SPY daily via simple SMA cross. Demonstrates: cash account, DelayedSettlementModel, unsettled funds. Edge case: log unsettled cash daily.",
+      "tags": [
+        "Equity",
+        "reality-models",
+        "settlement",
+        "cash-account"
+      ],
+      "reference_template": "custom-models"
+    },
+    {
+      "folder": "reality-margin-call-handler",
+      "name": "Reality: Margin Call Handler",
+      "description": "Implements on_margin_call and on_margin_call_warning hooks on a leveraged SPY position to log and partially flatten.",
+      "spec": "Asset: SPY at 4x leverage. Daily. 2023-01-01 to 2024-12-31, $100k. Set buying_power_model with leverage=4; long-only SPY 4x. Override on_margin_call_warning to log; on_margin_call to halve position rather than full liquidation. Demonstrates: margin call hooks, partial unwind. Edge case: still respect IsMarginable.",
+      "tags": [
+        "Equity",
+        "reality-models",
+        "margin-call",
+        "buying-power"
+      ],
+      "reference_template": "custom-models"
+    },
+    {
+      "folder": "reality-fred-risk-free-rate",
+      "name": "Reality: FRED Risk-Free Rate Override",
+      "description": "Overrides the default RiskFreeInterestRateModel with a FRED 3-month T-Bill series for accurate Sharpe calculation.",
+      "spec": "Asset: SPY. Daily. 2023-01-01 to 2024-12-31, $100k. set_risk_free_interest_rate_model(FREDRiskFreeInterestRateModel('DGS3MO')) (custom wrapper around custom data). Buy-and-hold SPY. Demonstrates: risk-free rate override, integration with custom data, statistics impact. Edge case: handle missing dates by forward-fill.",
+      "tags": [
+        "Equity",
+        "reality-models",
+        "risk-free-rate",
+        "custom-data"
+      ],
+      "reference_template": "custom-models"
+    },
+    {
+      "folder": "consolidator-multi-timeframe",
+      "name": "Consolidator: Multi-Timeframe (1m/5m/15m)",
+      "description": "Builds 1-minute, 5-minute, and 15-minute TradeBar consolidators on SPY and runs an EMA on each.",
+      "spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. Three TradeBarConsolidator(1m / 5m / 15m); register an EMA(20) on each. Trade SPY long when all 3 EMAs trend up; flat otherwise. Demonstrates: multiple consolidators per symbol, register_indicator, multi-timeframe alignment. Edge case: warm up via history(15min, 100, Resolution.MINUTE).",
+      "tags": [
+        "Equity",
+        "consolidators",
+        "multi-timeframe",
+        "indicators"
+      ],
+      "reference_template": "custom-consolidators"
+    },
+    {
+      "folder": "consolidator-renko-bars",
+      "name": "Consolidator: Renko Bars",
+      "description": "Builds RenkoConsolidator with brick size 1.0 on SPY minute bars and trades flips of the brick direction.",
+      "spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. RenkoConsolidator(brick_size=1.0); track last brick direction. Long on up-flip, flat on down-flip. Demonstrates: built-in RenkoConsolidator, non-time-based bars, on_renko_bar handler. Edge case: ignore the very first brick (calibration).",
+      "tags": [
+        "Equity",
+        "consolidators",
+        "renko",
+        "intraday"
+      ],
+      "reference_template": "custom-consolidators"
+    },
+    {
+      "folder": "consolidator-volume-bar",
+      "name": "Consolidator: Custom Volume Bar",
+      "description": "Implements a custom volume-bar consolidator (bars closing every N traded shares) on SPY tick data.",
+      "spec": "Asset: SPY. Tick. 2024-12-01 to 2024-12-31, $100k. Custom IDataConsolidator that closes a bar every 1,000,000 shares; emit aggregate TradeBar. Long on up-volume bar, flat on down. Demonstrates: writing a custom consolidator (non-time-based), tick subscription. Edge case: gracefully handle gaps when volume threshold is crossed mid-tick.",
+      "tags": [
+        "Equity",
+        "consolidators",
+        "volume-bar",
+        "tick"
+      ],
+      "reference_template": "custom-consolidators"
+    },
+    {
+      "folder": "history-multi-resolution-warmup",
+      "name": "History: Multi-Resolution Warm-Up",
+      "description": "Warms up an EMA(20) on SPY using a daily history request, then switches to minute bars for live trading.",
+      "spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. In Initialize: history(SPY, 50, Resolution.DAILY) to seed EMA(20) on a manual daily consolidator; trade on minute EMA crossovers. Demonstrates: history with explicit resolution, manual consolidator + warm-up, mixed-resolution algorithms. Edge case: ensure no double-counting between history and live data.",
+      "tags": [
+        "Equity",
+        "history",
+        "warm-up",
+        "consolidators"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "history-rolling-window-pattern",
+      "name": "History: Rolling Window Pattern",
+      "description": "Maintains a RollingWindow(60) of TradeBars and computes 60-day return without using indicators.",
+      "spec": "Asset: SPY. Daily. 2023-01-01 to 2024-12-31, $100k. RollingWindow[TradeBar](60); on_data appends bar; compute (latest.close/oldest.close - 1) and trade SPY long when 60d return >5%. Demonstrates: RollingWindow, history seeding window in Initialize, no indicator dependency. Edge case: skip while window not full.",
+      "tags": [
+        "Equity",
+        "history",
+        "rolling-window",
+        "scheduled-event"
+      ],
+      "reference_template": "history-and-etf-universe"
+    },
+    {
+      "folder": "live-signal-export-collective2",
+      "name": "Live: Signal Export to Collective2",
+      "description": "Exports portfolio targets to Collective2 each rebalance using SignalExportManager.",
+      "spec": "Asset: SPY. Daily. 2024-09-01 to 2024-12-31, $100k. set_holdings(SPY,1) on first bar; signal_export.add_signal_export_provider(Collective2SignalExport(api_key='STUB', system_id='STUB')); call signal_export.set_target_portfolio in scheduled rebalance. Demonstrates: SignalExport API, Collective2 provider. Edge case: stub credentials in backtest mode.",
+      "tags": [
+        "Equity",
+        "live-trading",
+        "signal-exports",
+        "collective2"
+      ],
+      "reference_template": "live-trading-features"
+    },
+    {
+      "folder": "forex-eurusd-sma-crossover",
+      "name": "Forex EURUSD SMA Crossover",
+      "description": "Trades EURUSD with a 50/200 SMA crossover on hourly QuoteBars at OANDA.",
+      "spec": "Asset: EURUSD on Oanda. Hourly. 2023-01-01 to 2024-12-31, $100k. SMA(50), SMA(200) on close of QuoteBar. Long on 50>200; short on 50<200. Demonstrates: Forex hourly resolution, SMA crossover, set_brokerage_model(OANDA). Edge case: warm-up via history.",
+      "tags": [
+        "Forex",
+        "indicators",
+        "sma-cross",
+        "oanda"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-gbpusd-rsi-mean-reversion",
+      "name": "Forex GBPUSD RSI Mean Reversion",
+      "description": "Mean-reverts GBPUSD on a 14-period RSI: long below 30, short above 70, exits at 50.",
+      "spec": "Asset: GBPUSD on Oanda. Hourly. 2023-01-01 to 2024-12-31, $100k. RSI(14) on hourly close. Long when RSI<30, short>70, exit at 50. Demonstrates: RSI on Forex hourly, position-flip logic, hourly bars. Edge case: skip orders during indicator warm-up.",
+      "tags": [
+        "Forex",
+        "indicators",
+        "rsi",
+        "mean-reversion"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-usdjpy-bollinger-breakout",
+      "name": "Forex USDJPY Bollinger Breakout",
+      "description": "Trades USDJPY breakouts of a 20-bar Bollinger Band (2 stdev) on hourly QuoteBars.",
+      "spec": "Asset: USDJPY on Oanda. Hourly. 2023-01-01 to 2024-12-31, $100k. BollingerBands(20,2). Long on close above upper; short on close below lower; exit on touch of middle band. Demonstrates: BollingerBands on Forex, breakout (not mean reversion). Edge case: avoid pyramiding within the same band excursion.",
+      "tags": [
+        "Forex",
+        "indicators",
+        "bollinger-bands",
+        "breakout"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-carry-trade-g10",
+      "name": "Forex Carry Trade G10",
+      "description": "Implements a long-high-yield short-low-yield carry trade across G10 pairs using FRED interest rate differentials.",
+      "spec": "Pairs: AUDJPY, NZDJPY, CADJPY, CHFJPY (proxies). Daily. 2023-01-01 to 2024-12-31, $100k. Use FRED short-term rates as a custom data feed; rank pairs by rate differential; long top 2, short bottom 2. Monthly rebalance. Demonstrates: Forex multi-pair, custom data integration (FRED), carry-trade weighting. Edge case: skip on missing rate update.",
+      "tags": [
+        "Forex",
+        "carry-trade",
+        "custom-data",
+        "scheduled-event"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-triangular-arbitrage",
+      "name": "Forex Triangular Arbitrage",
+      "description": "Detects triangular mispricings between EURUSD, GBPUSD, and EURGBP and trades when the spread exceeds threshold.",
+      "spec": "Assets: EURUSD, GBPUSD, EURGBP on Oanda. Minute. 2024-09-01 to 2024-12-31, $100k. Compute synthetic_eurgbp = EURUSD/GBPUSD; spread = (synthetic - EURGBP). If |spread|>10pips: long/short three legs in opposite direction. Demonstrates: Forex minute bars, multi-pair simultaneous orders, dollar-balanced legs. Edge case: enforce tight slippage tolerance.",
+      "tags": [
+        "Forex",
+        "triangular-arbitrage",
+        "multi-pair",
+        "intraday"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-london-session-breakout",
+      "name": "Forex London Session Breakout",
+      "description": "Trades EURUSD breakouts of the Asian session range (00:00-07:00 UTC) at the London open.",
+      "spec": "Asset: EURUSD on Oanda. Minute. 2024-09-01 to 2024-12-31, $100k. Build Asian session high/low between 00:00-07:00 UTC; at 07:00 schedule breakout entry; long if next bar > AsianHigh, short if < AsianLow. Flat at 16:00 UTC. Demonstrates: time-zone-aware scheduling on Forex, session-range trading. Edge case: handle DST transitions.",
+      "tags": [
+        "Forex",
+        "session-breakout",
+        "intraday",
+        "scheduled-event"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-asian-session-fade",
+      "name": "Forex Asian Session Fade",
+      "description": "Fades EURUSD during the quiet Asian session: shorts after a 0.3% rally, longs after a 0.3% drop.",
+      "spec": "Asset: EURUSD on Oanda. Minute. 2024-09-01 to 2024-12-31, $100k. Active 00:00-06:00 UTC. Compare current price to session open; if move>0.003 fade direction; flat at 06:00 UTC. Demonstrates: Forex session-bound logic, intraday fade strategy, time-zone scheduling. Edge case: skip Asian holidays where volume is too low.",
+      "tags": [
+        "Forex",
+        "session-fade",
+        "intraday",
+        "scheduled-event"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-multi-pair-momentum",
+      "name": "Forex Multi-Pair Momentum",
+      "description": "Ranks 7 G10 pairs by 20-day momentum and equal-weights long the top 3 / short the bottom 3 monthly.",
+      "spec": "Pairs: EURUSD, GBPUSD, USDJPY, AUDUSD, NZDUSD, USDCHF, USDCAD on Oanda. Daily. 2023-01-01 to 2024-12-31, $100k. ROC(20). Monthly long top 3, short bottom 3 (USD-quoted: invert sign as needed). Demonstrates: Forex multi-pair momentum, scheduled monthly rebalance, sign-aware long/short. Edge case: dollar-balance longs vs shorts.",
+      "tags": [
+        "Forex",
+        "momentum",
+        "multi-pair",
+        "scheduled-event"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-mean-reversion-zscore",
+      "name": "Forex Mean Reversion Z-Score",
+      "description": "Mean-reverts EURUSD on a 60-day price z-score; long below -2 sigma, short above +2 sigma.",
+      "spec": "Asset: EURUSD on Oanda. Daily. 2023-01-01 to 2024-12-31, $100k. SMA(60), STD(60) -> z = (close-mean)/std. Long when z<-2, short>2, exit at |z|<0.5. Demonstrates: Forex daily mean-reversion, manual z-score using indicators, single-pair logic. Edge case: pause during very tight stdev (pre-event).",
+      "tags": [
+        "Forex",
+        "mean-reversion",
+        "zscore",
+        "indicators"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-tick-quote-tick",
+      "name": "Forex Tick Resolution QuoteTicks",
+      "description": "Subscribes to EURUSD at tick resolution and computes a 5-minute consolidated EMA on bid/ask midpoint.",
+      "spec": "Asset: EURUSD on Oanda. Tick. 2024-12-01 to 2024-12-31, $100k. Tick subscription; consolidate ticks to 5-minute QuoteBar; EMA(20) on midpoint. Long if mid>EMA; flat else. Demonstrates: Forex tick resolution, manual tick-to-bar consolidation, mid-quote indicator. Edge case: skip ticks with zero size.",
+      "tags": [
+        "Forex",
+        "tick-data",
+        "consolidators",
+        "intraday"
+      ],
+      "reference_template": "custom-consolidators"
+    },
+    {
+      "folder": "forex-bid-ask-spread-filter",
+      "name": "Forex Bid-Ask Spread Filter",
+      "description": "Trades EURUSD only when the bid-ask spread is below 1 pip and otherwise stays flat — variation on the existing 'forex' template.",
+      "spec": "Asset: EURUSD on Oanda. Hourly. 2023-01-01 to 2024-12-31, $100k. SMA(50), SMA(200) crossover. Allow new entries only when (ask-bid)<0.0001. Demonstrates: spread-aware execution gate (different from the existing forex Min on spread), Forex liquidity check. Edge case: keep existing positions even when spread widens.",
+      "tags": [
+        "Forex",
+        "bid-ask-spread",
+        "indicators",
+        "execution-gate"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-renko-trend",
+      "name": "Forex Renko Trend on EURUSD",
+      "description": "Builds a 5-pip RenkoConsolidator on EURUSD and trades flips of the brick direction.",
+      "spec": "Asset: EURUSD on Oanda. Minute. 2024-09-01 to 2024-12-31, $100k. RenkoConsolidator(brick_size=0.0005). Long on up-flip, short on down-flip. Demonstrates: RenkoConsolidator on Forex, non-time-based bars, position flips. Edge case: ignore first brick after warm-up.",
+      "tags": [
+        "Forex",
+        "consolidators",
+        "renko",
+        "trend-following"
+      ],
+      "reference_template": "custom-consolidators"
+    },
+    {
+      "folder": "forex-keltner-channel-breakout",
+      "name": "Forex Keltner Channel Breakout",
+      "description": "Trades USDCHF breakouts of a 20-period KeltnerChannels(1.5) on hourly bars.",
+      "spec": "Asset: USDCHF on Oanda. Hourly. 2023-01-01 to 2024-12-31, $100k. KeltnerChannels(20,1.5). Long on close>upper; short on close<lower; exit on midline cross. Demonstrates: KeltnerChannels indicator on Forex, breakout style. Edge case: skip orders within first 20 bars.",
+      "tags": [
+        "Forex",
+        "indicators",
+        "keltner-channels",
+        "breakout"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-volatility-targeting",
+      "name": "Forex Volatility Targeting",
+      "description": "Sizes positions in EURUSD inversely to 20-day realized volatility to keep risk constant.",
+      "spec": "Asset: EURUSD on Oanda. Daily. 2023-01-01 to 2024-12-31, $100k. STD(20) annualized; target 10% portfolio vol; weight = target_vol / realized_vol capped at 1. Long-only when SMA(50)>SMA(200). Demonstrates: vol-targeting position sizing, multi-indicator combination. Edge case: cap leverage at 1.0 (no margin use).",
+      "tags": [
+        "Forex",
+        "volatility-targeting",
+        "position-sizing",
+        "indicators"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-monthly-rebalance-equal-weight",
+      "name": "Forex Monthly Equal-Weight Basket",
+      "description": "Holds an equal-weighted basket of 4 G10 pairs and rebalances monthly back to 25% each.",
+      "spec": "Pairs: EURUSD, GBPUSD, USDJPY, AUDUSD on Oanda. Daily. 2023-01-01 to 2024-12-31, $100k. set_holdings 25% each; monthly rebalance to target. Demonstrates: simple equal-weight Forex basket, monthly schedule. Edge case: drift threshold of 5% to avoid micro-rebalances.",
+      "tags": [
+        "Forex",
+        "asset-allocation",
+        "scheduled-event",
+        "rebalance"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-pairs-trade-eur-gbp",
+      "name": "Forex Pairs Trade EUR/GBP Spread",
+      "description": "Trades the EURUSD-GBPUSD synthetic spread on a 20-day z-score with mean reversion.",
+      "spec": "Pairs: EURUSD, GBPUSD on Oanda. Daily. 2023-01-01 to 2024-12-31, $100k. spread = log(EURUSD)-log(GBPUSD); 20-day z-score. Long EUR / short GBP when z<-2; opposite>2; exit at 0. Demonstrates: Forex pairs trading, log-spread, statistical thresholds. Edge case: re-fit hedge ratio weekly.",
+      "tags": [
+        "Forex",
+        "pairs-trading",
+        "zscore",
+        "statistical-arbitrage"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-news-blackout",
+      "name": "Forex News Blackout (NFP)",
+      "description": "Holds long EURUSD on EMA cross but exits 30 minutes before US Non-Farm Payrolls (first Friday 8:30 ET).",
+      "spec": "Asset: EURUSD on Oanda. Hourly. 2023-01-01 to 2024-12-31, $100k. EMA(50), EMA(200) cross signals. Trading calendar identifies first Friday of each month; flat from 08:00 to 09:00 ET. Demonstrates: scheduled blackout windows, trading calendar custom rule. Edge case: skip early-month observed holidays.",
+      "tags": [
+        "Forex",
+        "scheduled-event",
+        "news-blackout",
+        "indicators"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-stop-loss-atr",
+      "name": "Forex EURUSD ATR Stop-Loss",
+      "description": "Holds EURUSD long on EMA cross with an ATR(14)*2 stop-loss managed via stop_market_order.",
+      "spec": "Asset: EURUSD on Oanda. Hourly. 2023-01-01 to 2024-12-31, $100k. EMA(50)/EMA(200) entry; on entry submit stop_market_order at entry - 2*ATR(14). Demonstrates: ATR-sized stop on Forex, stop_market_order, OrderEvent re-entry logic. Edge case: cancel old stop on flip.",
+      "tags": [
+        "Forex",
+        "stop-loss",
+        "atr",
+        "order-types"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-take-profit-bracket",
+      "name": "Forex Take-Profit Bracket",
+      "description": "Adds a +1.5*ATR take-profit alongside the ATR stop on a EURUSD EMA crossover trade.",
+      "spec": "Asset: EURUSD on Oanda. Hourly. 2023-01-01 to 2024-12-31, $100k. EMA(50)/EMA(200) entry; on entry submit stop+limit (bracket): stop=entry-2*ATR, limit=entry+1.5*ATR; cancel-on-other-fill. Demonstrates: bracketed Forex orders, ATR-based stops/targets. Edge case: cancel both on direction flip.",
+      "tags": [
+        "Forex",
+        "take-profit",
+        "atr",
+        "order-types"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-five-pm-calendar-extra",
+      "name": "Forex 5PM Daily Calendar Bar EMA Cross",
+      "description": "Builds a daily QuoteBar consolidator anchored to 17:00 ET (Forex day) and trades a 10/30 EMA crossover.",
+      "spec": "Asset: EURUSD on Oanda. Hourly. 2023-01-01 to 2024-12-31, $100k. Custom calendar consolidator at 17:00 ET (different from 'custom-consolidators' which runs EMA single line); EMA(10), EMA(30) on consolidated daily bar. Long on 10>30; short<. Demonstrates: alternative consolidator built on the same 17:00 anchor but with a different signal (EMA cross). Edge case: warm up consolidator with history.",
+      "tags": [
+        "Forex",
+        "consolidators",
+        "ema-cross",
+        "calendar-bar"
+      ],
+      "reference_template": "custom-consolidators"
+    },
+    {
+      "folder": "forex-portfolio-vol-target",
+      "name": "Forex Portfolio Volatility Target",
+      "description": "Holds 4 G10 pairs and re-weights weekly so the portfolio's realized 30-day vol stays near 8%.",
+      "spec": "Pairs: EURUSD, USDJPY, AUDUSD, USDCAD on Oanda. Daily. 2023-01-01 to 2024-12-31, $100k. Each Friday: compute 30-day vol of equal-weight basket; scale total exposure = min(1, 0.08/realized). Demonstrates: portfolio-level vol targeting, weekly rebalance. Edge case: floor on minimum exposure of 0.25.",
+      "tags": [
+        "Forex",
+        "volatility-targeting",
+        "weekly",
+        "multi-pair"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-correlation-pair-rotation",
+      "name": "Forex Correlation-Driven Pair Rotation",
+      "description": "Each month picks the 2 USD-quoted Forex pairs least correlated to EURUSD over 60 days and equal-weights long.",
+      "spec": "Pairs: EURUSD, GBPUSD, USDJPY, AUDUSD, NZDUSD, USDCHF, USDCAD. Daily. 2023-01-01 to 2024-12-31, $100k. Compute 60-day Pearson correlation of each non-EUR pair with EURUSD via history; pick 2 lowest |corr|; equal-weight. Monthly. Demonstrates: pairwise correlation, history-based selector, monthly schedule. Edge case: drop NaNs before correlation.",
+      "tags": [
+        "Forex",
+        "correlation",
+        "diversification",
+        "history"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-margin-leverage-control",
+      "name": "Forex Margin Leverage Control",
+      "description": "Sets explicit Forex leverage (20x) on EURUSD at OANDA and demonstrates margin checks.",
+      "spec": "Asset: EURUSD on Oanda. Daily. 2023-01-01 to 2024-12-31, $100k. forex.set_leverage(20.0); SMA(50)/SMA(200) cross; size to use 50% of available margin. Demonstrates: Forex leverage configuration, margin-aware sizing using portfolio.MarginRemaining. Edge case: monitor MarginUsed and log if > 80%.",
+      "tags": [
+        "Forex",
+        "leverage",
+        "buying-power",
+        "indicators"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "forex-quote-bar-spread-indicator",
+      "name": "Forex Custom Spread Indicator",
+      "description": "Implements a custom IndicatorBase[QuoteBar] that emits the bid-ask spread and trades EURUSD when spread is unusually wide.",
+      "spec": "Asset: EURUSD on Oanda. Minute. 2024-09-01 to 2024-12-31, $100k. Custom IndicatorBase[QuoteBar] computes spread = ask-bid; SMA(60) of spread; flat when current spread > 2x SMA, else long EURUSD. Demonstrates: writing a QuoteBar custom indicator (different from custom-indicator's MFI), spread-as-signal. Edge case: skip during the first hour after midnight.",
+      "tags": [
+        "Forex",
+        "custom-indicator",
+        "bid-ask-spread",
+        "intraday"
+      ],
+      "reference_template": "custom-indicator"
+    },
+    {
+      "folder": "forex-multi-currency-portfolio",
+      "name": "Forex Multi-Currency Settlement",
+      "description": "Holds EUR, GBP, and JPY denominated balances simultaneously by trading EURUSD/GBPUSD/USDJPY in opposite directions.",
+      "spec": "Pairs: EURUSD, GBPUSD, USDJPY on Oanda. Daily. 2023-01-01 to 2024-12-31, $100k. Long EUR (long EURUSD), long GBP (long GBPUSD), short JPY (long USDJPY). Demonstrates: multi-currency portfolio.cash_book inspection, set_account_currency notion, cross-currency exposure tracking. Edge case: log per-currency PnL daily.",
+      "tags": [
+        "Forex",
+        "cash-book",
+        "multi-currency",
+        "portfolio"
+      ],
+      "reference_template": "forex"
+    },
+    {
+      "folder": "cfd-de30-trend-following",
+      "name": "CFD DE30 Trend Following",
+      "description": "Trades the German DAX CFD (DE30) on a 50/200 SMA crossover with a daily scheduled rebalance.",
+      "spec": "Asset: DE30 (Oanda CFD). Daily. 2023-01-01 to 2024-12-31, $100k. SMA(50), SMA(200). Long on 50>200; flat on 50<200. Daily after-open schedule. Demonstrates: CFD on a foreign equity index, set_brokerage_model(OANDA), classic dual-MA. Edge case: handle local exchange holidays (XETRA).",
+      "tags": [
+        "Cfd",
+        "indicators",
+        "dax",
+        "trend-following"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-us30-mean-reversion",
+      "name": "CFD US30 Mean Reversion",
+      "description": "Mean reverts the Dow CFD (US30) using a 14-period RSI on hourly bars.",
+      "spec": "Asset: US30 (Oanda CFD). Hourly. 2023-01-01 to 2024-12-31, $100k. RSI(14). Long when RSI<30; short when >70; exit at 50. Demonstrates: CFD on US index, hourly resolution, RSI fade. Edge case: skip orders during pre-market.",
+      "tags": [
+        "Cfd",
+        "indicators",
+        "rsi",
+        "mean-reversion"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-nas100-momentum",
+      "name": "CFD NAS100 Momentum",
+      "description": "Trades the Nasdaq 100 CFD (NAS100) using a 20-day ROC threshold strategy.",
+      "spec": "Asset: NAS100 (Oanda CFD). Daily. 2023-01-01 to 2024-12-31, $100k. ROC(20). Long when ROC>0.02; flat<0; short<-0.02. Demonstrates: CFD on Nasdaq index, threshold momentum. Edge case: cap exposure at 100% (no margin use).",
+      "tags": [
+        "Cfd",
+        "indicators",
+        "roc",
+        "momentum"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-fra40-bollinger",
+      "name": "CFD FRA40 Bollinger Mean Reversion",
+      "description": "Mean-reverts the French CAC 40 CFD (FRA40) on a 20-period BollingerBands fade.",
+      "spec": "Asset: FRA40 (Oanda CFD). Daily. 2023-01-01 to 2024-12-31, $100k. BollingerBands(20,2). Long touch lower band; exit middle; short touch upper. Demonstrates: CFD on French index, Bollinger fade, scheduled trading aligned with Paris hours. Edge case: stay flat during French holidays.",
+      "tags": [
+        "Cfd",
+        "indicators",
+        "bollinger-bands",
+        "fra40"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-au200-rsi",
+      "name": "CFD AU200 RSI Trend Filter",
+      "description": "Trades the Australian ASX 200 CFD (AU200) with EMA crossover gated by RSI(14)>50.",
+      "spec": "Asset: AU200 (Oanda CFD). Daily. 2023-01-01 to 2024-12-31, $100k. EMA(20)/EMA(50) cross; allow longs only if RSI(14)>50. Demonstrates: CFD on ASX index, indicator filter combination. Edge case: respect ASX holidays / time-zone.",
+      "tags": [
+        "Cfd",
+        "indicators",
+        "asx",
+        "trend-filter"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-jp225-overnight-range",
+      "name": "CFD JP225 Overnight Range",
+      "description": "Trades JP225 CFD breakouts of the prior day's range during the Tokyo session.",
+      "spec": "Asset: JP225 (Oanda CFD). Hourly. 2023-01-01 to 2024-12-31, $100k. Track previous day high/low; long on first hour close > prev high during Tokyo session; short < prev low. Flat at NY close. Demonstrates: CFD intraday session, prior-day reference levels. Edge case: ignore Tokyo holidays.",
+      "tags": [
+        "Cfd",
+        "session-breakout",
+        "jp225",
+        "intraday"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-xauusd-gold-trend",
+      "name": "CFD XAUUSD Gold Trend",
+      "description": "Trades gold via XAUUSD CFD on a 20/50 EMA crossover with ATR-based stops.",
+      "spec": "Asset: XAUUSD (Oanda CFD). Daily. 2023-01-01 to 2024-12-31, $100k. EMA(20)/EMA(50) crossover; ATR(14) stop at -2*ATR on entry. Demonstrates: metals CFD, ATR stop on CFD, trend following. Edge case: cancel old stops on flips.",
+      "tags": [
+        "Cfd",
+        "indicators",
+        "gold",
+        "trend-following"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-xagusd-silver-pairs",
+      "name": "CFD XAUUSD vs XAGUSD Pairs",
+      "description": "Trades the gold/silver ratio (XAU/XAG) on a 20-day z-score with mean reversion.",
+      "spec": "Assets: XAUUSD, XAGUSD (Oanda CFD). Daily. 2023-01-01 to 2024-12-31, $100k. ratio = XAUUSD/XAGUSD; SMA(20), STD(20) -> z. Long XAU short XAG when z<-2; opposite>2; exit at 0. Demonstrates: metals pairs trade, ratio-based signal, dollar-balanced shorts. Edge case: re-balance hedge ratio weekly.",
+      "tags": [
+        "Cfd",
+        "pairs-trading",
+        "metals",
+        "zscore"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-wti-oil-trend",
+      "name": "CFD WTI Oil Trend",
+      "description": "Trades WTI Crude Oil CFD (WTICOUSD) using Donchian channel breakouts (20/10).",
+      "spec": "Asset: WTICOUSD (Oanda CFD). Daily. 2023-01-01 to 2024-12-31, $100k. DonchianChannel(20) entry, DonchianChannel(10) exit. Long on close above 20-day high; exit on close below 10-day low. Demonstrates: oil CFD turtle-style, Donchian indicator. Edge case: respect contract roll season volatility.",
+      "tags": [
+        "Cfd",
+        "indicators",
+        "donchian",
+        "oil"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-natgas-mean-reversion",
+      "name": "CFD Natural Gas Mean Reversion",
+      "description": "Mean reverts NATGASUSD CFD with BollingerBands(20,2) on daily bars.",
+      "spec": "Asset: NATGASUSD (Oanda CFD). Daily. 2023-01-01 to 2024-12-31, $100k. BB(20,2); long lower-band touch, exit middle; short upper-band touch. Demonstrates: commodity CFD mean reversion, Bollinger bands on volatile underlying. Edge case: avoid trades within 3 days of EIA storage report.",
+      "tags": [
+        "Cfd",
+        "indicators",
+        "natural-gas",
+        "mean-reversion"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-multi-index-rotation",
+      "name": "CFD Multi-Index Rotation",
+      "description": "Rotates monthly into the 2 highest-momentum index CFDs across DE30, US30, NAS100, FRA40, JP225.",
+      "spec": "Assets: DE30, US30, NAS100, FRA40, JP225 (Oanda CFD). Daily. 2023-01-01 to 2024-12-31, $100k. ROC(63); monthly schedule picks top 2 by ROC; equal-weight. Demonstrates: CFD multi-instrument rotation, scheduled monthly rebalance. Edge case: stay flat if all ROCs negative.",
+      "tags": [
+        "Cfd",
+        "asset-rotation",
+        "roc",
+        "monthly-rebalance"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-vix-cfd-timer",
+      "name": "CFD VIX-Timed Index Switch",
+      "description": "Switches between US30 CFD (long) and gold CFD (defensive) based on VIX index regime.",
+      "spec": "Assets: US30, XAUUSD (Oanda CFD), VIX (Index). Daily. 2023-01-01 to 2024-12-31, $100k. Daily: if VIX<20 hold US30; if VIX>25 hold XAUUSD; else stay. Demonstrates: index data + CFD trading, regime-switch via VIX. Edge case: ensure VIX has updated price.",
+      "tags": [
+        "Cfd",
+        "vix",
+        "regime-switch",
+        "scheduled-event"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-volatility-targeting",
+      "name": "CFD Volatility Targeting on US30",
+      "description": "Sizes US30 CFD position inversely to 20-day realized vol to maintain 10% annualized portfolio volatility.",
+      "spec": "Asset: US30 (Oanda CFD). Daily. 2023-01-01 to 2024-12-31, $100k. STD(20) annualized; weight = min(1, 0.10/realized_vol). Long-only when SMA(50)>SMA(200). Demonstrates: vol-targeting on CFD, indicator-driven sizing. Edge case: cap leverage at 1.0.",
+      "tags": [
+        "Cfd",
+        "volatility-targeting",
+        "indicators",
+        "us30"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-news-blackout-cpi",
+      "name": "CFD News Blackout (US CPI)",
+      "description": "Holds US30 CFD on EMA cross signals but flattens in the hour around US CPI releases (2nd Tuesday 8:30 ET).",
+      "spec": "Asset: US30 (Oanda CFD). Hourly. 2023-01-01 to 2024-12-31, $100k. EMA(20)/EMA(50). Detect 2nd Tuesday of the month; flat from 08:00-09:30 ET. Demonstrates: scheduled blackout via custom date logic, news risk management on CFD. Edge case: detect CPI release calendar dynamically (approximate by 2nd Tuesday).",
+      "tags": [
+        "Cfd",
+        "scheduled-event",
+        "news-blackout",
+        "us30"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "cfd-pairs-de30-fra40",
+      "name": "CFD DE30 vs FRA40 Pairs",
+      "description": "Trades the spread between DE30 and FRA40 CFDs on a 20-day z-score with mean reversion.",
+      "spec": "Assets: DE30, FRA40 (Oanda CFD). Daily. 2023-01-01 to 2024-12-31, $100k. ratio = DE30/FRA40; 20-day z-score; long DE30 / short FRA40 when z<-2; opposite>2; exit at 0. Demonstrates: European-index pairs trade, ratio z-score, dollar-balanced legs. Edge case: re-fit hedge ratio monthly.",
+      "tags": [
+        "Cfd",
+        "pairs-trading",
+        "european-indices",
+        "zscore"
+      ],
+      "reference_template": "cfd"
+    },
+    {
+      "folder": "crypto-btc-bollinger-mean-reversion",
+      "name": "Crypto BTC Bollinger Mean Reversion",
+      "description": "Mean-reverts BTCUSD on Coinbase using a 20-period Bollinger Band touch on hourly bars.",
+      "spec": "Asset: BTCUSD on Coinbase. Hourly. 2023-01-01 to 2024-12-31, $100k. BollingerBands(20,2). Long when low<lower band; exit at middle; flat else. Demonstrates: Crypto BollingerBands mean reversion, hourly bars, scheduled exit. Edge case: stay flat during indicator warm-up.",
+      "tags": [
+        "Crypto",
+        "indicators",
+        "bollinger-bands",
+        "mean-reversion"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-btc-rsi-fade",
+      "name": "Crypto BTC RSI Fade",
+      "description": "Fades BTCUSD on Coinbase with RSI(14): long under 30, short over 70, exits at 50.",
+      "spec": "Asset: BTCUSD on Coinbase. Hourly. 2023-01-01 to 2024-12-31, $100k. RSI(14). Long when <30; short when >70; exit at 50. Demonstrates: RSI on Crypto hourly, full long/short flip. Edge case: skip orders during the first 14 bars.",
+      "tags": [
+        "Crypto",
+        "indicators",
+        "rsi",
+        "intraday"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-eth-macd",
+      "name": "Crypto ETH MACD Crossover",
+      "description": "Trades ETHUSD on Coinbase using a MACD(12,26,9) signal crossover.",
+      "spec": "Asset: ETHUSD on Coinbase. Hourly. 2023-01-01 to 2024-12-31, $100k. MACD(12,26,9, EXPONENTIAL). Long on MACD cross above signal; flat on cross below. Demonstrates: MACD on ETH hourly, automatic warm-up. Edge case: ignore signals during weekend off-hours (skip first hour after midnight UTC).",
+      "tags": [
+        "Crypto",
+        "indicators",
+        "macd",
+        "ethusd"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-btc-donchian-breakout",
+      "name": "Crypto BTC Donchian Breakout",
+      "description": "Trades BTCUSD breakouts of a 20-bar DonchianChannel on hourly bars.",
+      "spec": "Asset: BTCUSD on Coinbase. Hourly. 2023-01-01 to 2024-12-31, $100k. DonchianChannel(20). Long on close above 20-bar high; flat on close below 10-bar low. Demonstrates: Donchian breakout on Crypto, hourly resolution. Edge case: cap trades to 1 entry per breakout.",
+      "tags": [
+        "Crypto",
+        "indicators",
+        "donchian",
+        "breakout"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-multi-coin-momentum",
+      "name": "Crypto Multi-Coin Momentum",
+      "description": "Ranks 5 majors (BTC, ETH, SOL, ADA, DOT) by 30-day ROC and equal-weights the top 2.",
+      "spec": "Assets: BTCUSD, ETHUSD, SOLUSD, ADAUSD, DOTUSD on Coinbase. Daily. 2023-01-01 to 2024-12-31, $100k. ROC(30); weekly schedule picks top 2 and equal-weights. Demonstrates: multi-coin momentum, weekly schedule, set_holdings 50/50. Edge case: hold cash if all ROCs negative.",
+      "tags": [
+        "Crypto",
+        "momentum",
+        "multi-coin",
+        "weekly"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-cross-exchange-spread",
+      "name": "Crypto Cross-Exchange Spread",
+      "description": "Compares BTCUSD on Coinbase vs Bitfinex and trades the spread when it exceeds 0.3%.",
+      "spec": "Asset: BTCUSD on Coinbase + BTCUSD on Bitfinex. Minute. 2024-09-01 to 2024-12-31, $100k. Track spread = Coinbase - Bitfinex. If spread<-0.003: long Coinbase, short Bitfinex (and vice versa). Exit at spread=0. Demonstrates: multi-exchange Crypto subscription, spread arbitrage. Edge case: respect each venue's available leverage.",
+      "tags": [
+        "Crypto",
+        "cross-exchange",
+        "spread",
+        "intraday"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-coingecko-marketcap-rotation",
+      "name": "Crypto CoinGecko Market Cap Rotation",
+      "description": "Selects the top 5 cryptos by CoinGecko market cap that are tradable on Kraken and equal-weights weekly.",
+      "spec": "Universe: CoinGeckoUniverse with Kraken filter. Daily. 2023-01-01 to 2024-12-31, $100k. add_universe(CoinGeckoUniverse, selector); weekly equal-weight top 5. Demonstrates: CoinGeckoUniverse, alternative-data universe with non-Coinbase exchange. Edge case: handle delistings via OnSecuritiesChanged.",
+      "tags": [
+        "Crypto",
+        "alternative-data",
+        "universe",
+        "kraken"
+      ],
+      "reference_template": "alternative-data-universe-coingeckouniverse"
+    },
+    {
+      "folder": "crypto-volatility-targeting",
+      "name": "Crypto Volatility Targeting BTC",
+      "description": "Sizes BTCUSD position inversely to 14-day realized vol to maintain 30% annualized portfolio vol.",
+      "spec": "Asset: BTCUSD on Coinbase. Daily. 2023-01-01 to 2024-12-31, $100k. STD(14) annualized; weight = min(1, 0.30/realized). Long when SMA(20)>SMA(50). Demonstrates: vol-targeting sizing for Crypto, multi-indicator combination. Edge case: cap leverage at 1.0.",
+      "tags": [
+        "Crypto",
+        "volatility-targeting",
+        "indicators",
+        "btc"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-stable-pair-arbitrage",
+      "name": "Crypto USDC/USDT Stable Pair",
+      "description": "Arbitrages tiny deviations between USDCUSD and USDTUSD on Coinbase vs Kraken.",
+      "spec": "Assets: USDCUSD, USDTUSD on Coinbase + Kraken. Minute. 2024-09-01 to 2024-12-31, $50k. If price diverges >5bps between exchanges, long the cheaper / short the dearer; exit at par. Demonstrates: stablecoin arbitrage, multi-exchange, tight spread tolerance. Edge case: wider tolerance if liquidity warrants (>10bps).",
+      "tags": [
+        "Crypto",
+        "stablecoin",
+        "cross-exchange",
+        "arbitrage"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-keltner-trend-eth",
+      "name": "Crypto ETH Keltner Trend",
+      "description": "Trades ETHUSD breakouts of KeltnerChannels(20,1.5) on hourly bars.",
+      "spec": "Asset: ETHUSD on Coinbase. Hourly. 2023-01-01 to 2024-12-31, $100k. KeltnerChannels(20,1.5). Long on close above upper; short on close below lower; exit on midline. Demonstrates: Keltner breakout on Crypto, indicator on ETH. Edge case: skip the first 20 bars of warm-up.",
+      "tags": [
+        "Crypto",
+        "indicators",
+        "keltner-channels",
+        "ethusd"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-supertrend-btc",
+      "name": "Crypto BTC SuperTrend",
+      "description": "Trades BTCUSD with a 14-period 3x ATR SuperTrend, flipping long/short on band-side flips.",
+      "spec": "Asset: BTCUSD on Coinbase. Hourly. 2023-01-01 to 2024-12-31, $100k. ATR(14)*3 SuperTrend (custom). Long when price crosses above SuperTrend; short when below. Demonstrates: SuperTrend on Crypto (custom indicator pattern). Edge case: cap to 1 flip per bar.",
+      "tags": [
+        "Crypto",
+        "custom-indicator",
+        "supertrend",
+        "btc"
+      ],
+      "reference_template": "custom-indicator"
+    },
+    {
+      "folder": "crypto-coinbase-tick-orderbook",
+      "name": "Crypto Coinbase Tick Order Book",
+      "description": "Subscribes to BTCUSD at tick resolution on Coinbase and trades on bid-ask imbalance.",
+      "spec": "Asset: BTCUSD on Coinbase. Tick. 2024-12-01 to 2024-12-31, $50k. Subscribe quote ticks; compute 1-min sliding bid_volume / (bid_volume+ask_volume). Long if >0.6; short if <0.4; flat else. Demonstrates: tick subscription on Crypto, bid-ask imbalance, manual bar build. Edge case: skip ticks with zero size.",
+      "tags": [
+        "Crypto",
+        "tick-data",
+        "order-book",
+        "intraday"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-grid-trading-btc",
+      "name": "Crypto BTC Grid Trading",
+      "description": "Implements a fixed-grid (price levels every 1%) on BTCUSD: buy at lower grid points, sell at upper.",
+      "spec": "Asset: BTCUSD on Coinbase. Minute. 2024-09-01 to 2024-12-31, $50k. Define price grid every 1% from anchor; cross-grid level downward triggers buy, upward triggers sell. Cap inventory to 1 BTC. Demonstrates: grid order management, level-cross detection, inventory cap. Edge case: re-anchor grid weekly to current price.",
+      "tags": [
+        "Crypto",
+        "grid-trading",
+        "intraday",
+        "order-management"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-hashrate-momentum",
+      "name": "Crypto BTC Hashrate Momentum",
+      "description": "Holds BTCUSD when 30-day ROC of network hashrate (Blockchain dataset) is positive.",
+      "spec": "Asset: BTCUSD on Coinbase + Blockchain Hashrate custom data. Daily. 2023-01-01 to 2024-12-31, $100k. ROC(30) of hashrate; long BTC when ROC>0, flat when <0. Demonstrates: on-chain data as universe filter, ROC on custom data. Edge case: ignore hashrate data older than 7 days.",
+      "tags": [
+        "Crypto",
+        "alternative-data",
+        "blockchain",
+        "momentum"
+      ],
+      "reference_template": "alternative-data-universe-coingeckouniverse"
+    },
+    {
+      "folder": "crypto-stable-dca",
+      "name": "Crypto BTC Dollar Cost Averaging",
+      "description": "Buys $200 worth of BTCUSD every Monday morning UTC and never sells.",
+      "spec": "Asset: BTCUSD on Coinbase. Daily. 2023-01-01 to 2024-12-31, $50k. Schedule every Monday 00:01 UTC; market_order(BTCUSD, 200/price). Demonstrates: weekly DCA schedule on Crypto, no-sell logic. Edge case: skip if cash<200.",
+      "tags": [
+        "Crypto",
+        "dca",
+        "scheduled-event",
+        "buy-and-hold"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-multi-exchange-static",
+      "name": "Crypto Multi-Exchange Static Basket",
+      "description": "Holds BTC on Coinbase, ETH on Kraken, and SOL on Bitfinex with a weekly equal-weight rebalance.",
+      "spec": "Assets: BTCUSD@Coinbase, ETHUSD@Kraken, SOLUSD@Bitfinex. Daily. 2023-01-01 to 2024-12-31, $150k. Weekly equal-weight 1/3 each. Demonstrates: multi-exchange static portfolio, set_brokerage_model per security. Edge case: respect different account currencies if needed.",
+      "tags": [
+        "Crypto",
+        "multi-exchange",
+        "asset-allocation",
+        "weekly"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-volume-breakout",
+      "name": "Crypto BTC Volume Breakout",
+      "description": "Trades BTCUSD breakouts when 1-hour volume exceeds 2x its 20-period SMA and price closes above prior high.",
+      "spec": "Asset: BTCUSD on Coinbase. Hourly. 2023-01-01 to 2024-12-31, $100k. SMA(20) of volume; track prior 20-bar high. Long if vol>2*SMA AND close>20bar high. Exit at 5*ATR(14). Demonstrates: volume-confirmed breakout, multi-indicator gate. Edge case: only one entry per breakout cluster.",
+      "tags": [
+        "Crypto",
+        "indicators",
+        "volume",
+        "breakout"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-pairs-btc-eth",
+      "name": "Crypto BTC/ETH Pairs",
+      "description": "Trades the BTC/ETH spread on a 60-day z-score with mean reversion at hourly resolution.",
+      "spec": "Assets: BTCUSD, ETHUSD on Coinbase. Hourly. 2023-01-01 to 2024-12-31, $100k. log spread = log(BTC) - log(ETH). 60-bar SMA / STD -> z. Long BTC short ETH if z<-2; opposite>2; exit at 0. Demonstrates: log-spread pairs trade, hourly Crypto. Edge case: re-fit weekly.",
+      "tags": [
+        "Crypto",
+        "pairs-trading",
+        "zscore",
+        "btc-eth"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-warmup-with-history",
+      "name": "Crypto Warm-Up With History",
+      "description": "Warms up an EMA(50) on BTCUSD by issuing a history(50, Resolution.HOUR) request before live bars start.",
+      "spec": "Asset: BTCUSD on Coinbase. Hourly. 2023-01-01 to 2024-12-31, $100k. EMA(50) registered; on Initialize: history(BTCUSD,50,Resolution.HOUR) and update EMA bar-by-bar. Trade on EMA cross. Demonstrates: explicit indicator warm-up via history, automatic_indicator_warm_up alternative. Edge case: ensure EMA is_ready after warm-up.",
+      "tags": [
+        "Crypto",
+        "warm-up",
+        "history",
+        "indicators"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-custom-data-bitstamp-eth",
+      "name": "Crypto Custom Data Bitstamp ETH",
+      "description": "Defines a PythonData type that parses Bitstamp daily ETHUSD CSV — variant of the existing custom-data template for ETH.",
+      "spec": "Asset: custom Bitstamp ETHUSD daily CSV. Daily. 2023-01-01 to 2024-12-31, $50k. PythonData get_source/Reader for Bitstamp ETH; chart price; long when 5-day return positive. Demonstrates: PythonData for ETH (different ticker than existing BTC template), no real trading on built-in feed. Edge case: handle missing CSV days.",
+      "tags": [
+        "Crypto",
+        "custom-data",
+        "bitstamp",
+        "ethusd"
+      ],
+      "reference_template": "custom-data"
+    },
+    {
+      "folder": "crypto-coinbase-altcoin-momentum",
+      "name": "Crypto Altcoin Momentum",
+      "description": "Selects 3 of the top 10 Coinbase altcoins by 7-day ROC and equal-weights weekly.",
+      "spec": "Universe: top-10 Coinbase by USD volume excluding BTC/ETH. Daily. 2023-01-01 to 2024-12-31, $100k. Weekly: ROC(7) per altcoin; equal-weight top 3. Demonstrates: filtered Crypto universe, weekly schedule, momentum across altcoins. Edge case: skip days with fewer than 10 candidates.",
+      "tags": [
+        "Crypto",
+        "momentum",
+        "universe",
+        "altcoins"
+      ],
+      "reference_template": "crypto-universe"
+    },
+    {
+      "folder": "crypto-bb-squeeze-eth",
+      "name": "Crypto ETH Bollinger Squeeze",
+      "description": "Detects a Bollinger-inside-Keltner squeeze on ETHUSD and trades the BB breakout direction.",
+      "spec": "Asset: ETHUSD on Coinbase. Hourly. 2023-01-01 to 2024-12-31, $100k. BollingerBands(20,2), KeltnerChannels(20,1.5). Squeeze when BB inside KC; first close outside BB triggers entry; exit on midline. Demonstrates: dual-indicator squeeze on ETH (variation of equity Keltner squeeze). Edge case: only one trade per squeeze.",
+      "tags": [
+        "Crypto",
+        "indicators",
+        "squeeze",
+        "ethusd"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-vwap-fade",
+      "name": "Crypto BTC Hourly VWAP Fade",
+      "description": "Fades BTCUSD when hourly close deviates >1% from session VWAP.",
+      "spec": "Asset: BTCUSD on Coinbase. Minute. 2024-09-01 to 2024-12-31, $50k. Session VWAP (UTC midnight reset). Long if (close-VWAP)/VWAP<-0.01; short if >0.01; flat at VWAP. Demonstrates: session VWAP on Crypto, scheduled reset, fade strategy. Edge case: handle zero volume bars.",
+      "tags": [
+        "Crypto",
+        "indicators",
+        "vwap",
+        "intraday"
+      ],
+      "reference_template": "intraday-indicator-scans"
+    },
+    {
+      "folder": "crypto-correlation-rotation",
+      "name": "Crypto Correlation Rotation",
+      "description": "Each week picks the 2 altcoins least correlated with BTC over 30 days and equal-weights long.",
+      "spec": "Assets: BTC, ETH, SOL, ADA, DOT, LINK, MATIC on Coinbase. Daily. 2023-01-01 to 2024-12-31, $100k. Weekly: 30-day Pearson correlation of each non-BTC vs BTC; pick 2 lowest |corr|; equal-weight. Demonstrates: correlation diversification, weekly rebalance, history per pair. Edge case: drop NaNs before correlation.",
+      "tags": [
+        "Crypto",
+        "correlation",
+        "diversification",
+        "weekly"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-bitfinex-margin",
+      "name": "Crypto Bitfinex Margin Trading",
+      "description": "Trades BTCUSD on Bitfinex with set_brokerage_model(BITFINEX) to use margin and leverage.",
+      "spec": "Asset: BTCUSD on Bitfinex. Hourly. 2023-01-01 to 2024-12-31, $50k. set_brokerage_model(BrokerageName.BITFINEX, AccountType.MARGIN). EMA(20)/EMA(50) cross with 2x leverage. Demonstrates: Bitfinex brokerage model, margin account on Crypto, leverage usage. Edge case: monitor margin remaining.",
+      "tags": [
+        "Crypto",
+        "bitfinex",
+        "margin",
+        "indicators"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-kraken-trend",
+      "name": "Crypto Kraken Trend Following",
+      "description": "Trades BTCUSD on Kraken with EMA crossover and set_brokerage_model(KRAKEN).",
+      "spec": "Asset: BTCUSD on Kraken. Hourly. 2023-01-01 to 2024-12-31, $50k. set_brokerage_model(BrokerageName.KRAKEN). EMA(50)/EMA(200). Demonstrates: Kraken brokerage model, classical trend following on Crypto. Edge case: respect Kraken's minimum order sizes.",
+      "tags": [
+        "Crypto",
+        "kraken",
+        "indicators",
+        "trend-following"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "crypto-binance-spot",
+      "name": "Crypto Binance Spot Universe",
+      "description": "Builds a Binance Crypto universe selecting the top 5 by USD volume daily and equal-weights monthly.",
+      "spec": "Universe: Binance Crypto. Daily. 2023-01-01 to 2024-12-31, $100k. set_brokerage_model(BrokerageName.BINANCE); add_universe(CryptoUniverse.binance(...)) selecting top 5 by USD volume. Equal-weight monthly. Demonstrates: Binance brokerage model + native Crypto universe (different from Coinbase). Edge case: handle pair delistings.",
+      "tags": [
+        "Crypto",
+        "binance",
+        "universe",
+        "monthly"
+      ],
+      "reference_template": "crypto-universe"
+    },
+    {
+      "folder": "crypto-bybit-spot",
+      "name": "Crypto Bybit Spot Trend",
+      "description": "Trades BTCUSDT on Bybit with EMA cross and set_brokerage_model(BYBIT).",
+      "spec": "Asset: BTCUSDT on Bybit. Hourly. 2023-01-01 to 2024-12-31, $50k. set_brokerage_model(BrokerageName.BYBIT, AccountType.CASH). EMA(20)/EMA(50). Demonstrates: Bybit brokerage model, USDT-quoted spot Crypto pair. Edge case: respect Bybit minimum increments.",
+      "tags": [
+        "Crypto",
+        "bybit",
+        "indicators",
+        "usdt"
+      ],
+      "reference_template": "crypto-static"
+    },
+    {
+      "folder": "cryptofuture-btcusdt-perp-momentum",
+      "name": "CryptoFuture BTCUSDT Perpetual Momentum",
+      "description": "Trades the BTCUSDT perpetual on Binance Futures using a 20/50 EMA crossover with leverage.",
+      "spec": "Asset: BTCUSDT perpetual on Binance Futures (CryptoFuture). Hourly. 2023-01-01 to 2024-12-31, $100k. set_brokerage_model(BINANCE_FUTURES). EMA(20)/EMA(50) cross. Long on 20>50, short on 20<50; 3x notional. Demonstrates: CryptoFuture leveraged momentum, binance perp trading. Edge case: respect notional vs equity sizing.",
+      "tags": [
+        "CryptoFuture",
+        "binance-futures",
+        "indicators",
+        "perpetual"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-funding-rate-harvest",
+      "name": "CryptoFuture Funding Rate Harvest",
+      "description": "Holds short BTCUSDT perpetual when funding rate is positive >0.05% to harvest payments.",
+      "spec": "Asset: BTCUSDT perpetual on Binance Futures. Hourly. 2023-01-01 to 2024-12-31, $100k. Read funding rate from security.fundamentals (or custom data); short BTC perp when funding>0.0005; flat when <=0. Demonstrates: funding-rate harvesting, perp microstructure. Edge case: cap notional to keep risk bounded.",
+      "tags": [
+        "CryptoFuture",
+        "funding-rate",
+        "binance-futures",
+        "btc"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-basis-arbitrage",
+      "name": "CryptoFuture Basis Arbitrage",
+      "description": "Arbitrages BTCUSDT perpetual basis vs BTCUSD spot — long spot / short perp when basis exceeds 0.5%.",
+      "spec": "Assets: BTCUSDT perp (Binance Futures) + BTCUSD spot (Coinbase). Hourly. 2023-01-01 to 2024-12-31, $100k. basis = (perp - spot)/spot. If basis>0.005: long spot short perp (cash-and-carry); exit at 0. Demonstrates: cross-venue basis arbitrage, multi-asset class portfolio. Edge case: dollar-balanced legs.",
+      "tags": [
+        "CryptoFuture",
+        "basis-arbitrage",
+        "binance-futures",
+        "btc"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-eth-perp-mean-reversion",
+      "name": "CryptoFuture ETH Perpetual Mean Reversion",
+      "description": "Mean reverts ETHUSDT perpetual on Binance Futures with BollingerBands(20,2) on hourly bars.",
+      "spec": "Asset: ETHUSDT perpetual on Binance Futures. Hourly. 2023-01-01 to 2024-12-31, $100k. BollingerBands(20,2). Long when close<lower; short when >upper; exit middle. 2x leverage. Demonstrates: BB mean reversion on perp, leverage. Edge case: cap re-entries within same band excursion.",
+      "tags": [
+        "CryptoFuture",
+        "indicators",
+        "bollinger-bands",
+        "ethusdt"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-perp-momentum-multi",
+      "name": "CryptoFuture Multi-Coin Perp Momentum",
+      "description": "Ranks 5 majors (BTC, ETH, SOL, ADA, DOT) USDT perps by 7-day ROC and equal-weights long the top 2.",
+      "spec": "Assets: BTCUSDT, ETHUSDT, SOLUSDT, ADAUSDT, DOTUSDT perp on Binance Futures. Daily. 2023-01-01 to 2024-12-31, $100k. ROC(7); weekly schedule top 2 equal-weight. Demonstrates: multi-coin perp momentum. Edge case: stay flat if all ROCs negative.",
+      "tags": [
+        "CryptoFuture",
+        "momentum",
+        "multi-coin",
+        "perpetual"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-volatility-targeting",
+      "name": "CryptoFuture Volatility Targeting",
+      "description": "Sizes BTCUSDT perp inverse to 14-day vol to maintain 40% annualized portfolio volatility.",
+      "spec": "Asset: BTCUSDT perpetual on Binance Futures. Daily. 2023-01-01 to 2024-12-31, $100k. STD(14) annualized; weight = min(2, 0.40/realized). Long-only when SMA(20)>SMA(50). Demonstrates: vol-targeting on perp with leverage cap, indicator-based sizing. Edge case: floor weight at 0.1.",
+      "tags": [
+        "CryptoFuture",
+        "volatility-targeting",
+        "indicators",
+        "perpetual"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-margin-interest-tracker",
+      "name": "CryptoFuture Margin Interest Tracker",
+      "description": "Long-only BTCUSDT perp with explicit charting of accrued margin interest and PnL.",
+      "spec": "Asset: BTCUSDT perpetual on Binance Futures. Daily. 2023-01-01 to 2024-12-31, $100k. EMA cross entry; track accrued margin interest cost via portfolio.transactions / brokerage events; chart cumulative interest on a custom Series. Demonstrates: margin interest visualization, cost tracking on perp (different scope from existing crypto-futures template). Edge case: skip days with no fills.",
+      "tags": [
+        "CryptoFuture",
+        "charting",
+        "margin-interest",
+        "perpetual"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-pairs-btc-eth-perp",
+      "name": "CryptoFuture BTC/ETH Perp Pairs",
+      "description": "Trades the BTCUSDT/ETHUSDT perp spread on a 60-bar z-score with mean reversion.",
+      "spec": "Assets: BTCUSDT, ETHUSDT perp on Binance Futures. Hourly. 2023-01-01 to 2024-12-31, $100k. log-spread, 60-bar z; long BTC short ETH at z<-2, opposite>2, exit 0. 2x leverage each leg. Demonstrates: pairs trade on perps, hourly mean reversion. Edge case: re-fit hedge ratio weekly.",
+      "tags": [
+        "CryptoFuture",
+        "pairs-trading",
+        "zscore",
+        "perpetual"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-bybit-perp",
+      "name": "CryptoFuture Bybit BTC Perp",
+      "description": "Trades BTCUSDT perpetual on Bybit with set_brokerage_model(BYBIT_FUTURES) and EMA cross.",
+      "spec": "Asset: BTCUSDT perp on Bybit. Hourly. 2023-01-01 to 2024-12-31, $50k. set_brokerage_model(BrokerageName.BYBIT, AccountType.MARGIN) for futures; EMA(20)/EMA(50) cross with 3x leverage. Demonstrates: Bybit Futures brokerage model, perp leverage. Edge case: respect Bybit min increments.",
+      "tags": [
+        "CryptoFuture",
+        "bybit-futures",
+        "indicators",
+        "perpetual"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-binance-margin-call",
+      "name": "CryptoFuture Binance Margin Call Hook",
+      "description": "Implements on_margin_call_warning + on_margin_call to log and reduce position on a leveraged BTCUSDT perp strategy.",
+      "spec": "Asset: BTCUSDT perp on Binance Futures. Hourly. 2023-01-01 to 2024-12-31, $50k. EMA cross at 5x leverage; override on_margin_call_warning to log and on_margin_call to halve position. Demonstrates: margin call hooks on CryptoFuture, leveraged risk control. Edge case: ensure partial flatten respects min lot size.",
+      "tags": [
+        "CryptoFuture",
+        "margin-call",
+        "binance-futures",
+        "buying-power"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-funding-rate-skew",
+      "name": "CryptoFuture Funding Skew Long",
+      "description": "Goes long BTCUSDT perpetual only when funding rate is below -0.01% (capturing pay-to-be-long).",
+      "spec": "Asset: BTCUSDT perp on Binance Futures. Hourly. 2023-01-01 to 2024-12-31, $50k. Read funding rate via custom data; long perp when funding<-0.0001; flat otherwise. Demonstrates: funding-rate filter (long-only complement to short-skew template). Edge case: ensure funding data freshness.",
+      "tags": [
+        "CryptoFuture",
+        "funding-rate",
+        "long-only",
+        "btc"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-leveraged-dca",
+      "name": "CryptoFuture Leveraged DCA",
+      "description": "Adds $200 of BTCUSDT perpetual at 2x leverage every Monday and never sells.",
+      "spec": "Asset: BTCUSDT perp on Binance Futures. Daily. 2023-01-01 to 2024-12-31, $50k. Schedule Monday 00:01 UTC: market_order at 2x notional of $200 cash. Demonstrates: leveraged DCA on perp, scheduled buy logic. Edge case: stop adding when total notional > 5x equity.",
+      "tags": [
+        "CryptoFuture",
+        "dca",
+        "scheduled-event",
+        "perpetual"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-perpetual-history",
+      "name": "CryptoFuture Perpetual History Warm-Up",
+      "description": "Warms up an EMA(50) on BTCUSDT perp via history(50, Resolution.HOUR) and trades crossovers thereafter.",
+      "spec": "Asset: BTCUSDT perpetual on Binance Futures. Hourly. 2023-01-01 to 2024-12-31, $50k. history(BTCUSDT,50,Resolution.HOUR) seeds EMA(50). Long on close>EMA, flat<EMA. 2x leverage. Demonstrates: history-driven warm-up on perp. Edge case: validate is_ready after warm-up.",
+      "tags": [
+        "CryptoFuture",
+        "warm-up",
+        "history",
+        "perpetual"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-rolling-window-perp",
+      "name": "CryptoFuture Rolling Window Perp",
+      "description": "Maintains a RollingWindow(48) of hourly bars on BTCUSDT perp and trades when 48-hour high is broken.",
+      "spec": "Asset: BTCUSDT perp on Binance Futures. Hourly. 2023-01-01 to 2024-12-31, $50k. RollingWindow[TradeBar](48); long on close > max(window.highs); flat on close < min(window.lows). Demonstrates: RollingWindow-based breakout on perp without indicators. Edge case: skip until window full.",
+      "tags": [
+        "CryptoFuture",
+        "rolling-window",
+        "breakout",
+        "perpetual"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "cryptofuture-portfolio-perp-spot-hedge",
+      "name": "CryptoFuture Spot+Perp Hedge",
+      "description": "Holds long BTCUSD spot on Coinbase and shorts a smaller BTCUSDT perp on Binance Futures to lock in the basis.",
+      "spec": "Assets: BTCUSD spot (Coinbase) + BTCUSDT perp (Binance Futures). Daily. 2023-01-01 to 2024-12-31, $100k. Long spot 1 BTC; short perp 0.5 BTC continuously; rebalance weekly to maintain 0.5 hedge ratio. Demonstrates: cross-venue hedge with set_brokerage_model per security, hedged inventory. Edge case: handle delisting/listing of perp by halting rebalance.",
+      "tags": [
+        "CryptoFuture",
+        "hedge",
+        "cross-exchange",
+        "basis"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "future-es-momentum-ema",
+      "name": "Future ES EMA Momentum",
+      "description": "Trades the continuous E-mini S&P 500 (ES) Future with a 20/50 EMA cross on daily bars.",
+      "spec": "Asset: ES continuous, BACKWARDS_RATIO. Daily. 2023-01-01 to 2024-12-31, $100k. EMA(20)/EMA(50). Long mapped on 20>50, short on 20<50. Roll on SymbolChangedEvents. Demonstrates: ES continuous future, EMA momentum, contract roll handling. Edge case: liquidate old + reopen new on roll.",
+      "tags": [
+        "Future",
+        "indicators",
+        "ema-cross",
+        "es-mini"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-nq-rsi-mean-reversion",
+      "name": "Future NQ RSI Mean Reversion",
+      "description": "Mean reverts continuous NQ Future with a 14-period RSI on daily bars.",
+      "spec": "Asset: NQ continuous, BACKWARDS_RATIO. Daily. 2023-01-01 to 2024-12-31, $100k. RSI(14). Long when RSI<30; short>70; exit at 50. Trade _future.mapped contract. Demonstrates: continuous NQ Future, RSI mean reversion, mapped-symbol trading. Edge case: skip during contract roll.",
+      "tags": [
+        "Future",
+        "indicators",
+        "rsi",
+        "nq-mini"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-cl-bollinger-breakout",
+      "name": "Future CL Bollinger Breakout",
+      "description": "Trades continuous Crude Oil Future (CL) breakouts of a 20-period Bollinger Band.",
+      "spec": "Asset: CL continuous. Daily. 2023-01-01 to 2024-12-31, $100k. BollingerBands(20,2). Long on close>upper; short<lower; exit middle. Demonstrates: oil Future breakout, Bollinger on commodities, mapped-contract trading. Edge case: handle CL roll-related volatility spikes.",
+      "tags": [
+        "Future",
+        "indicators",
+        "bollinger-bands",
+        "crude-oil"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-gc-trend-following",
+      "name": "Future GC Gold Trend",
+      "description": "Trades continuous Gold Future (GC) on a 50/200 SMA crossover with monthly position checks.",
+      "spec": "Asset: GC continuous. Daily. 2023-01-01 to 2024-12-31, $100k. SMA(50)/SMA(200). Long mapped on 50>200; flat<. Monthly schedule check. Demonstrates: gold Future, simple SMA trend. Edge case: no shorting (long-only).",
+      "tags": [
+        "Future",
+        "indicators",
+        "sma-cross",
+        "gold"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-zb-yield-curve",
+      "name": "Future ZB Bond Trend",
+      "description": "Trades continuous 30-Year Bond Future (ZB) with EMA(20)/EMA(50) cross and ATR-based stops.",
+      "spec": "Asset: ZB continuous. Daily. 2023-01-01 to 2024-12-31, $100k. EMA(20)/EMA(50) cross; ATR(14)*2 stop. Long mapped on 20>50; flat<. Demonstrates: bond Future trend, ATR stop on Future. Edge case: handle ZB tick value (1/32).",
+      "tags": [
+        "Future",
+        "indicators",
+        "ema-cross",
+        "treasury-bond"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-zn-treasury-mean-reversion",
+      "name": "Future ZN Treasury Mean Reversion",
+      "description": "Mean reverts continuous 10-Year Treasury Note Future (ZN) on BollingerBands(20,2).",
+      "spec": "Asset: ZN continuous. Daily. 2023-01-01 to 2024-12-31, $100k. BB(20,2). Long when low<lower; exit middle; short when high>upper. Demonstrates: ZN bond Future mean reversion, BB indicator on rates. Edge case: skip orders within first 20 bars.",
+      "tags": [
+        "Future",
+        "indicators",
+        "bollinger-bands",
+        "ten-year-note"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-zc-corn-momentum",
+      "name": "Future ZC Corn Momentum",
+      "description": "Trades continuous Corn Future (ZC) with 20-day ROC threshold strategy.",
+      "spec": "Asset: ZC continuous. Daily. 2023-01-01 to 2024-12-31, $100k. ROC(20). Long when ROC>0.03; flat else; short<-0.03. Demonstrates: agricultural Future momentum. Edge case: avoid trading during USDA WASDE release week.",
+      "tags": [
+        "Future",
+        "indicators",
+        "roc",
+        "corn"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-zs-soybean-trend",
+      "name": "Future ZS Soybean Trend",
+      "description": "Trades continuous Soybean Future (ZS) on EMA(50)/EMA(200) crossover.",
+      "spec": "Asset: ZS continuous. Daily. 2023-01-01 to 2024-12-31, $100k. EMA(50)/EMA(200). Long on 50>200; short on 50<200. Demonstrates: agricultural Future trend, classical golden-cross. Edge case: handle ZS tick size (1/4 cent).",
+      "tags": [
+        "Future",
+        "indicators",
+        "ema-cross",
+        "soybean"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-ng-natural-gas",
+      "name": "Future NG Natural Gas Mean Reversion",
+      "description": "Mean reverts continuous Natural Gas Future (NG) on BollingerBands(20,2).",
+      "spec": "Asset: NG continuous. Daily. 2023-01-01 to 2024-12-31, $100k. BB(20,2). Long when low<lower; short when high>upper; exit at middle. Demonstrates: NG mean reversion, Bollinger on volatile commodity. Edge case: avoid weeks of EIA storage report (Thu).",
+      "tags": [
+        "Future",
+        "indicators",
+        "bollinger-bands",
+        "natural-gas"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-si-silver-momentum",
+      "name": "Future SI Silver Momentum",
+      "description": "Trades continuous Silver Future (SI) on a 30-day ROC momentum signal.",
+      "spec": "Asset: SI continuous. Daily. 2023-01-01 to 2024-12-31, $100k. ROC(30). Long when ROC>0.05; flat<0; short<-0.05. Demonstrates: silver Future momentum. Edge case: handle SI tick value (5,000 oz contract).",
+      "tags": [
+        "Future",
+        "indicators",
+        "roc",
+        "silver"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-ym-dow-mini",
+      "name": "Future YM Dow Mini Trend",
+      "description": "Trades continuous E-mini Dow Future (YM) on a 50/200 SMA crossover.",
+      "spec": "Asset: YM continuous. Daily. 2023-01-01 to 2024-12-31, $100k. SMA(50)/SMA(200). Long mapped on 50>200; flat<. Demonstrates: Dow Future trend following, mapped trading. Edge case: contract rollover handling.",
+      "tags": [
+        "Future",
+        "indicators",
+        "sma-cross",
+        "ym"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-rty-russell-mini",
+      "name": "Future RTY Russell Mini Trend",
+      "description": "Trades continuous E-mini Russell 2000 Future (RTY) using 20/50 EMA cross.",
+      "spec": "Asset: RTY continuous. Daily. 2023-01-01 to 2024-12-31, $100k. EMA(20)/EMA(50). Long on 20>50; flat<. Demonstrates: small-cap Future trend, mapped trading. Edge case: adjust for RTY contract roll calendar.",
+      "tags": [
+        "Future",
+        "indicators",
+        "ema-cross",
+        "rty"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-zf-five-year-note",
+      "name": "Future ZF 5Y Note Carry",
+      "description": "Holds continuous 5Y Treasury Note Future (ZF) long when 50-day SMA slope > 0.",
+      "spec": "Asset: ZF continuous. Daily. 2023-01-01 to 2024-12-31, $100k. SMA(50); compute slope from RollingWindow(5) of SMA values. Long when slope>0; flat<0. Demonstrates: indicator slope analytics, ZF trading. Edge case: skip during first 50 bars.",
+      "tags": [
+        "Future",
+        "indicators",
+        "rolling-window",
+        "five-year-note"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-zw-wheat-trend",
+      "name": "Future ZW Wheat Trend",
+      "description": "Trades continuous Wheat Future (ZW) using EMA(50)/EMA(200) crossover.",
+      "spec": "Asset: ZW continuous. Daily. 2023-01-01 to 2024-12-31, $100k. EMA(50)/EMA(200). Long mapped on 50>200; flat<. Demonstrates: ZW Future trend, agricultural. Edge case: skip during USDA WASDE release weeks.",
+      "tags": [
+        "Future",
+        "indicators",
+        "ema-cross",
+        "wheat"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-calendar-spread-cl",
+      "name": "Future CL Calendar Spread",
+      "description": "Trades the front-month vs second-month Crude Oil (CL) calendar spread when it deviates from its 30-day mean.",
+      "spec": "Asset: CL with set_filter(0,180) so we get front and second contract. Daily. 2023-01-01 to 2024-12-31, $100k. Compute spread = front - second; SMA(30); long spread (long front, short second) when spread<SMA-1*STD; opposite when >SMA+1*STD. Demonstrates: explicit two-contract Future trading (no continuous), calendar spread. Edge case: skip days with only one expiry available.",
+      "tags": [
+        "Future",
+        "calendar-spread",
+        "crude-oil",
+        "filter"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-multi-future-momentum",
+      "name": "Future Multi-Future Momentum",
+      "description": "Ranks 4 macro Futures (ES, ZB, GC, CL) by 60-day ROC monthly and equal-weights long the top 2.",
+      "spec": "Assets: ES, ZB, GC, CL continuous. Daily. 2023-01-01 to 2024-12-31, $200k. ROC(60); monthly schedule top 2 equal-weight on .mapped contract. Demonstrates: cross-asset Future momentum, monthly rebalance, multi-mapped trading. Edge case: handle rolls per asset.",
+      "tags": [
+        "Future",
+        "momentum",
+        "multi-future",
+        "monthly-rebalance"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-zs-zw-pairs",
+      "name": "Future ZS-ZW Spread",
+      "description": "Trades the corn-soybean-wheat agricultural spread (ZS-ZW) on a 30-day z-score.",
+      "spec": "Assets: ZS, ZW continuous. Daily. 2023-01-01 to 2024-12-31, $100k. spread = ZS-ZW; SMA(30), STD(30) -> z. Long ZS short ZW when z<-2; opposite>2; exit 0. Demonstrates: agricultural Future pairs, mapped-contract trading. Edge case: re-fit hedge ratio monthly.",
+      "tags": [
+        "Future",
+        "pairs-trading",
+        "agricultural",
+        "zscore"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-nq-volatility-targeting",
+      "name": "Future NQ Volatility Targeting",
+      "description": "Sizes NQ position inversely to 14-day realized vol to maintain 15% portfolio volatility.",
+      "spec": "Asset: NQ continuous. Daily. 2023-01-01 to 2024-12-31, $100k. STD(14) annualized; weight = min(1, 0.15/realized). Long-only when SMA(20)>SMA(50). Demonstrates: vol-targeting on Future, indicator-driven sizing. Edge case: floor weight at 0.1.",
+      "tags": [
+        "Future",
+        "volatility-targeting",
+        "indicators",
+        "nq-mini"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-es-vix-regime",
+      "name": "Future ES VIX Regime",
+      "description": "Holds long ES Future when VIX<20 and flat when VIX>25 (hysteresis).",
+      "spec": "Asset: ES continuous + VIX index. Daily. 2023-01-01 to 2024-12-31, $100k. add_index(VIX); daily schedule: if VIX>25 flat; if VIX<20 long ES.mapped; else stay. Demonstrates: index data + Future trading, regime switch. Edge case: ensure VIX has valid value before trading.",
+      "tags": [
+        "Future",
+        "vix",
+        "regime-switch",
+        "es-mini"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-cl-gc-pairs",
+      "name": "Future CL-GC Inflation Hedge",
+      "description": "Trades the gold/oil ratio (GC/CL) on a 30-day z-score with mean reversion.",
+      "spec": "Assets: GC, CL continuous. Daily. 2023-01-01 to 2024-12-31, $100k. ratio = GC/CL; SMA(30), STD(30) -> z. Long GC short CL at z<-2; opposite>2; exit 0. Demonstrates: cross-commodity ratio trade, mapped-contract trading. Edge case: re-fit hedge ratio monthly.",
+      "tags": [
+        "Future",
+        "pairs-trading",
+        "commodities",
+        "zscore"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-es-overnight-effect",
+      "name": "Future ES Overnight Effect",
+      "description": "Holds long ES Future from 16:00 ET to 09:30 ET each day to capture the overnight risk premium.",
+      "spec": "Asset: ES continuous. Hourly. 2023-01-01 to 2024-12-31, $100k. Schedule 16:00 ET buy mapped contract; 09:30 ET liquidate. Demonstrates: scheduled overnight trading, two-event-per-day pattern. Edge case: skip half-day exchange schedules.",
+      "tags": [
+        "Future",
+        "overnight-effect",
+        "scheduled-event",
+        "es-mini"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-cl-news-blackout",
+      "name": "Future CL EIA Blackout",
+      "description": "Holds CL trend signals but flattens 30 minutes around the weekly EIA petroleum report (Wed 10:30 ET).",
+      "spec": "Asset: CL continuous. Hourly. 2023-01-01 to 2024-12-31, $100k. EMA(20)/EMA(50). Each Wednesday flat 10:00-11:00 ET; otherwise trend signals. Demonstrates: scheduled news blackout on Future, weekly report avoidance. Edge case: handle Wednesday holidays.",
+      "tags": [
+        "Future",
+        "scheduled-event",
+        "news-blackout",
+        "crude-oil"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-rolling-window-breakout",
+      "name": "Future ES Rolling Window Breakout",
+      "description": "Maintains a RollingWindow(60) of daily bars on ES Future and trades 60-day high/low breakouts.",
+      "spec": "Asset: ES continuous. Daily. 2023-01-01 to 2024-12-31, $100k. RollingWindow[TradeBar](60). Long mapped on close > max(highs); short on close < min(lows). Demonstrates: RollingWindow-based breakout, no indicator dependency. Edge case: skip until window full.",
+      "tags": [
+        "Future",
+        "rolling-window",
+        "breakout",
+        "es-mini"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-roll-with-history",
+      "name": "Future Roll With History Warm-Up",
+      "description": "Warms up an ES SMA(200) using history(200, Resolution.DAILY) so trading can start on day 1.",
+      "spec": "Asset: ES continuous. Daily. 2023-01-01 to 2024-12-31, $100k. Initialize: history(_future.symbol, 200, Resolution.DAILY) feeds SMA(200) and RollingWindow. Trade mapped on close>SMA. Demonstrates: history warm-up on Future continuous symbol, immediate trading capability. Edge case: history may include rolls — feed by date.",
+      "tags": [
+        "Future",
+        "warm-up",
+        "history",
+        "es-mini"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-mes-micro-mini",
+      "name": "Future MES Micro E-mini",
+      "description": "Trades continuous Micro E-mini S&P (MES) Future with 20/50 EMA cross — smaller notional than ES.",
+      "spec": "Asset: MES continuous. Daily. 2023-01-01 to 2024-12-31, $50k. EMA(20)/EMA(50). Long mapped on 20>50; flat<. Demonstrates: micro-mini Future for smaller account sizing, identical mechanics to ES. Edge case: respect MES contract multiplier ($5/pt).",
+      "tags": [
+        "Future",
+        "indicators",
+        "ema-cross",
+        "micro-mini"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-mnq-micro-nasdaq",
+      "name": "Future MNQ Micro Nasdaq",
+      "description": "Trades continuous Micro E-mini Nasdaq (MNQ) Future with RSI(14) mean reversion.",
+      "spec": "Asset: MNQ continuous. Daily. 2023-01-01 to 2024-12-31, $50k. RSI(14). Long when <30; short when >70; exit 50. Demonstrates: micro-mini Nasdaq Future, RSI mean reversion. Edge case: handle MNQ contract multiplier ($2/pt).",
+      "tags": [
+        "Future",
+        "indicators",
+        "rsi",
+        "micro-nasdaq"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-vx-vix-future",
+      "name": "Future VX VIX Future",
+      "description": "Trades continuous CBOE VIX Future (VX) by going long when contango is steep (>5%) and rolling at expiry.",
+      "spec": "Asset: VX continuous. Daily. 2023-01-01 to 2024-12-31, $100k. Compute contango = (front-second)/front; if contango>0.05 short mapped (VX tends to fall); if backwardation>0.05 long. Demonstrates: VIX Future term-structure trade, mapped trading. Edge case: respect VX contract size and roll calendar.",
+      "tags": [
+        "Future",
+        "vix-future",
+        "term-structure",
+        "contango"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-3-month-eurodollar",
+      "name": "Future GE Eurodollar Trend",
+      "description": "Trades continuous Eurodollar Future (GE) — short-rate proxy — on EMA(50)/EMA(200) cross.",
+      "spec": "Asset: GE continuous. Daily. 2023-01-01 to 2024-12-31, $100k. EMA(50)/EMA(200). Long mapped on 50>200 (rates falling). Demonstrates: short-rate Future trend, mapped trading. Edge case: GE tick value reflects 1bp = $25.",
+      "tags": [
+        "Future",
+        "indicators",
+        "ema-cross",
+        "eurodollar"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-vol-target-multi",
+      "name": "Future Multi-Future Vol-Target Portfolio",
+      "description": "Holds equal-vol-weighted basket of ES, ZB, GC, CL Futures rebalanced monthly to 10% portfolio vol.",
+      "spec": "Assets: ES, ZB, GC, CL continuous. Daily. 2023-01-01 to 2024-12-31, $250k. STD(20) per Future; weight = (target_vol/sigma) normalized to sum 1; cap each leg at 30%. Monthly. Demonstrates: vol-weighted multi-Future portfolio, mapped-contract trading. Edge case: handle missing data on rolls.",
+      "tags": [
+        "Future",
+        "volatility-targeting",
+        "multi-future",
+        "monthly"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-stop-loss-atr",
+      "name": "Future ES ATR Stop-Loss",
+      "description": "Trades ES Future on 50/200 SMA cross with a 2*ATR stop_market_order managed dynamically.",
+      "spec": "Asset: ES continuous. Daily. 2023-01-01 to 2024-12-31, $100k. SMA(50)/SMA(200) entry on mapped; on entry submit stop_market at entry-2*ATR(14). Cancel on flip. Demonstrates: ATR stop on Future, stop_market_order mechanics. Edge case: cancel on roll and re-submit.",
+      "tags": [
+        "Future",
+        "stop-loss",
+        "atr",
+        "order-types"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-bracket-orders",
+      "name": "Future ES Bracket Orders",
+      "description": "Wraps each ES entry with a paired limit profit-target and stop-loss — bracket order pattern on Future.",
+      "spec": "Asset: ES continuous. Daily. 2023-01-01 to 2024-12-31, $100k. EMA(20)/EMA(50) entry on mapped; on entry submit limit (entry+50pts target) and stop_market (entry-25pts stop) — cancel-on-other-fill. Demonstrates: bracket on Future, OCO across legs. Edge case: cancel both children on roll.",
+      "tags": [
+        "Future",
+        "order-types",
+        "bracket-orders",
+        "oco-orders"
+      ],
+      "reference_template": "trade-management"
+    },
+    {
+      "folder": "future-supertrend-cl",
+      "name": "Future CL SuperTrend",
+      "description": "Trades continuous CL Future with a 14-period 3x ATR custom SuperTrend.",
+      "spec": "Asset: CL continuous. Daily. 2023-01-01 to 2024-12-31, $100k. ATR(14)*3 SuperTrend (custom indicator). Long mapped when price > SuperTrend; flat when below. Demonstrates: custom indicator on Future, ATR-based regime line. Edge case: skip first 30 bars for warm-up.",
+      "tags": [
+        "Future",
+        "custom-indicator",
+        "supertrend",
+        "crude-oil"
+      ],
+      "reference_template": "custom-indicator"
+    },
+    {
+      "folder": "future-roll-tracking",
+      "name": "Future Roll Tracking and PnL Attribution",
+      "description": "Tracks every SymbolChangedEvent on ES and logs a custom Series of cumulative roll cost.",
+      "spec": "Asset: ES continuous. Daily. 2023-01-01 to 2024-12-31, $100k. EMA(20)/EMA(50) cross trades; on every SymbolChangedEvent capture old.close vs new.close as roll cost; plot cumulative on a custom Series. Demonstrates: SymbolChangedEvents accounting, charting roll cost. Edge case: only count rolls that occur while invested.",
+      "tags": [
+        "Future",
+        "contract-rolling",
+        "charting",
+        "es-mini"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "future-mes-mnq-pairs",
+      "name": "Future MES vs MNQ Pairs",
+      "description": "Trades the MES/MNQ ratio on a 30-day z-score (small-cap vs tech mini-Nasdaq).",
+      "spec": "Assets: MES, MNQ continuous. Daily. 2023-01-01 to 2024-12-31, $100k. ratio = MES/MNQ; SMA(30), STD(30) -> z. Long MES short MNQ at z<-2; opposite>2; exit 0. Demonstrates: micro-mini cross-index pairs, mapped trading. Edge case: re-fit hedge ratio monthly.",
+      "tags": [
+        "Future",
+        "pairs-trading",
+        "micro-mini",
+        "zscore"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "option-short-strangle-spy",
+      "name": "Option SPY Short Strangle",
+      "description": "Sells weekly SPY short strangles at 15 delta call and 15 delta put, exiting at expiry.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: pick 15 delta call and 15 delta put expiring next Friday. Combo sell. Demonstrates: short strangle, delta-based filter, weekly cycle. Edge case: ensure greeks present (filter.greeks/include_greeks).",
+      "tags": [
+        "Option",
+        "short-strangle",
+        "option-strategies",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-long-strangle-spy",
+      "name": "Option SPY Long Strangle",
+      "description": "Buys weekly SPY long strangles at 25 delta call and 25 delta put around major macro releases.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Buy 25-delta call and 25-delta put expiring 7 days out, on the Monday before each FOMC meeting (custom calendar). Demonstrates: long strangle, calendar-aware entries. Edge case: skip weeks without macro release.",
+      "tags": [
+        "Option",
+        "long-strangle",
+        "option-strategies",
+        "scheduled-event"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-bull-put-spread",
+      "name": "Option SPY Bull Put Spread",
+      "description": "Sells weekly bull put spreads on SPY: short put at 30 delta, long put 5 strikes lower.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: short put nearest 30 delta, long put 5 strikes lower; same expiry next Friday. Demonstrates: 2-leg credit spread, delta-based short, fixed-width long. Edge case: skip if width unavailable.",
+      "tags": [
+        "Option",
+        "bull-put-spread",
+        "option-strategies",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-bear-call-spread",
+      "name": "Option SPY Bear Call Spread",
+      "description": "Sells weekly bear call spreads on SPY: short call at 30 delta, long call 5 strikes higher.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: short call nearest 30 delta, long call 5 strikes higher; same expiry next Friday. Demonstrates: 2-leg credit spread (call side). Edge case: skip if either leg unpriced.",
+      "tags": [
+        "Option",
+        "bear-call-spread",
+        "option-strategies",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-bull-call-spread-spy",
+      "name": "Option SPY Bull Call Spread",
+      "description": "Buys weekly bull call spreads on SPY: long call at 30 delta, short call 5 strikes higher (debit).",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: long call nearest 30 delta, short call 5 strikes higher; same expiry next Friday. Demonstrates: debit vertical spread on Equity Option. Edge case: skip if cost > 50% of width (poor reward/risk).",
+      "tags": [
+        "Option",
+        "bull-call-spread",
+        "option-strategies",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-bear-put-spread-spy",
+      "name": "Option SPY Bear Put Spread",
+      "description": "Buys weekly bear put spreads on SPY: long put at 30 delta, short put 5 strikes lower (debit).",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: long put nearest 30 delta, short put 5 strikes lower; same expiry next Friday. Demonstrates: debit vertical spread (put side). Edge case: ensure adequate liquidity at both strikes.",
+      "tags": [
+        "Option",
+        "bear-put-spread",
+        "option-strategies",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-iron-butterfly-spy",
+      "name": "Option SPY Iron Butterfly",
+      "description": "Sells weekly SPY iron butterflies with short strikes ATM and long wings 5 strikes away.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: short ATM call+put; long call 5 higher and long put 5 lower; same Friday expiry. Demonstrates: 4-leg iron butterfly, ATM-anchored selection. Edge case: handle even strike grids.",
+      "tags": [
+        "Option",
+        "iron-butterfly",
+        "option-strategies",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-broken-wing-butterfly",
+      "name": "Option SPY Broken-Wing Butterfly",
+      "description": "Sells weekly SPY broken-wing call butterflies (short ATM call, long call +5, long call +10, ratio 1:1:1).",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Long ATM call, short 2x +5 strike calls, long +10 strike call; weekly Friday expiry. Demonstrates: asymmetric butterfly, multi-leg combo. Edge case: ensure ratio integer multiples.",
+      "tags": [
+        "Option",
+        "broken-wing-butterfly",
+        "option-strategies",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-calendar-spread-spy",
+      "name": "Option SPY Calendar Spread",
+      "description": "Sells the front-week ATM call and buys the next-week ATM call on SPY (long calendar).",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: short next-Friday ATM call + long Friday-after-next ATM call. Close on front expiry. Demonstrates: calendar spread (different expiries same strike). Edge case: handle case where second expiry lacks ATM strike.",
+      "tags": [
+        "Option",
+        "calendar-spread",
+        "option-strategies",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-diagonal-call-spread",
+      "name": "Option SPY Diagonal Call Spread",
+      "description": "Buys a 30-day OTM call and sells a weekly ATM call against it on SPY.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: ensure long 30-DTE OTM call (5 strikes OTM); roll weekly short ATM call expiring Friday. Demonstrates: diagonal spread, weekly short-leg roll vs longer long. Edge case: open new long when prior one has <14 DTE.",
+      "tags": [
+        "Option",
+        "diagonal-spread",
+        "option-strategies",
+        "weekly-roll"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-cash-secured-put",
+      "name": "Option SPY Cash-Secured Put",
+      "description": "Sells weekly OTM cash-secured puts on SPY at 20 delta, taking assignment if put closes ITM.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: short put nearest 20 delta expiring Friday; cash reserved equal to strike*100*qty. If assigned, hold underlying briefly then sell next Monday. Demonstrates: cash-secured put, assignment handling. Edge case: ensure cash sufficient.",
+      "tags": [
+        "Option",
+        "cash-secured-put",
+        "option-strategies",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-collar-aapl",
+      "name": "Option AAPL Collar",
+      "description": "Holds 100 shares AAPL with a monthly collar (long 5% OTM put, short 5% OTM call).",
+      "spec": "Asset: AAPL + AAPL Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Buy 100 AAPL on first day; each month: long 5% OTM put + short 5% OTM call expiring 30 days out. Demonstrates: collar, hedge of equity holding. Edge case: roll on expiry, not on strike threshold.",
+      "tags": [
+        "Option",
+        "collar",
+        "option-strategies",
+        "monthly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-married-put-aapl",
+      "name": "Option AAPL Married Put",
+      "description": "Buys 100 shares of AAPL together with an ATM put each month for downside protection.",
+      "spec": "Asset: AAPL + AAPL Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month: ensure long 100 AAPL + long ATM put 30-DTE. Roll put on expiry. Demonstrates: married put, ongoing protective put roll. Edge case: when assignment occurs, re-buy underlying.",
+      "tags": [
+        "Option",
+        "married-put",
+        "option-strategies",
+        "monthly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-protective-put-spy",
+      "name": "Option SPY Protective Put",
+      "description": "Holds long SPY with quarterly OTM put protection at -10% strike.",
+      "spec": "Asset: SPY + SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Long 100 SPY; quarterly: buy put at -10% from spot, expiring 90 DTE. Roll on expiry. Demonstrates: long-dated protective put, quarterly schedule. Edge case: handle put expiring ITM (cash-settle then re-buy).",
+      "tags": [
+        "Option",
+        "protective-put",
+        "option-strategies",
+        "quarterly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-ratio-call-spread",
+      "name": "Option SPY 1:2 Ratio Call Spread",
+      "description": "Sells 1 ATM SPY call and 2 OTM (+5 strikes) calls weekly as a ratio call spread.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: short 1x ATM call, short 2x +5-strike call expiring Friday. Demonstrates: ratio (asymmetric naked) call spread, multi-leg combo. Edge case: cap notional risk — small qty.",
+      "tags": [
+        "Option",
+        "ratio-spread",
+        "option-strategies",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-jade-lizard-spy",
+      "name": "Option SPY Jade Lizard",
+      "description": "Sells a weekly SPY jade lizard (short put + short call vertical) where total credit > call width — eliminates upside risk.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: short put 30-delta + short ATM call + long call 5-strikes higher; ensure total credit > call spread width. Demonstrates: jade lizard combo, premium engineering, multi-leg combo. Edge case: skip if credit insufficient.",
+      "tags": [
+        "Option",
+        "jade-lizard",
+        "option-strategies",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-iron-condor-aapl",
+      "name": "Option AAPL Iron Condor",
+      "description": "Sells monthly AAPL iron condors with short strikes 10 delta and long wings 5 strikes wider.",
+      "spec": "Asset: AAPL Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Monthly schedule: pick AAPL options with 30 DTE; short call/put at 10-delta; long wings 5 strikes wider. Demonstrates: iron condor on a single name (vs SPY), monthly cycle. Edge case: skip if greeks unavailable.",
+      "tags": [
+        "Option",
+        "iron-condor",
+        "single-name",
+        "monthly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-earnings-straddle",
+      "name": "Option AAPL Earnings Long Straddle",
+      "description": "Buys an ATM straddle on AAPL the day before its earnings release (using EODHD upcoming-earnings dataset).",
+      "spec": "Asset: AAPL Equity Options + EODHDUpcomingEarnings custom data. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. On detection of next-day earnings: buy ATM call+put 7 DTE. Close 1 day after release. Demonstrates: alt-data-driven option entry, ATM straddle. Edge case: skip if no chain available.",
+      "tags": [
+        "Option",
+        "earnings",
+        "long-straddle",
+        "alternative-data"
+      ],
+      "reference_template": "alternative-data-universe"
+    },
+    {
+      "folder": "option-vol-rank-iv-percentile",
+      "name": "Option SPY IV Rank Filter",
+      "description": "Sells SPY iron condors only when the 30-day IV rank > 60 (high volatility regime).",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Track 252-day RollingWindow of ATM 30D IV; compute IV rank. If rank>60 each Monday: sell short-strangle/iron-condor; else flat. Demonstrates: IV-rank-gated short premium, RollingWindow over IV. Edge case: skip during warm-up period.",
+      "tags": [
+        "Option",
+        "iv-rank",
+        "implied-volatility",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-zero-dte-credit",
+      "name": "Option SPY 0DTE Credit Spread",
+      "description": "Sells 0DTE SPY credit spreads (call or put side based on ORB direction) every weekday morning.",
+      "spec": "Asset: SPY Equity Options. Minute. 2024-09-01 to 2024-12-31, $50k. data_normalization_mode RAW. At 10:05 ET: if ORB-up sell put credit spread 5 strikes wide; if ORB-down sell call credit spread. 0DTE expiry. Close at 15:55. Demonstrates: 0DTE on equity options (different from SPX templates), ORB-driven side. Edge case: avoid if range too tight (no clear ORB).",
+      "tags": [
+        "Option",
+        "zero-dte",
+        "credit-spread",
+        "intraday"
+      ],
+      "reference_template": "intraday-index-options-selection"
+    },
+    {
+      "folder": "option-poor-mans-covered-call",
+      "name": "Option Poor Man's Covered Call",
+      "description": "Buys a deep ITM 90-DTE call on SPY and sells a weekly OTM call against it (LEAPS-style proxy).",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Maintain long ITM call (delta>0.7, 90 DTE); each Monday short 30-delta call expiring Friday. Roll long when <30 DTE. Demonstrates: PMCC diagonal, long-leg refresh logic. Edge case: skip short if long too close to expiry.",
+      "tags": [
+        "Option",
+        "pmcc",
+        "diagonal-spread",
+        "weekly-roll"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-delta-hedged-call",
+      "name": "Option AAPL Delta-Hedged Long Call",
+      "description": "Buys a 30 DTE OTM call on AAPL and dynamically delta-hedges with the underlying daily.",
+      "spec": "Asset: AAPL + AAPL Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Buy 30-DTE 5-pct OTM call. Each EOD compute portfolio delta (call_delta * qty * 100 + shares); short shares to net delta = 0. Demonstrates: delta hedging via greeks, daily rebalance. Edge case: ensure greeks present in chain.",
+      "tags": [
+        "Option",
+        "delta-hedge",
+        "greeks",
+        "daily-rebalance"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-gamma-scalping",
+      "name": "Option SPY Gamma Scalping Long Straddle",
+      "description": "Holds a 30-DTE ATM long straddle on SPY and re-hedges delta back to 0 every minute when |delta|>0.05.",
+      "spec": "Asset: SPY + SPY Equity Options. Minute. 2024-09-01 to 2024-12-31, $100k. data_normalization_mode RAW. Buy ATM call+put 30-DTE. Each minute compute portfolio delta; if |delta|>5 (1 contract = 100 shares), hedge with SPY shares. Demonstrates: gamma scalping, intraday delta re-hedge. Edge case: avoid hedging in last 30 min before close.",
+      "tags": [
+        "Option",
+        "gamma-scalping",
+        "delta-hedge",
+        "intraday"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-theta-harvest-strangle",
+      "name": "Option SPY Theta Harvest Strangle",
+      "description": "Sells weekly SPY 10-delta strangles only when 5-day SPY realized vol is below 30-day median.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. STD(5) and STD(30) on SPY returns. Each Monday: if 5-day vol < median(30-day vol), short 10-delta strangle expiring Friday. Demonstrates: regime-gated theta harvest, vol-based filter. Edge case: skip during macro release weeks.",
+      "tags": [
+        "Option",
+        "short-strangle",
+        "theta-harvest",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-leveraged-etf-call",
+      "name": "Option TQQQ Long Call",
+      "description": "Buys 30-DTE 5-delta calls on leveraged ETF TQQQ each month (lottery-ticket style).",
+      "spec": "Asset: TQQQ Equity Options. Daily. 2023-01-01 to 2024-12-31, $50k. data_normalization_mode RAW. Each month: long 5-delta call 30 DTE on TQQQ. Hold to expiry. Demonstrates: lottery-style options on leveraged ETF, low delta selection. Edge case: cap monthly spend at $1k.",
+      "tags": [
+        "Option",
+        "leveraged-etf",
+        "long-call",
+        "monthly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-univ-aapl-vertical-rank",
+      "name": "Option AAPL Vertical Rank By IV",
+      "description": "Each week sells a vertical credit spread on AAPL (call or put) on the side with the higher IV skew.",
+      "spec": "Asset: AAPL Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: compute call-side and put-side ATM IV; sell spread on higher-IV side (5-wide, 30-delta short). Weekly cycle. Demonstrates: skew-driven side selection, IV comparison. Edge case: require greeks present.",
+      "tags": [
+        "Option",
+        "skew",
+        "credit-spread",
+        "weekly"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-univ-multi-equity-condor",
+      "name": "Option Multi-Equity Iron Condor Basket",
+      "description": "Sells weekly iron condors on AAPL, MSFT, AMZN and rebalances margin across the 3 names equally.",
+      "spec": "Asset: AAPL, MSFT, AMZN Equity Options. Daily. 2023-01-01 to 2024-12-31, $200k. data_normalization_mode RAW. Each Monday: 4-leg iron condor on each name with 10-delta shorts and 5-strike wings. Equal margin allocation. Demonstrates: multi-name option universe, parallel option strategies. Edge case: skip a name if any leg unpriced.",
+      "tags": [
+        "Option",
+        "iron-condor",
+        "multi-equity",
+        "weekly"
+      ],
+      "reference_template": "equity-options-universe"
+    },
+    {
+      "folder": "option-conversion-arbitrage",
+      "name": "Option SPY Conversion Arbitrage",
+      "description": "Detects mispriced SPY options where put-call parity deviates >$0.05 and trades the conversion arbitrage.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. For ATM strike compute synthetic = call - put + PV(strike); compare to spot. If diff>0.05 long SPY + short call + long put (conversion); reverse if -0.05. Demonstrates: put-call parity arbitrage, multi-leg synthetic. Edge case: tight execution tolerance.",
+      "tags": [
+        "Option",
+        "put-call-parity",
+        "arbitrage",
+        "synthetic"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "option-greeks-rolling-hedge",
+      "name": "Option Greeks-Driven Hedge Sizing",
+      "description": "Maintains long SPY straddle and rebalances vega exposure to a target via call-only adjustments weekly.",
+      "spec": "Asset: SPY Equity Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Long ATM call+put 30 DTE. Each Friday compute portfolio vega; if |vega|>target add/remove ATM calls to bring vega back. Demonstrates: vega tracking, greek-based rebalance, weekly. Edge case: skip if greeks not present in chain data.",
+      "tags": [
+        "Option",
+        "vega-hedge",
+        "greeks",
+        "weekly-rebalance"
+      ],
+      "reference_template": "equity-options-static"
+    },
+    {
+      "folder": "indexoption-spx-iron-condor-monthly",
+      "name": "IndexOption SPX Monthly Iron Condor",
+      "description": "Sells SPX iron condors at the 3rd Friday expiry each month with 10-delta shorts and 25-wide wings.",
+      "spec": "Asset: SPX Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Open trade on first Monday of each month: 4-leg iron condor expiring 3rd Friday; 10-delta shorts, 25-strike wings. Close at expiry. Demonstrates: 4-leg SPX condor, monthly cycle. Edge case: respect SPX cash-settled expiry mechanics.",
+      "tags": [
+        "IndexOption",
+        "iron-condor",
+        "spx",
+        "monthly"
+      ],
+      "reference_template": "index-options-static"
+    },
+    {
+      "folder": "indexoption-spx-iron-butterfly",
+      "name": "IndexOption SPX Iron Butterfly",
+      "description": "Sells SPX iron butterflies at the next monthly expiry with ATM shorts and 50-strike wings.",
+      "spec": "Asset: SPX Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month first Monday: 4-leg iron butterfly expiring 3rd Friday; ATM call+put short, 50-strike-wide longs. Demonstrates: SPX iron butterfly. Edge case: ensure 50-wide strikes exist.",
+      "tags": [
+        "IndexOption",
+        "iron-butterfly",
+        "spx",
+        "monthly"
+      ],
+      "reference_template": "index-options-static"
+    },
+    {
+      "folder": "indexoption-spx-short-strangle",
+      "name": "IndexOption SPX Short Strangle",
+      "description": "Sells SPX short strangles at 15-delta call/put expiring monthly.",
+      "spec": "Asset: SPX Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Open monthly: short 15-delta call and 15-delta put expiring 3rd Friday. Demonstrates: short strangle on SPX, monthly cycle. Edge case: pause during weeks with FOMC.",
+      "tags": [
+        "IndexOption",
+        "short-strangle",
+        "spx",
+        "monthly"
+      ],
+      "reference_template": "index-options-static"
+    },
+    {
+      "folder": "indexoption-spxw-zero-dte-condor",
+      "name": "IndexOption SPXW 0DTE Condor",
+      "description": "Sells SPXW 0DTE iron condors each morning at 09:35 with 5-wide wings and 5-delta shorts.",
+      "spec": "Asset: SPXW Index Options. Minute. 2024-09-01 to 2024-12-31, $50k. data_normalization_mode RAW. At 09:35 each weekday: filter chain expiring same day; short 5-delta call/put; long 5-strike-wider wings. Close at 15:55. Demonstrates: 0DTE iron condor on SPXW, intraday entry. Edge case: skip if liquidity insufficient at strikes.",
+      "tags": [
+        "IndexOption",
+        "iron-condor",
+        "zero-dte",
+        "spxw"
+      ],
+      "reference_template": "index-options-universe"
+    },
+    {
+      "folder": "indexoption-rut-short-strangle",
+      "name": "IndexOption RUT Short Strangle",
+      "description": "Sells monthly RUT (Russell 2000) short strangles at 15-delta call/put on the 3rd Friday cycle.",
+      "spec": "Asset: RUT Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month first Monday: short 15-delta strangle expiring 3rd Friday. Demonstrates: short strangle on RUT (vs SPX), monthly. Edge case: skip names with insufficient liquidity at strikes.",
+      "tags": [
+        "IndexOption",
+        "short-strangle",
+        "rut",
+        "monthly"
+      ],
+      "reference_template": "index-options-static"
+    },
+    {
+      "folder": "indexoption-ndx-iron-condor",
+      "name": "IndexOption NDX Iron Condor",
+      "description": "Sells NDX (Nasdaq 100) iron condors monthly at 10 delta with 50-wide wings.",
+      "spec": "Asset: NDX Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month first Monday: 4-leg iron condor 30 DTE; 10-delta shorts, 50-strike wings. Demonstrates: NDX iron condor, monthly cycle. Edge case: NDX strikes are wider — adjust width accordingly.",
+      "tags": [
+        "IndexOption",
+        "iron-condor",
+        "ndx",
+        "monthly"
+      ],
+      "reference_template": "index-options-static"
+    },
+    {
+      "folder": "indexoption-spx-calendar",
+      "name": "IndexOption SPX Calendar Spread",
+      "description": "Sells front-month SPX ATM call and buys back-month ATM call (long calendar).",
+      "spec": "Asset: SPX Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month: short next monthly ATM call + long second-month ATM call. Close on front expiry. Demonstrates: calendar spread on SPX, multi-expiry. Edge case: handle missing back-month at start of cycle.",
+      "tags": [
+        "IndexOption",
+        "calendar-spread",
+        "spx",
+        "monthly-roll"
+      ],
+      "reference_template": "index-options-static"
+    },
+    {
+      "folder": "indexoption-spx-bull-put-spread",
+      "name": "IndexOption SPX Bull Put Spread",
+      "description": "Sells weekly SPXW bull put spreads at 30-delta short put and 25-strike-wider long put.",
+      "spec": "Asset: SPXW Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: short put nearest 30 delta, long put 25 strikes lower; expiry next Friday. Demonstrates: SPX put credit spread, weekly. Edge case: ensure spread width strike exists.",
+      "tags": [
+        "IndexOption",
+        "bull-put-spread",
+        "spxw",
+        "weekly"
+      ],
+      "reference_template": "index-options-universe"
+    },
+    {
+      "folder": "indexoption-spx-bear-call-spread",
+      "name": "IndexOption SPXW Bear Call Spread",
+      "description": "Sells weekly SPXW bear call spreads at 30-delta short call and 25-strike-wider long call.",
+      "spec": "Asset: SPXW Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: short call nearest 30 delta, long call 25 strikes higher; expiry next Friday. Demonstrates: SPX call credit spread (call side), weekly. Edge case: skip if only one of the legs available.",
+      "tags": [
+        "IndexOption",
+        "bear-call-spread",
+        "spxw",
+        "weekly"
+      ],
+      "reference_template": "index-options-universe"
+    },
+    {
+      "folder": "indexoption-spx-double-diagonal",
+      "name": "IndexOption SPX Double Diagonal",
+      "description": "Combines a long SPX 60-DTE OTM strangle with weekly short ATM strangles to harvest theta.",
+      "spec": "Asset: SPX Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Maintain long 60-DTE 25-delta strangle. Each Monday: short ATM strangle expiring Friday. Roll long strangle when <30 DTE. Demonstrates: double diagonal, multi-expiry combo. Edge case: skip short if long < 30 DTE.",
+      "tags": [
+        "IndexOption",
+        "double-diagonal",
+        "spx",
+        "weekly-roll"
+      ],
+      "reference_template": "index-options-static"
+    },
+    {
+      "folder": "indexoption-spx-vix-gating",
+      "name": "IndexOption SPX Iron Condor with VIX Gate",
+      "description": "Sells SPX iron condors only when VIX is above 18 — gating short premium by IV regime.",
+      "spec": "Asset: SPX Index Options + VIX index. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Monday: if VIX>18 sell 30-DTE iron condor at 10-delta and 50-wide wings; else flat. Demonstrates: VIX-regime-gated SPX condor, index data input. Edge case: skip when VIX missing.",
+      "tags": [
+        "IndexOption",
+        "iron-condor",
+        "vix-gate",
+        "spx"
+      ],
+      "reference_template": "index-options-static"
+    },
+    {
+      "folder": "indexoption-spxw-greeks-vega",
+      "name": "IndexOption SPXW Vega-Targeting",
+      "description": "Maintains a long SPXW 30-DTE ATM straddle and rebalances when portfolio vega drifts above $50/$1vol.",
+      "spec": "Asset: SPXW Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Long ATM call+put 30 DTE; each EOD compute aggregate vega; if |vega|>50 trim ATM contracts to bring vega back. Demonstrates: vega tracking on SPXW, greeks computation. Edge case: skip when greeks missing.",
+      "tags": [
+        "IndexOption",
+        "vega-targeting",
+        "greeks",
+        "spxw"
+      ],
+      "reference_template": "intraday-greeks-based-options-selection"
+    },
+    {
+      "folder": "indexoption-spx-jade-lizard",
+      "name": "IndexOption SPX Jade Lizard",
+      "description": "Sells SPX monthly jade lizards (short put + short call vertical) where total credit > call width.",
+      "spec": "Asset: SPX Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. First Monday of month: 30-DTE short put 30-delta + short ATM call + long call +25 strikes; ensure total credit > call width. Demonstrates: jade lizard on SPX, multi-leg combo. Edge case: skip if credit insufficient.",
+      "tags": [
+        "IndexOption",
+        "jade-lizard",
+        "spx",
+        "monthly"
+      ],
+      "reference_template": "index-options-static"
+    },
+    {
+      "folder": "indexoption-spx-broken-wing-butterfly",
+      "name": "IndexOption SPX Broken-Wing Butterfly",
+      "description": "Sells SPX broken-wing put butterflies (long ATM put, short 2x +25 strike puts, long +50 strike put) monthly.",
+      "spec": "Asset: SPX Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month: long ATM put, short 2x put +25 strikes lower, long put +50 strikes lower; same 3rd-Friday expiry. Demonstrates: asymmetric butterfly on SPX, ratio combo. Edge case: ensure 50-wide strikes exist on chain.",
+      "tags": [
+        "IndexOption",
+        "broken-wing-butterfly",
+        "spx",
+        "monthly"
+      ],
+      "reference_template": "index-options-static"
+    },
+    {
+      "folder": "indexoption-vix-options-spike",
+      "name": "IndexOption VIX Long Call Hedge",
+      "description": "Buys VIX 30-DTE 30-delta calls when VIX index drops below 14 (cheap-protection regime).",
+      "spec": "Asset: VIX Index Options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Daily: if VIX<14 and no open calls, buy 30-DTE 30-delta VIX call. Hold until expiry or VIX>20. Demonstrates: VIX index option for tail hedging, regime-gated entry. Edge case: ensure VIXW chain availability.",
+      "tags": [
+        "IndexOption",
+        "vix-options",
+        "tail-hedge",
+        "long-call"
+      ],
+      "reference_template": "index-options-static"
+    },
+    {
+      "folder": "futureoption-es-iron-condor",
+      "name": "FutureOption ES Iron Condor",
+      "description": "Sells ES (E-mini S&P) future-option iron condors monthly with 10-delta shorts and 25-strike wings.",
+      "spec": "Asset: ES future + ES future options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month: filter ES future options expiring 30 DTE; 4-leg iron condor 10-delta shorts. Demonstrates: future options iron condor, set_filter on FOPS chain. Edge case: select correct underlying future contract.",
+      "tags": [
+        "FutureOption",
+        "iron-condor",
+        "es-mini",
+        "monthly"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "futureoption-es-short-strangle",
+      "name": "FutureOption ES Short Strangle",
+      "description": "Sells monthly ES future-option short strangles at 15-delta call/put.",
+      "spec": "Asset: ES future + ES future options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month: short 15-delta call + 15-delta put expiring ~30 DTE. Demonstrates: short strangle on ES future options, monthly. Edge case: filter to liquid front-month chains.",
+      "tags": [
+        "FutureOption",
+        "short-strangle",
+        "es-mini",
+        "monthly"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "futureoption-cl-long-straddle",
+      "name": "FutureOption CL Long Straddle",
+      "description": "Buys ATM call and put on CL (Crude Oil) future options 7 days before each EIA storage report.",
+      "spec": "Asset: CL future + CL future options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each Wednesday morning: buy ATM call+put expiring 7 DTE. Close 1 day after report. Demonstrates: event-driven long straddle on CL, weekly cycle. Edge case: skip if mapped contract is rolling.",
+      "tags": [
+        "FutureOption",
+        "long-straddle",
+        "crude-oil",
+        "weekly"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "futureoption-gc-bull-put-spread",
+      "name": "FutureOption GC Bull Put Spread",
+      "description": "Sells monthly bull put spreads on Gold future options at 30-delta short, $25-wide long.",
+      "spec": "Asset: GC future + GC future options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month: 30-DTE short put 30-delta + long put $25 lower. Demonstrates: gold future option credit spread. Edge case: ensure gold chain has the chosen width.",
+      "tags": [
+        "FutureOption",
+        "bull-put-spread",
+        "gold",
+        "monthly"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "futureoption-zb-bear-call",
+      "name": "FutureOption ZB Bear Call Spread",
+      "description": "Sells monthly bear call spreads on ZB (30Y Treasury) future options at 30-delta short, $2-wide long.",
+      "spec": "Asset: ZB future + ZB future options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. 30-DTE short call 30-delta + long call $2 higher. Demonstrates: bond future option credit spread (call side). Edge case: handle ZB tick size 1/32 in strike grid.",
+      "tags": [
+        "FutureOption",
+        "bear-call-spread",
+        "treasury-bond",
+        "monthly"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "futureoption-cl-iron-condor",
+      "name": "FutureOption CL Iron Condor",
+      "description": "Sells monthly Crude Oil future-option iron condors with 10-delta shorts and $5 wings.",
+      "spec": "Asset: CL future + CL future options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month: 4-leg iron condor 30 DTE; 10-delta shorts, $5-wide wings. Demonstrates: oil future option iron condor. Edge case: avoid roll period for underlying.",
+      "tags": [
+        "FutureOption",
+        "iron-condor",
+        "crude-oil",
+        "monthly"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "futureoption-ng-short-strangle",
+      "name": "FutureOption NG Short Strangle",
+      "description": "Sells monthly NG (Nat Gas) future-option short strangles at 10-delta call/put.",
+      "spec": "Asset: NG future + NG future options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month: 30-DTE 10-delta short call + 10-delta short put. Demonstrates: short strangle on NG (high vol). Edge case: pause around weekly EIA storage report.",
+      "tags": [
+        "FutureOption",
+        "short-strangle",
+        "natural-gas",
+        "monthly"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "futureoption-zc-bear-put",
+      "name": "FutureOption ZC Bear Put Spread",
+      "description": "Buys monthly Corn future-option bear put spreads (30-delta long, $0.50 wide short) — debit.",
+      "spec": "Asset: ZC future + ZC future options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month: 30-DTE 30-delta long put + $0.50-wider short put (debit). Demonstrates: agricultural future option debit spread. Edge case: skip USDA WASDE weeks.",
+      "tags": [
+        "FutureOption",
+        "bear-put-spread",
+        "corn",
+        "monthly"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "futureoption-es-calendar-spread",
+      "name": "FutureOption ES Calendar Spread",
+      "description": "Sells front-month ES future-option ATM call and buys back-month ATM call (calendar).",
+      "spec": "Asset: ES future + ES future options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month: short next-month ATM call + long second-month ATM call. Close on front expiry. Demonstrates: calendar spread on ES future options. Edge case: ensure both expiries available.",
+      "tags": [
+        "FutureOption",
+        "calendar-spread",
+        "es-mini",
+        "monthly-roll"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "futureoption-es-vix-gated",
+      "name": "FutureOption ES VIX-Gated Iron Condor",
+      "description": "Sells ES future-option iron condors only when VIX is above 18 (regime gate).",
+      "spec": "Asset: ES future + ES future options + VIX index. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Each month: if VIX>18 open 30-DTE iron condor 10-delta and $25 wings; else flat. Demonstrates: VIX-gated future-option short premium. Edge case: skip if VIX value not yet available.",
+      "tags": [
+        "FutureOption",
+        "iron-condor",
+        "vix-gate",
+        "es-mini"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "futureoption-cl-protective-put",
+      "name": "FutureOption CL Protective Put on Long Future",
+      "description": "Holds long CL future and buys ATM put on CL future options each month for downside protection.",
+      "spec": "Asset: CL future + CL future options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Long mapped CL future; each month: long 30-DTE ATM put. Roll put on expiry. Demonstrates: protective put on future hedge. Edge case: handle CL roll concurrently with put roll.",
+      "tags": [
+        "FutureOption",
+        "protective-put",
+        "crude-oil",
+        "monthly"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "futureoption-gc-delta-hedge",
+      "name": "FutureOption GC Delta-Hedged Call",
+      "description": "Buys 30-DTE OTM call on GC future options and dynamically delta-hedges with the GC future daily.",
+      "spec": "Asset: GC future + GC future options. Daily. 2023-01-01 to 2024-12-31, $100k. data_normalization_mode RAW. Long 30-DTE 25-delta call. Each EOD compute portfolio delta (call_delta * qty * 100 + future qty); short futures to bring delta to 0. Demonstrates: delta hedging across future option + future. Edge case: track future contract multiplier (100 oz GC = $100/$1).",
+      "tags": [
+        "FutureOption",
+        "delta-hedge",
+        "gold",
+        "greeks"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "live-ib-equity",
+      "name": "Live: Interactive Brokers Equity",
+      "description": "Configures Interactive Brokers as the brokerage model for an Equity portfolio (SPY EMA cross).",
+      "spec": "Asset: SPY. Daily. 2024-09-01 to 2024-12-31, $100k. set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN). EMA(50)/EMA(200) cross. Demonstrates: IB brokerage model on Equity, set fee/slippage from brokerage. Edge case: log all order events with broker-specific fields.",
+      "tags": [
+        "Equity",
+        "live-trading",
+        "interactive-brokers",
+        "indicators"
+      ],
+      "reference_template": "financial-advisors"
+    },
+    {
+      "folder": "live-tradier-options",
+      "name": "Live: Tradier Options",
+      "description": "Configures Tradier as the brokerage model for SPY weekly covered calls.",
+      "spec": "Asset: SPY + Equity Options. Daily. 2024-09-01 to 2024-12-31, $50k. set_brokerage_model(BrokerageName.TRADIER, AccountType.MARGIN). data_normalization_mode RAW. Weekly ATM covered call on SPY. Demonstrates: Tradier brokerage model on Equity Options. Edge case: handle Tradier-specific reject codes via brokerage_message_event.",
+      "tags": [
+        "Option",
+        "live-trading",
+        "tradier",
+        "covered-call"
+      ],
+      "reference_template": "live-trading-features"
+    },
+    {
+      "folder": "live-coinbase-crypto",
+      "name": "Live: Coinbase Crypto",
+      "description": "Configures Coinbase as the brokerage model for a BTCUSD EMA cross strategy.",
+      "spec": "Asset: BTCUSD on Coinbase. Hourly. 2024-09-01 to 2024-12-31, $20k. set_brokerage_model(BrokerageName.COINBASE, AccountType.CASH). EMA(20)/EMA(50) cross. Demonstrates: Coinbase brokerage model, cash account on Crypto. Edge case: skip orders when cash<min order size.",
+      "tags": [
+        "Crypto",
+        "live-trading",
+        "coinbase",
+        "indicators"
+      ],
+      "reference_template": "live-trading-features"
+    },
+    {
+      "folder": "live-bitfinex-crypto",
+      "name": "Live: Bitfinex Crypto Margin",
+      "description": "Configures Bitfinex as the brokerage model for BTCUSD with 3x leverage.",
+      "spec": "Asset: BTCUSD on Bitfinex. Hourly. 2024-09-01 to 2024-12-31, $20k. set_brokerage_model(BrokerageName.BITFINEX, AccountType.MARGIN). EMA(20)/EMA(50) cross with 3x notional. Demonstrates: Bitfinex margin trading. Edge case: monitor margin remaining on each order.",
+      "tags": [
+        "Crypto",
+        "live-trading",
+        "bitfinex",
+        "margin"
+      ],
+      "reference_template": "live-trading-features"
+    },
+    {
+      "folder": "live-oanda-forex",
+      "name": "Live: Oanda Forex",
+      "description": "Configures Oanda as the brokerage model for EURUSD with 50:1 leverage and SMA crossover.",
+      "spec": "Asset: EURUSD on Oanda. Hourly. 2024-09-01 to 2024-12-31, $20k. set_brokerage_model(BrokerageName.OANDA_BROKERAGE). SMA(50)/SMA(200) cross with leverage 50. Demonstrates: Oanda brokerage model on Forex, leverage. Edge case: cap nominal exposure to 80% of margin remaining.",
+      "tags": [
+        "Forex",
+        "live-trading",
+        "oanda",
+        "indicators"
+      ],
+      "reference_template": "live-trading-features"
+    },
+    {
+      "folder": "live-bybit-cryptofuture",
+      "name": "Live: Bybit Crypto Futures",
+      "description": "Configures Bybit as the brokerage model for a BTCUSDT perp with 5x leverage and EMA crossover.",
+      "spec": "Asset: BTCUSDT perp on Bybit. Hourly. 2024-09-01 to 2024-12-31, $20k. set_brokerage_model(BrokerageName.BYBIT, AccountType.MARGIN). EMA(20)/EMA(50) cross with 5x leverage. Demonstrates: Bybit Futures brokerage model on perp. Edge case: respect Bybit min increments and lot size.",
+      "tags": [
+        "CryptoFuture",
+        "live-trading",
+        "bybit-futures",
+        "perpetual"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "live-binance-cryptofuture",
+      "name": "Live: Binance Crypto Futures",
+      "description": "Configures Binance Futures as the brokerage model for a BTCUSDT perp with 3x leverage and momentum.",
+      "spec": "Asset: BTCUSDT perp on Binance Futures. Hourly. 2024-09-01 to 2024-12-31, $20k. set_brokerage_model(BrokerageName.BINANCE_FUTURES). ROC(7)>0 long; ROC<0 flat; 3x leverage. Demonstrates: Binance Futures live brokerage model. Edge case: respect symbol activation timing.",
+      "tags": [
+        "CryptoFuture",
+        "live-trading",
+        "binance-futures",
+        "momentum"
+      ],
+      "reference_template": "crypto-futures"
+    },
+    {
+      "folder": "live-zerodha-equity",
+      "name": "Live: Zerodha Equity (India)",
+      "description": "Configures Zerodha as the brokerage model for an Indian-equities EMA crossover (uses INR cash).",
+      "spec": "Asset: NIFTY 50 ETF (or equivalent). Daily. 2024-09-01 to 2024-12-31, INR 1,000,000. set_brokerage_model(BrokerageName.ZERODHA). set_account_currency('INR'). EMA(50)/EMA(200) cross. Demonstrates: Zerodha brokerage model + INR account currency. Edge case: respect NSE / BSE market hours.",
+      "tags": [
+        "Equity",
+        "live-trading",
+        "zerodha",
+        "indian-equities"
+      ],
+      "reference_template": "live-trading-features"
+    },
+    {
+      "folder": "live-tradestation-equity",
+      "name": "Live: TradeStation Equity",
+      "description": "Configures TradeStation as the brokerage model for SPY EMA crossover with margin.",
+      "spec": "Asset: SPY. Daily. 2024-09-01 to 2024-12-31, $100k. set_brokerage_model(BrokerageName.TRADE_STATION, AccountType.MARGIN). EMA(50)/EMA(200) cross. Demonstrates: TradeStation brokerage model. Edge case: handle TradeStation-specific order rejects.",
+      "tags": [
+        "Equity",
+        "live-trading",
+        "tradestation",
+        "indicators"
+      ],
+      "reference_template": "live-trading-features"
+    },
+    {
+      "folder": "live-signal-export-numerai",
+      "name": "Live: Signal Export to NumerAi Signals",
+      "description": "Exports portfolio targets to NumerAi Signals on a weekly schedule.",
+      "spec": "Universe: SPY constituents. Daily. 2024-09-01 to 2024-12-31, $200k. signal_export.add_signal_export_provider(NumeraiSignalExport(api_key='STUB', tournament_id='STUB')). Each Friday: build target weights from a momentum alpha and call set_target_portfolio. Demonstrates: NumerAi Signals export. Edge case: stub credentials in backtest.",
+      "tags": [
+        "Equity",
+        "live-trading",
+        "signal-exports",
+        "numerai"
+      ],
+      "reference_template": "live-trading-features"
+    },
+    {
+      "folder": "live-signal-export-crunch-dao",
+      "name": "Live: Signal Export to Crunch DAO",
+      "description": "Exports portfolio targets to Crunch DAO Signals weekly.",
+      "spec": "Universe: SPY constituents. Daily. 2024-09-01 to 2024-12-31, $200k. signal_export.add_signal_export_provider(CrunchDAOSignalExport(api_key='STUB', model='STUB')). Each Friday set_target_portfolio. Demonstrates: Crunch DAO signal exports. Edge case: degrade gracefully if API is unreachable.",
+      "tags": [
+        "Equity",
+        "live-trading",
+        "signal-exports",
+        "crunch-dao"
+      ],
+      "reference_template": "live-trading-features"
+    },
+    {
+      "folder": "live-commands-listener",
+      "name": "Live: Commands Listener",
+      "description": "Implements a custom Command class to manually pause/resume an SPY EMA cross strategy via API.",
+      "spec": "Asset: SPY. Daily. 2024-09-01 to 2024-12-31, $100k. Define class PauseCommand(Command): def run(...). add_command(PauseCommand). EMA(50)/EMA(200) trades only when not paused. Demonstrates: live commands pattern (different from existing live-trading-features), parameterized command. Edge case: persist pause state across restarts via Object Store.",
+      "tags": [
+        "Equity",
+        "live-trading",
+        "commands",
+        "object-store"
+      ],
+      "reference_template": "live-trading-features"
+    },
+    {
+      "folder": "live-notifications-telegram-webhook",
+      "name": "Live: Telegram Webhook Notifications",
+      "description": "Sends notifications to a Telegram bot via notify.web on every trade fill.",
+      "spec": "Asset: SPY. Daily. 2024-09-01 to 2024-12-31, $100k. EMA(50)/EMA(200) cross. On on_order_event(filled) call notify.web('https://api.telegram.org/...', headers={...}, body='...'). Demonstrates: notify.web for arbitrary HTTP webhook (different from email/SMS in live-trading-features). Edge case: stub URL in backtest mode.",
+      "tags": [
+        "Equity",
+        "live-trading",
+        "notifications",
+        "webhook"
+      ],
+      "reference_template": "live-trading-features"
+    },
+    {
+      "folder": "alternative-data-universe-brainwikipediapageviews",
+      "name": "Alternative Data Universe for Brain Wikipedia Page Views",
+      "description": "Selects US Equities ranked by 5-day change in Brain Wikipedia page views; equal-weights the top 10 with a daily scheduled rebalance.",
+      "spec": "Universe: BrainWikipediaPageViewsUniverse. Daily. 2023-01-01 to 2024-12-31, $100k. Daily selector keeps top 10 by 5-day delta in Wikipedia page-view counts; equal-weight long with a scheduled daily rebalance. Demonstrates: BrainWikipediaPageViewsUniverse alt-data class, ranking by deltas, scheduled equal-weight. Edge case: skip days with zero coverage.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "universe",
+        "wikipedia"
+      ],
+      "reference_template": "alternative-data-universe-brainstockrankinguniverse"
+    },
+    {
+      "folder": "alternative-data-universe-quiverwallstreetbetsuniverse",
+      "name": "Alternative Data Universe for Quiver WallStreetBets",
+      "description": "Selects US Equities mentioned at least 50 times on r/WallStreetBets in the prior day and equal-weights them with a daily scheduled rebalance.",
+      "spec": "Universe: QuiverWallStreetBetsUniverse. Daily. 2023-01-01 to 2024-12-31, $100k. Selector requires WSB mentions >= 50 over prior day; cap to top 10 by mention count; equal-weight long; scheduled daily rebalance. Demonstrates: QuiverWallStreetBetsUniverse alt-data class, social-media-driven equity selection. Edge case: skip days with empty data.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "universe",
+        "social-media"
+      ],
+      "reference_template": "alternative-data-universe-quivercnbcsuniverse"
+    },
+    {
+      "folder": "dataset-eodhd-economic-events",
+      "name": "Dataset: EODHD Economic Events",
+      "description": "Trades SPY around scheduled US economic releases from the EODHD Economic Events calendar — flat 30 minutes each side of any high-importance event.",
+      "spec": "Asset: SPY + EODHDEconomicEvents custom data. Hourly. 2023-01-01 to 2024-12-31, $100k. add_data(EODHDEconomicEvents). On_data of the events feed: build a forward 24h list of high-importance US releases; gate SPY long-only EMA(50)/EMA(200) cross to be flat 30 min around each event. Demonstrates: EODHD Economic Events feed, scheduled blackouts. Edge case: skip events with missing severity.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "economic-events",
+        "scheduled-event"
+      ],
+      "reference_template": "alternative-data-universe"
+    },
+    {
+      "folder": "dataset-extractalpha-true-beats",
+      "name": "Dataset: ExtractAlpha True Beats",
+      "description": "Selects US Equities with a positive ExtractAlpha True Beats score (predicted earnings beat) and equal-weights the top 20 with a daily rebalance.",
+      "spec": "Universe: ExtractAlphaTrueBeats alt-data universe. Daily. 2023-01-01 to 2024-12-31, $200k. Selector requires TrueBeats score > 0; rank by score; equal-weight top 20; daily scheduled rebalance. Demonstrates: ExtractAlphaTrueBeats class, earnings-prediction-driven selection. Edge case: skip days with no data.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "earnings-estimates",
+        "universe"
+      ],
+      "reference_template": "alternative-data-universe-brainstockrankinguniverse"
+    },
+    {
+      "folder": "dataset-extractalpha-estimize",
+      "name": "Dataset: ExtractAlpha Estimize",
+      "description": "Selects US Equities whose Estimize consensus EPS estimate exceeds Wall Street consensus by at least 5%; equal-weights the top 15 daily.",
+      "spec": "Universe: ExtractAlphaEstimize alt-data class. Daily. 2023-01-01 to 2024-12-31, $200k. Selector requires (Estimize EPS - WS consensus)/|WS| > 0.05; rank by spread; equal-weight top 15; daily rebalance. Demonstrates: ExtractAlphaEstimize class, crowd-vs-Wall-St earnings spread, ranking universe. Edge case: drop names with zero/missing WS consensus.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "earnings-estimates",
+        "universe"
+      ],
+      "reference_template": "alternative-data-universe-brainstockrankinguniverse"
+    },
+    {
+      "folder": "dataset-extractalpha-cross-asset-model",
+      "name": "Dataset: ExtractAlpha Cross Asset Model",
+      "description": "Selects US Equities with a positive ExtractAlpha Cross Asset Model factor; equal-weights the top 25 with a daily scheduled rebalance.",
+      "spec": "Universe: ExtractAlphaCrossAssetModel alt-data class. Daily. 2023-01-01 to 2024-12-31, $200k. Selector requires factor > 0; rank by factor; equal-weight top 25; daily schedule. Demonstrates: ExtractAlphaCrossAssetModel class, multi-asset factor signal. Edge case: skip days with NaN factors.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "cross-asset-factor",
+        "universe"
+      ],
+      "reference_template": "alternative-data-universe-brainstockrankinguniverse"
+    },
+    {
+      "folder": "dataset-extractalpha-tactical",
+      "name": "Dataset: ExtractAlpha Tactical",
+      "description": "Selects US Equities with a top-decile ExtractAlpha Tactical short-horizon score; equal-weights the top 10 with a daily rebalance.",
+      "spec": "Universe: ExtractAlphaTactical alt-data class. Daily. 2023-01-01 to 2024-12-31, $200k. Selector ranks by Tactical score and picks top 10 (decile-style cut); equal-weight long; daily schedule. Demonstrates: ExtractAlphaTactical class, short-horizon ranking model, decile cuts. Edge case: skip days with insufficient cross-section.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "tactical-factor",
+        "universe"
+      ],
+      "reference_template": "alternative-data-universe-brainstockrankinguniverse"
+    },
+    {
+      "folder": "dataset-fred-fed-funds-regime",
+      "name": "Dataset: FRED Fed Funds Regime",
+      "description": "Toggles SPY long/flat based on 3-month change in the FRED Effective Federal Funds Rate; long when rates falling, flat when rising.",
+      "spec": "Asset: SPY + FRED Fed Funds custom data (FRED FEDFUNDS). Daily. 2023-01-01 to 2024-12-31, $100k. add_data(FRED, 'FEDFUNDS'). RollingWindow(63) of values; if latest - 63d-ago < 0 hold SPY, else flat. Demonstrates: FRED data subscription, macro regime switch on Equity. Edge case: handle FRED monthly publish lag.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "fred",
+        "macro"
+      ],
+      "reference_template": "alternative-data-universe"
+    },
+    {
+      "folder": "dataset-frbsl-interest-rate",
+      "name": "Dataset: FRBSL US Interest Rate",
+      "description": "Trades TLT vs SHY based on the FRBSL US Interest Rate level — long TLT when below 3%, long SHY otherwise.",
+      "spec": "Assets: TLT, SHY + FRBSL US Interest Rate custom data. Daily. 2023-01-01 to 2024-12-31, $100k. add_data(FRBSL, 'US Interest Rate'). Daily schedule: if latest rate < 3% hold TLT 100%; else hold SHY 100%. Demonstrates: FRBSL data subscription, rate-driven bond ETF rotation. Edge case: handle FRBSL publication delay.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "frbsl",
+        "rates"
+      ],
+      "reference_template": "alternative-data-universe"
+    },
+    {
+      "folder": "dataset-treasury-yield-curve-steepener",
+      "name": "Dataset: Treasury Yield Curve Steepener",
+      "description": "Trades a TLT-vs-IEF steepener based on the US Treasury Department 10y-2y yield curve — long IEF / short TLT when the curve flattens (10y-2y < 0).",
+      "spec": "Assets: TLT, IEF + USTreasuryYieldCurveRate custom data. Daily. 2023-01-01 to 2024-12-31, $100k. add_data(USTreasuryYieldCurveRate). Daily schedule: spread = 10y - 2y; if spread < 0 long IEF / short TLT (50/-50); else flat. Demonstrates: Treasury yield curve dataset, dollar-balanced steepener. Edge case: handle missing tenor data.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "treasury",
+        "yield-curve"
+      ],
+      "reference_template": "alternative-data-universe"
+    },
+    {
+      "folder": "dataset-eia-petroleum-storage",
+      "name": "Dataset: EIA Petroleum Storage",
+      "description": "Trades USO based on the weekly EIA petroleum storage report — short USO if storage builds exceed expectations, long if draws.",
+      "spec": "Asset: USO + USEnergyAPI custom data (weekly storage). Daily. 2023-01-01 to 2024-12-31, $100k. add_data(USEnergyAPI). On Wednesday after release: short USO if delta_vs_prev > 0 (build); long if < 0 (draw). Hold 5 days. Demonstrates: EIA dataset subscription, event-driven trading. Edge case: handle holiday-shifted Thursday releases.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "eia",
+        "energy"
+      ],
+      "reference_template": "alternative-data-universe"
+    },
+    {
+      "folder": "dataset-benzinga-news-sentiment",
+      "name": "Dataset: Benzinga News Sentiment",
+      "description": "Trades AAPL long when the rolling 24h Benzinga news sentiment score on AAPL is positive, flat otherwise.",
+      "spec": "Asset: AAPL + BenzingaNewsFeed for AAPL. Hourly. 2023-01-01 to 2024-12-31, $100k. add_data(BenzingaNewsFeed, 'AAPL'). Maintain rolling 24h average sentiment; long AAPL when avg > 0; flat otherwise. Demonstrates: BenzingaNewsFeed subscription, news-sentiment gating. Edge case: skip headlines with neutral/missing sentiment.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "benzinga",
+        "news"
+      ],
+      "reference_template": "alternative-data-universe"
+    },
+    {
+      "folder": "dataset-tiingo-news-finbert",
+      "name": "Dataset: Tiingo News + FinBERT",
+      "description": "Scores Tiingo News headlines on AAPL with a FinBERT HuggingFace pipeline and trades AAPL long when the daily mean sentiment exceeds 0.6.",
+      "spec": "Asset: AAPL + TiingoNews for AAPL. Daily. 2023-01-01 to 2024-12-31, $100k. add_data(TiingoNews, 'AAPL'). Use transformers.pipeline('sentiment-analysis', 'ProsusAI/finbert') to score titles; long AAPL when daily mean > 0.6, flat otherwise. Demonstrates: Tiingo news + HuggingFace FinBERT integration. Edge case: handle empty news days.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "tiingo",
+        "machine-learning"
+      ],
+      "reference_template": "ai"
+    },
+    {
+      "folder": "dataset-vix-central-contango",
+      "name": "Dataset: VIX Central Contango",
+      "description": "Trades VXX-vs-SVXY based on VIX Central front-second-month contango — short VXX (long SVXY) when contango exceeds 5%.",
+      "spec": "Assets: VXX, SVXY + VIXCentralContango custom data. Daily. 2023-01-01 to 2024-12-31, $100k. add_data(VIXCentralContango). Daily: contango = (M2-M1)/M1; if > 0.05 long SVXY 100%; if < -0.05 long VXX 100%; else flat. Demonstrates: VIX Central term-structure data, contango-driven rotation. Edge case: skip days where M2 missing.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "vix-central",
+        "term-structure"
+      ],
+      "reference_template": "alternative-data-universe"
+    },
+    {
+      "folder": "dataset-sec-form-4-insider-buys",
+      "name": "Dataset: SEC Form 4 Insider Buys",
+      "description": "Selects US Equities with SEC Form 4 insider purchases above $1M in the past 5 days; equal-weights the top 10 with a daily rebalance.",
+      "spec": "Universe: SECReport8K / SECReport4 alt-data class for Form 4. Daily. 2023-01-01 to 2024-12-31, $100k. Selector requires last-5-day insider buy notional > $1M; cap top 10 by total notional; equal-weight long. Daily rebalance. Demonstrates: SEC Form 4 dataset, insider-buy signal aggregation. Edge case: drop sales-only filings.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "sec",
+        "insider-trading"
+      ],
+      "reference_template": "alternative-data-universe-quiverinsidertradinguniverse"
+    },
+    {
+      "folder": "dataset-regalytics-financial-alerts",
+      "name": "Dataset: RegAlytics Financial Alerts",
+      "description": "Trades XLF flat for 24 hours after any RegAlytics financial-sector regulatory alert with severity = high.",
+      "spec": "Asset: XLF + RegalyticsRegulatoryArticle alt-data feed. Daily. 2023-01-01 to 2024-12-31, $100k. add_data(RegalyticsRegulatoryArticle). On_data: if any high-severity financial-sector article today, set _flat_until = today+1 day. Hold XLF 100% otherwise; flat during blackout window. Demonstrates: RegAlytics dataset, event-driven blackout pattern. Edge case: handle multiple alerts/day.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "regalytics",
+        "regulatory"
+      ],
+      "reference_template": "alternative-data-universe"
+    },
+    {
+      "folder": "dataset-usda-fruit-vegetables",
+      "name": "Dataset: USDA Fruit & Vegetables",
+      "description": "Trades agricultural Future ZC (Corn) on USDA Fruit & Vegetables price-trend signals — long when 30-day USDA index trending up.",
+      "spec": "Asset: ZC continuous future + USDAFruitAndVegetables custom data. Daily. 2023-01-01 to 2024-12-31, $100k. add_data(USDAFruitAndVegetables); track 30-day ROC of USDA aggregate price index; long mapped ZC when ROC > 0; flat else. Demonstrates: USDA dataset on a Future, ROC over alt-data. Edge case: handle weekly publish cadence.",
+      "tags": [
+        "Future",
+        "alternative-data",
+        "usda",
+        "agricultural"
+      ],
+      "reference_template": "alternative-data-universe"
+    },
+    {
+      "folder": "dataset-kavout-k-score",
+      "name": "Dataset: Kavout K-Score",
+      "description": "Selects US Equities with a Kavout K-Score in the top decile; equal-weights the top 25 with a daily scheduled rebalance.",
+      "spec": "Universe: KavoutKScoreUniverse alt-data class. Daily. 2023-01-01 to 2024-12-31, $200k. Selector ranks by Kavout K-Score; cap top 25 (decile-style cut); equal-weight long; daily schedule. Demonstrates: KavoutKScore dataset, composite-factor-driven equity selection. Edge case: drop names with stale scores (>5 days old).",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "kavout",
+        "factor"
+      ],
+      "reference_template": "alternative-data-universe-brainstockrankinguniverse"
+    },
+    {
+      "folder": "dataset-nasdaq-data-link-shiller-pe",
+      "name": "Dataset: Nasdaq Data Link (Shiller PE)",
+      "description": "Toggles SPY long/flat based on the Shiller PE 10 series from Nasdaq Data Link — flat when CAPE > 35, long when below.",
+      "spec": "Asset: SPY + NasdaqDataLink series ('MULTPL/SHILLER_PE_RATIO_MONTH'). Daily. 2023-01-01 to 2024-12-31, $100k. add_data(NasdaqDataLink, 'MULTPL/SHILLER_PE_RATIO_MONTH'). Daily: hold SPY 100% if latest CAPE < 35; flat else. Demonstrates: NasdaqDataLink data subscription, valuation-regime switch. Edge case: handle monthly publish cadence.",
+      "tags": [
+        "Equity",
+        "alternative-data",
+        "nasdaq-data-link",
+        "valuation"
+      ],
+      "reference_template": "alternative-data-universe"
+    },
+    {
+      "folder": "dataset-blockchain-bitcoin-metadata",
+      "name": "Dataset: Blockchain Bitcoin Metadata",
+      "description": "Trades BTCUSD long when 30-day Bitcoin block-time metadata trends down (faster blocks => more activity), flat when up.",
+      "spec": "Asset: BTCUSD on Coinbase + BitcoinMetadata custom data. Daily. 2023-01-01 to 2024-12-31, $100k. add_data(BitcoinMetadata) for block time and difficulty fields. ROC(30) of average block time; long BTCUSD when ROC < 0, flat when > 0. Demonstrates: Blockchain Bitcoin Metadata dataset, on-chain regime switch (distinct from MVRV/hashrate templates). Edge case: handle stale data.",
+      "tags": [
+        "Crypto",
+        "alternative-data",
+        "blockchain",
+        "btc"
+      ],
+      "reference_template": "alternative-data-universe-coingeckouniverse"
+    },
+    {
+      "folder": "dataset-tickdata-international-futures",
+      "name": "Dataset: TickData International Futures",
+      "description": "Subscribes to the TickData International Futures feed for FDAX (Eurex DAX future) and trades a 50/200 SMA crossover at hourly resolution.",
+      "spec": "Asset: FDAX (Eurex DAX) future via TickData International Futures provider. Hourly. 2023-01-01 to 2024-12-31, $100k. set_security_initializer / configure data provider for TickData; SMA(50)/SMA(200) cross. Demonstrates: TickData International Futures provider on a non-US future, hourly trading. Edge case: respect Eurex hours.",
+      "tags": [
+        "Future",
+        "tick-data",
+        "international-futures",
+        "indicators"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "dataset-algoseek-us-equities-tick",
+      "name": "Dataset: AlgoSeek US Equities Tick",
+      "description": "Subscribes to AlgoSeek US Equities tick data for SPY and trades on bid-ask imbalance computed from QuoteTicks.",
+      "spec": "Asset: SPY via AlgoSeek US Equities tick data provider. Tick. 2024-09-01 to 2024-12-31, $100k. Configure brokerage / data provider for AlgoSeek; subscribe quote ticks; sliding 1-min imbalance = bid_size/(bid_size+ask_size); long if > 0.6, short if < 0.4. Demonstrates: AlgoSeek US Equities tick microstructure trade. Edge case: skip ticks with zero size.",
+      "tags": [
+        "Equity",
+        "tick-data",
+        "algoseek",
+        "microstructure"
+      ],
+      "reference_template": "intraday-indicator-scans"
+    },
+    {
+      "folder": "dataset-algoseek-us-equity-options-tick",
+      "name": "Dataset: AlgoSeek US Equity Options Tick",
+      "description": "Subscribes to AlgoSeek US Equity Options tick data for SPY weekly chain and trades the ATM call on bid-ask imbalance.",
+      "spec": "Asset: SPY Equity Options via AlgoSeek US Equity Options tick provider. Tick (option), Daily (underlying). 2024-09-01 to 2024-12-31, $100k. data_normalization_mode RAW. Filter ATM Friday call; long when 1-min imbalance > 0.6. Demonstrates: AlgoSeek tick options microstructure. Edge case: ensure greeks present.",
+      "tags": [
+        "Option",
+        "tick-data",
+        "algoseek",
+        "microstructure"
+      ],
+      "reference_template": "intraday-greeks-based-options-selection"
+    },
+    {
+      "folder": "dataset-algoseek-us-future-options-tick",
+      "name": "Dataset: AlgoSeek US Future Options Tick",
+      "description": "Subscribes to AlgoSeek US Future Options tick data on ES future options and trades ATM calls on intraday quote imbalance.",
+      "spec": "Asset: ES future options via AlgoSeek US Future Options tick provider. Tick option, Daily underlying. 2024-09-01 to 2024-12-31, $100k. data_normalization_mode RAW. Filter ATM 30-DTE call on ES; long when bid-imbalance > 0.6 in last 1 min. Demonstrates: AlgoSeek tick future options microstructure. Edge case: respect ES roll period.",
+      "tags": [
+        "FutureOption",
+        "tick-data",
+        "algoseek",
+        "microstructure"
+      ],
+      "reference_template": "future-options"
+    },
+    {
+      "folder": "dataset-algoseek-us-futures-tick",
+      "name": "Dataset: AlgoSeek US Futures Tick",
+      "description": "Subscribes to AlgoSeek US Futures tick data on continuous ES and trades on bid-ask imbalance from QuoteTicks.",
+      "spec": "Asset: ES continuous future via AlgoSeek US Futures tick provider. Tick. 2024-09-01 to 2024-12-31, $100k. Configure data provider for AlgoSeek tick futures; sliding 1-min imbalance on ES quotes; long mapped if > 0.6, short if < 0.4. Demonstrates: AlgoSeek tick futures microstructure on continuous contract. Edge case: handle rolls.",
+      "tags": [
+        "Future",
+        "tick-data",
+        "algoseek",
+        "microstructure"
+      ],
+      "reference_template": "futures"
+    },
+    {
+      "folder": "dataset-algoseek-us-index-options-tick",
+      "name": "Dataset: AlgoSeek US Index Options Tick",
+      "description": "Subscribes to AlgoSeek US Index Options tick data on SPXW and trades 0DTE ATM calls on quote imbalance signals.",
+      "spec": "Asset: SPXW Index Options via AlgoSeek US Index Options tick provider. Tick option. 2024-09-01 to 2024-12-31, $100k. data_normalization_mode RAW. Filter 0DTE ATM call; long when 1-min bid-imbalance > 0.6 between 09:35 and 15:00. Flat at 15:55. Demonstrates: AlgoSeek tick index options microstructure on SPXW. Edge case: skip days with insufficient liquidity.",
+      "tags": [
+        "IndexOption",
+        "tick-data",
+        "algoseek",
+        "microstructure"
+      ],
+      "reference_template": "intraday-index-options-selection"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds three project templates, each with matching Python and C# implementations registered in both `project-templates/python/templates.json` and `project-templates/csharp/templates.json`:

- **equity-pairs-trading-cointegration** — trades the KO/PEP spread using a 60-day rolling OLS hedge ratio with z-score entry/exit thresholds, sourcing closes from cached daily market sessions.
- **equity-momentum-cross-sectional-decile** — chains the SPY ETF-constituents universe into a fundamental universe, streams each constituent's adjusted price through a per-symbol momentum indicator, and equal-weights the top decile (capped at the top 100 by dollar volume) on a monthly rebalance.
- **equity-roc-momentum-rank** — rotates monthly into the top-3 sector ETFs ranked by a daily `ROC` indicator, using minute data with `automatic_indicator_warm_up`.

The three built ideas are removed from `project-templates/template-ideas.json`, which is added to the repo as the backlog of un-built template ideas.

## Test plan

- **equity-pairs-trading-cointegration** — Python and C# cloud backtests produce identical statistics.
- **equity-roc-momentum-rank** — Python and C# both compile cleanly; backtests match on the indicator logic.
- **equity-momentum-cross-sectional-decile** — Python and C# both compile and run; their backtests are currently ~1% apart (476 vs 478 orders) from a selection-boundary rank flip between the two runtimes — known, to be reconciled in a follow-up.
