### PR TITLE
Add equity strategy project templates (batch 2)

### DIFF
--- a/project-templates/csharp/equity-all-weather-portfolio/Main.cs
+++ b/project-templates/csharp/equity-all-weather-portfolio/Main.cs
@@ -1,0 +1,169 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class AllWeatherPortfolioAlgorithm : QCAlgorithm
+{
+    private const decimal _driftThreshold = 0.01m;
+
+    private DateTime _lastRebalanceDate;
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(200000);
+
+        var targets = new Dictionary<string, decimal>
+        {
+            { "SPY", 0.30m },
+            { "TLT", 0.40m },
+            { "IEF", 0.15m },
+            { "GLD", 0.075m },
+            { "DBC", 0.075m },
+        };
+
+        foreach (var (ticker, target) in targets)
+        {
+            // Duck-type the target weight onto the security object.
+            dynamic security = AddEquity(ticker, Resolution.Minute);
+            security.Target = target;
+        }
+
+        // Set target weights on the first bar with data.
+        _lastRebalanceDate = StartDate.Date;
+
+        // Annual rebalance on the first trading day of each year.
+        Schedule.On(
+            DateRules.YearStart("SPY", 0),
+            TimeRules.AfterMarketOpen("SPY", 1),
+            Rebalance);
+
+        // Weekly holdings-drift monitoring.
+        Schedule.On(
+            DateRules.WeekStart("SPY"),
+            TimeRules.AfterMarketOpen("SPY", 30),
+            LogDrift);
+    }
+
+    public override void OnWarmupFinished()
+    {
+        Rebalance();
+    }
+
+    private void Rebalance()
+    {
+        var today = Time.Date;
+        if (_lastRebalanceDate == today)
+        {
+            return;
+        }
+
+        var targets = new List<PortfolioTarget>();
+        foreach (var (symbol, security) in Securities)
+        {
+            // Edge case: skip GLD/DBC if missing in early data.
+            if (!security.HasData)
+            {
+                Debug($"Skipping {symbol}: no data available.");
+                continue;
+            }
+
+            targets.Add(new PortfolioTarget(symbol, (decimal)((dynamic)security).Target));
+        }
+
+        if (targets.Count > 0)
+        {
+            SetHoldings(targets, liquidateExistingHoldings: true);
+            Debug($"Rebalanced on {Time}");
+        }
+
+        _lastRebalanceDate = today;
+        LogDrift();
+    }
+
+    private void LogDrift()
+    {
+        var totalValue = Portfolio.TotalPortfolioValue;
+        if (totalValue <= 0)
+        {
+            return;
+        }
+
+        foreach (var (symbol, security) in Securities)
+        {
+            if (!security.HasData)
+            {
+                continue;
+            }
+
+            var target = (decimal)((dynamic)security).Target;
+            var currentWeight = security.Holdings.HoldingsValue / totalValue;
+            var drift = Math.Abs(currentWeight - target);
+            Debug($"{symbol}: target={target:P2}, current={currentWeight:P2}, drift={drift:P2}");
+
+            if (drift > _driftThreshold)
+            {
+                Debug($"{symbol} drift exceeds {_driftThreshold:P2}: {drift:P2}");
+            }
+        }
+    }
+}

--- a/project-templates/csharp/equity-cmf-money-flow/Main.cs
+++ b/project-templates/csharp/equity-cmf-money-flow/Main.cs
@@ -1,0 +1,129 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class ChaikinMoneyFlowXlfAlgorithm : QCAlgorithm
+{
+    private const decimal _longThreshold = 0.10m;
+    private const decimal _shortThreshold = -0.10m;
+
+    private Equity _xlf;
+    private ChaikinMoneyFlow _cmf;
+    private int _previousSignal = 0;  // 1 = long, -1 = short, 0 = flat
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+
+        Settings.AutomaticIndicatorWarmUp = true;
+
+        _xlf = AddEquity("XLF", Resolution.Minute);
+        _cmf = CMF(_xlf.Symbol, 20, Resolution.Minute);
+        PlotIndicator("CMF", _cmf);
+
+        Schedule.On(
+            DateRules.EveryDay(_xlf.Symbol),
+            TimeRules.AfterMarketOpen(_xlf.Symbol, 30),
+            Rebalance
+        );
+    }
+
+    private void Rebalance()
+    {
+        if (!_cmf.IsReady)
+        {
+            return;
+        }
+
+        var cmfValue = _cmf.Current.Value;
+        var signal = 0;
+        if (cmfValue > _longThreshold)
+        {
+            signal = 1;
+        }
+        else if (cmfValue < _shortThreshold)
+        {
+            signal = -1;
+        }
+
+        if (signal == _previousSignal)
+        {
+            return;
+        }
+
+        _previousSignal = signal;
+
+        if (signal == 1)
+        {
+            SetHoldings(_xlf.Symbol, 1m);
+        }
+        else if (signal == -1)
+        {
+            SetHoldings(_xlf.Symbol, -1m);
+        }
+        else
+        {
+            Liquidate(_xlf.Symbol);
+        }
+    }
+}

--- a/project-templates/csharp/equity-monthly-roc-rotation/Main.cs
+++ b/project-templates/csharp/equity-monthly-roc-rotation/Main.cs
@@ -1,0 +1,118 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+
+public class MonthlyRotationAlgorithm : QCAlgorithm
+{
+    private readonly int _rocPeriod = 60;
+    private readonly int _topN = 3;
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+        Settings.AutomaticIndicatorWarmUp = true;
+
+        foreach (var ticker in new[] { "SPY", "EFA", "EEM", "AGG", "GLD" })
+        {
+            dynamic equity = AddEquity(ticker, Resolution.Minute);
+            equity.Roc = ROC(equity, _rocPeriod, Resolution.Daily);
+        }
+
+        Schedule.On(
+            DateRules.MonthStart("SPY"),
+            TimeRules.AfterMarketOpen("SPY", 1),
+            Rebalance);
+    }
+
+    private void Rebalance()
+    {
+        var securities = Securities.Values
+            .Where(security => (bool)((dynamic)security).Roc.IsReady)
+            .ToList();
+        if (securities.Count < _topN)
+        {
+            return;
+        }
+
+        if (securities.All(security => (decimal)((dynamic)security).Roc.Current.Value < 0))
+        {
+            Liquidate();
+            return;
+        }
+
+        var topSymbols = securities
+            .OrderByDescending(security => (decimal)((dynamic)security).Roc.Current.Value)
+            .Take(_topN)
+            .Select(security => security.Symbol)
+            .ToHashSet();
+
+        var weight = 1.0m / _topN;
+        var targets = Securities.Values
+            .Select(security => new PortfolioTarget(
+                security.Symbol, topSymbols.Contains(security.Symbol) ? weight : 0))
+            .ToList();
+
+        SetHoldings(targets, liquidateExistingHoldings: true);
+    }
+}

--- a/project-templates/csharp/equity-opening-range-breakout/Main.cs
+++ b/project-templates/csharp/equity-opening-range-breakout/Main.cs
@@ -1,0 +1,141 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class OpeningRangeBreakoutAlgorithm : QCAlgorithm
+{
+    private static readonly TimeSpan _orbStart = new TimeSpan(9, 30, 0);
+    private static readonly TimeSpan _orbEnd = new TimeSpan(10, 0, 0);
+
+    private Symbol _spy;
+    private decimal? _orbHigh;
+    private decimal? _orbLow;
+
+    public override void Initialize()
+    {
+        SetStartDate(2024, 9, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+        Settings.SeedInitialPrices = true;
+
+        _spy = AddEquity("SPY", Resolution.Minute).Symbol;
+
+        _orbHigh = null;
+        _orbLow = null;
+
+        Schedule.On(
+            DateRules.EveryDay(_spy),
+            TimeRules.At(15, 55),
+            LiquidateEod
+        );
+    }
+
+    private void LiquidateEod()
+    {
+        Liquidate(_spy);
+        // Clearing the range stops further entries and resets it for tomorrow.
+        _orbHigh = null;
+        _orbLow = null;
+    }
+
+    public override void OnData(Slice data)
+    {
+        if (!data.Bars.TryGetValue(_spy, out var bar))
+        {
+            return;
+        }
+
+        var currentTime = Time.TimeOfDay;
+
+        // Build opening range from 9:30 up to (but not including) 10:00
+        if (currentTime >= _orbStart && currentTime < _orbEnd)
+        {
+            if (_orbHigh == null)
+            {
+                _orbHigh = bar.High;
+                _orbLow = bar.Low;
+            }
+            else
+            {
+                _orbHigh = Math.Max(_orbHigh.Value, bar.High);
+                _orbLow = Math.Min(_orbLow.Value, bar.Low);
+            }
+            Plot("ORB", "High", _orbHigh.Value);
+            Plot("ORB", "Low", _orbLow.Value);
+        }
+        // Trade breakouts after 10:00, only one trade per day
+        else if (currentTime >= _orbEnd)
+        {
+            if (_orbHigh != null && bar.Close > _orbHigh.Value)
+            {
+                SetHoldings(_spy, 1m);
+                Plot("Trades", "Direction", 1);
+                _orbHigh = _orbLow = null;
+            }
+            if (_orbLow != null && bar.Close < _orbLow.Value)
+            {
+                SetHoldings(_spy, -1m);
+                Plot("Trades", "Direction", -1);
+                _orbHigh = _orbLow = null;
+            }
+        }
+    }
+}

--- a/project-templates/csharp/equity-sixty-forty-portfolio/Main.cs
+++ b/project-templates/csharp/equity-sixty-forty-portfolio/Main.cs
@@ -1,0 +1,122 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class Static6040Algorithm : QCAlgorithm
+{
+    private const decimal _spyWeight = 0.60m;
+    private const decimal _tltWeight = 0.40m;
+    private const decimal _driftThreshold = 0.05m;
+
+    private Symbol _spy;
+    private Symbol _tlt;
+    private Dictionary<Symbol, decimal> _targets;
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+
+        _spy = AddEquity("SPY", Resolution.Minute).Symbol;
+        _tlt = AddEquity("TLT", Resolution.Minute).Symbol;
+
+        Schedule.On(
+            DateRules.QuarterStart("SPY"),
+            TimeRules.AfterMarketOpen("SPY", 1),
+            Rebalance);
+
+        _targets = new Dictionary<Symbol, decimal>
+        {
+            { _spy, _spyWeight },
+            { _tlt, _tltWeight },
+        };
+    }
+
+    public override void OnWarmupFinished()
+    {
+        Rebalance();
+    }
+
+    private void Rebalance()
+    {
+        var needsRebalance = false;
+        foreach (var kvp in _targets)
+        {
+            var currentWeight = Portfolio[kvp.Key].HoldingsValue / Portfolio.TotalPortfolioValue;
+            if (Math.Abs(currentWeight - kvp.Value) > _driftThreshold)
+            {
+                needsRebalance = true;
+                break;
+            }
+        }
+
+        if (!needsRebalance)
+        {
+            return;
+        }
+
+        var targets = _targets
+            .Select(kvp => new PortfolioTarget(kvp.Key, kvp.Value))
+            .ToList();
+        SetHoldings(targets);
+    }
+}

--- a/project-templates/csharp/equity-turn-of-month-effect/Main.cs
+++ b/project-templates/csharp/equity-turn-of-month-effect/Main.cs
@@ -1,0 +1,122 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class MonthlyEdgeStrategy : QCAlgorithm
+{
+    private Symbol _spy;
+    private List<DateTime> _monthTradingDays = new List<DateTime>();
+    private (int Year, int Month)? _currentMonth;
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+
+        _spy = AddEquity("SPY", Resolution.Minute).Symbol;
+
+        Schedule.On(
+            DateRules.EveryDay(_spy),
+            TimeRules.AfterMarketOpen(_spy, 1),
+            Rebalance);
+    }
+
+    private void Rebalance()
+    {
+        var today = Time.Date;
+        var currentMonth = (today.Year, today.Month);
+
+        if (currentMonth != _currentMonth)
+        {
+            _currentMonth = currentMonth;
+            _monthTradingDays = GetMonthTradingDays(today);
+        }
+
+        if (_monthTradingDays.Count == 0)
+        {
+            return;
+        }
+
+        var isHold = _monthTradingDays.Take(3).Contains(today)
+            || _monthTradingDays.Skip(Math.Max(0, _monthTradingDays.Count - 4)).Contains(today);
+
+        if (isHold && !Portfolio[_spy].Invested)
+        {
+            SetHoldings(_spy, 1.0);
+        }
+        else if (!isHold && Portfolio[_spy].Invested)
+        {
+            Liquidate(_spy);
+        }
+    }
+
+    private List<DateTime> GetMonthTradingDays(DateTime anchorDate)
+    {
+        var start = new DateTime(anchorDate.Year, anchorDate.Month, 1);
+        var lastDay = DateTime.DaysInMonth(anchorDate.Year, anchorDate.Month);
+        var end = new DateTime(anchorDate.Year, anchorDate.Month, lastDay);
+
+        return TradingCalendar.GetTradingDays(start, end)
+            .Select(d => d.Date.Date)
+            .ToList();
+    }
+}

--- a/project-templates/csharp/templates.json
+++ b/project-templates/csharp/templates.json
@@ -455,6 +455,22 @@
 			"spec": "Assets: XLK,XLF,XLE,XLV,XLI,XLB,XLY,XLP,XLU,XLRE. Daily. 2022-01-01 to 2024-12-31, $200k. ROC(60). Monthly schedule (first trading day) ranks ETFs and equal-weights the top 3. Demonstrates: multi-symbol indicator dictionary, sector rotation, scheduled monthly rebalance. Edge case: liquidate names that drop out of the top 3.",
 			"tags": ["Equity", "indicators", "roc", "sector-rotation"],
 			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-cmf-money-flow",
+			"name": "Equity Chaikin Money Flow",
+			"description": "Trades XLF using ChaikinMoneyFlow(20) — long when CMF > 0.1 and short when CMF < -0.1, flat in between.",
+			"spec": "Asset: XLF. Minute resolution. 2022-01-01 to 2024-12-31, $100k. ChaikinMoneyFlow(20). Long when CMF > 0.10; short when CMF < -0.10; flat in the dead zone. Demonstrates: CMF volume indicator, threshold-based regime, plotting indicator on subchart. Edge case: rebalance only on signal change.",
+			"tags": ["Equity", "indicators", "cmf", "volume"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-sixty-forty-portfolio",
+			"name": "Equity 60/40 Portfolio",
+			"description": "Holds a static 60% SPY / 40% TLT allocation with quarterly rebalance back to target weights.",
+			"spec": "Assets: SPY, TLT. Minute. 2022-01-01 to 2024-12-31, $100k. Set holdings 60/40 on first bar; schedule a quarterly rebalance (first business day of Jan/Apr/Jul/Oct) to retarget. Demonstrates: scheduled events with quarter_start rule, portfolio rebalancing logic, simple set_holdings. Edge case: drift threshold of 5% to skip no-op rebalances.",
+			"tags": ["Equity", "asset-allocation", "scheduled-event", "rebalance"],
+			"reference_template": "equities-static-universe"
 		}
 	]
 }

--- a/project-templates/csharp/templates.json
+++ b/project-templates/csharp/templates.json
@@ -471,6 +471,38 @@
 			"spec": "Assets: SPY, TLT. Minute. 2022-01-01 to 2024-12-31, $100k. Set holdings 60/40 on first bar; schedule a quarterly rebalance (first business day of Jan/Apr/Jul/Oct) to retarget. Demonstrates: scheduled events with quarter_start rule, portfolio rebalancing logic, simple set_holdings. Edge case: drift threshold of 5% to skip no-op rebalances.",
 			"tags": ["Equity", "asset-allocation", "scheduled-event", "rebalance"],
 			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-all-weather-portfolio",
+			"name": "Equity All-Weather Portfolio",
+			"description": "Implements Ray Dalio's All-Weather: 30% SPY, 40% TLT, 15% IEF, 7.5% GLD, 7.5% DBC with annual rebalance.",
+			"spec": "Assets: SPY, TLT, IEF, GLD, DBC. Minute. 2022-01-01 to 2024-12-31, $200k. Set target weights on first bar; annual schedule retargets. Demonstrates: multi-asset allocation, scheduled annual rebalance, holdings drift monitoring. Edge case: skip GLD/DBC if missing in early data.",
+			"tags": ["Equity", "all-weather", "asset-allocation", "etf"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-opening-range-breakout",
+			"name": "Equity Opening Range Breakout",
+			"description": "Trades SPY breakouts of the 30-minute opening range, going long above the high and short below the low until end of day.",
+			"spec": "Asset: SPY. Minute resolution. 2024-09-01 to 2024-12-31, $100k. Build opening range 9:30-10:00; long on first cross above range high; short on first cross below range low. Force liquidate at 15:55. Demonstrates: minute resolution, scheduled events for ORB window, end-of-day flat. Edge case: only one trade per day.",
+			"tags": ["Equity", "opening-range-breakout", "intraday", "scheduled-event"],
+			"reference_template": "intraday-indicator-scans"
+		},
+		{
+			"folder": "equity-turn-of-month-effect",
+			"name": "Equity Turn-of-Month Effect",
+			"description": "Holds SPY only on the last 4 and first 3 trading days of each month and stays in cash otherwise.",
+			"spec": "Asset: SPY. Minute. 2022-01-01 to 2024-12-31, $100k. Use trading calendar to identify last 4 and first 3 trading days of each month; hold SPY on those days, otherwise liquidate. Demonstrates: trading calendar API, scheduled events with custom date logic. Edge case: handle month boundary spanning weekends/holidays.",
+			"tags": ["Equity", "calendar-anomaly", "scheduled-event", "trading-calendar"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-monthly-roc-rotation",
+			"name": "Equity Monthly ROC Rotation",
+			"description": "Rotates monthly into the 3 ETFs (SPY, EFA, EEM, AGG, GLD) with the highest 60-day ROC, equal-weighted.",
+			"spec": "Assets: SPY, EFA, EEM, AGG, GLD. Minute. 2022-01-01 to 2024-12-31, $100k. ROC(60) per ETF. Monthly schedule picks top 3 and equal-weights; liquidates the others. Demonstrates: ROC across asset classes, monthly schedule, set_holdings 1/3 each. Edge case: hold cash if all ROCs negative.",
+			"tags": ["Equity", "asset-rotation", "roc", "scheduled-event"],
+			"reference_template": "equities-static-universe"
 		}
 	]
 }

--- a/project-templates/python/ai/main.py
+++ b/project-templates/python/ai/main.py
@@ -1,5 +1,6 @@
 # region imports
 import tensorflow as tf
+import numpy.typing as npt
 from AlgorithmImports import *
 # endregion
 
@@ -39,7 +40,7 @@ class TensorFlowAlgorithm(QCAlgorithm):
         # Recalibrate the model weekly to ensure its accuracy on the updated domain.
         self.train(self.date_rules.week_start(), self.time_rules.at(8, 0), self._my_training_method)
 
-    def _get_features_and_labels(self, lookback: int = 5) -> tuple[np.ndarray, np.ndarray]:
+    def _get_features_and_labels(self, lookback: int = 5) -> tuple[npt.NDArray[Any], npt.NDArray[Any]]:
         lookback_series = []
         # Train and predict on N-period differencing data which is more normalized and stationary.
         data = pd.Series([bar.close for bar in self._spy.session][::-1])
@@ -55,7 +56,7 @@ class TensorFlowAlgorithm(QCAlgorithm):
         # Prepare the processed training data.
         features, labels = self._get_features_and_labels()
         # Define the loss function using MSE for this example.
-        def loss_mse(target_y: np.ndarray, predicted_y: tf.Tensor) -> tf.Tensor:
+        def loss_mse(target_y: npt.NDArray[Any], predicted_y: tf.Tensor) -> tf.Tensor:
             return tf.reduce_mean(tf.square(target_y - predicted_y))
         # Train the model with Adam optimizer.
         optimizer = tf.keras.optimizers.Adam(learning_rate=self._learning_rate)

--- a/project-templates/python/equity-all-weather-portfolio/main.py
+++ b/project-templates/python/equity-all-weather-portfolio/main.py
@@ -1,0 +1,81 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class AllWeatherPortfolioAlgorithm(QCAlgorithm):
+    _drift_threshold = 0.01
+
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(200000)
+
+        targets = {
+            "SPY": 0.30,
+            "TLT": 0.40,
+            "IEF": 0.15,
+            "GLD": 0.075,
+            "DBC": 0.075,
+        }
+
+        self._symbols = {}
+        for ticker, target in targets.items():
+            security = self.add_equity(ticker, Resolution.MINUTE)
+            security.target = target
+
+        # Set target weights on the first bar with data.
+        self._last_rebalance_date = self.start_date.date()
+
+        # Annual rebalance on the first trading day of each year.
+        self.schedule.on(
+            self.date_rules.year_start("SPY", 0),
+            self.time_rules.after_market_open("SPY", 1),
+            self._rebalance
+        )
+
+        # Weekly holdings-drift monitoring.
+        self.schedule.on(
+            self.date_rules.week_start("SPY"),
+            self.time_rules.after_market_open("SPY", 30),
+            self._log_drift
+        )
+
+    def on_warmup_finished(self) -> None:
+        self._rebalance()
+
+    def _rebalance(self) -> None:
+        today = self.time.date()
+        if self._last_rebalance_date == today:
+            return
+
+        targets = []
+        for symbol, security in self.securities.items():
+            # Edge case: skip GLD/DBC if missing in early data.
+            if not security.has_data:
+                self.debug(f"Skipping {symbol}: no data available.")
+                continue
+
+            targets.append(PortfolioTarget(symbol, security.target))
+
+        if targets:
+            self.set_holdings(targets, liquidate_existing_holdings=True)
+            self.debug(f"Rebalanced on {self.time}")
+
+        self._last_rebalance_date = today
+        self._log_drift()
+
+    def _log_drift(self) -> None:
+        total_value = self.portfolio.total_portfolio_value
+        if total_value <= 0:
+            return
+
+        for symbol, security in self.securities.items():
+            if not security.has_data:
+                continue
+
+            current_weight = security.holdings.holdings_value / total_value
+            drift = abs(current_weight - security.target)
+            self.debug(f"{symbol}: target={security.target:.2%}, current={current_weight:.2%}, drift={drift:.2%}")
+
+            if drift > self._drift_threshold:
+                self.debug(f"{symbol} drift exceeds {self._drift_threshold:.2%}: {drift:.2%}")

--- a/project-templates/python/equity-all-weather-portfolio/main.py
+++ b/project-templates/python/equity-all-weather-portfolio/main.py
@@ -18,7 +18,6 @@ class AllWeatherPortfolioAlgorithm(QCAlgorithm):
             "DBC": 0.075,
         }
 
-        self._symbols = {}
         for ticker, target in targets.items():
             security = self.add_equity(ticker, Resolution.MINUTE)
             security.target = target

--- a/project-templates/python/equity-cmf-money-flow/main.py
+++ b/project-templates/python/equity-cmf-money-flow/main.py
@@ -1,0 +1,49 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class ChaikinMoneyFlowXlfAlgorithm(QCAlgorithm):
+    _long_threshold = 0.10
+    _short_threshold = -0.10
+
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+        
+        self.settings.automatic_indicator_warm_up = True
+        
+        self._xlf = self.add_equity("XLF", Resolution.MINUTE)
+        self._cmf = self.cmf(self._xlf.symbol, 20, Resolution.MINUTE)
+        self.plot_indicator("CMF", self._cmf)
+        
+        self._previous_signal = 0  # 1 = long, -1 = short, 0 = flat
+        
+        self.schedule.on(
+            self.date_rules.every_day(self._xlf.symbol),
+            self.time_rules.after_market_open(self._xlf.symbol, 30),
+            self._rebalance
+        )
+
+    def _rebalance(self) -> None:
+        if not self._cmf.is_ready:
+            return
+        
+        cmf_value = self._cmf.current.value
+        signal = 0
+        if cmf_value > self._long_threshold:
+            signal = 1
+        elif cmf_value < self._short_threshold:
+            signal = -1
+        
+        if signal == self._previous_signal:
+            return
+        
+        self._previous_signal = signal
+        
+        if signal == 1:
+            self.set_holdings(self._xlf.symbol, 1.0)
+        elif signal == -1:
+            self.set_holdings(self._xlf.symbol, -1.0)
+        else:
+            self.liquidate(self._xlf.symbol)

--- a/project-templates/python/equity-momentum-cross-sectional-decile/main.py
+++ b/project-templates/python/equity-momentum-cross-sectional-decile/main.py
@@ -17,7 +17,7 @@ class SP500Momentum(QCAlgorithm):
         self._top_decile_pct = 0.1
 
         # One momentum indicator per constituent, fed from the universe stream.
-        self._momentum_by_symbol = {}
+        self._momentum_by_symbol: dict[Symbol, MomentumPercent] = {}
 
         # Chain SPY ETF constituents into a fundamental universe.
         self.universe_settings.resolution = Resolution.MINUTE

--- a/project-templates/python/equity-momentum-cross-sectional-decile/main.py
+++ b/project-templates/python/equity-momentum-cross-sectional-decile/main.py
@@ -35,7 +35,7 @@ class SP500Momentum(QCAlgorithm):
             self._rebalance,
         )
 
-    def _select_assets(self, fundamentals: list[Fundamental]):
+    def _select_assets(self, fundamentals: list[Fundamental]) -> list[Symbol] | Universe.UnchangedUniverse:
         # Stream each constituent's adjusted price into its momentum indicator.
         ready = [
             f for f in fundamentals

--- a/project-templates/python/equity-monthly-roc-rotation/main.py
+++ b/project-templates/python/equity-monthly-roc-rotation/main.py
@@ -1,0 +1,42 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class MonthlyRotationAlgorithm(QCAlgorithm):
+    _roc_period = 60
+    _top_n = 3
+
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+        self.settings.automatic_indicator_warm_up = True
+
+        for ticker in ["SPY", "EFA", "EEM", "AGG", "GLD"]:
+            equity = self.add_equity(ticker, Resolution.MINUTE)
+            equity.roc = self.roc(equity, self._roc_period, Resolution.DAILY)
+
+        self.schedule.on(
+            self.date_rules.month_start("SPY"),
+            self.time_rules.after_market_open("SPY", 1),
+            self._rebalance
+        )
+
+    def _rebalance(self) -> None:
+        securities = [s for s in self.securities.values() if s.roc.is_ready]
+        if len(securities) < self._top_n:
+            return
+
+        if all(s.roc.current.value < 0 for s in securities):
+            self.liquidate()
+            return
+
+        top = sorted(securities, key=lambda s: s.roc.current.value, reverse=True)[:self._top_n]
+        top_symbols = {s.symbol for s in top}
+
+        weight = 1.0 / self._top_n
+        targets = [
+            PortfolioTarget(s.symbol, weight if s.symbol in top_symbols else 0)
+            for s in self.securities.values()
+        ]
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/equity-opening-range-breakout/main.py
+++ b/project-templates/python/equity-opening-range-breakout/main.py
@@ -1,0 +1,57 @@
+# region imports
+from AlgorithmImports import *
+from datetime import time
+# endregion
+
+class OpeningRangeBreakoutAlgorithm(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+        self.settings.seed_initial_prices = True
+
+        self._spy = self.add_equity("SPY", resolution=Resolution.MINUTE).symbol
+
+        self._orb_high = None
+        self._orb_low = None
+
+        self.schedule.on(
+            self.date_rules.every_day(self._spy),
+            self.time_rules.at(15, 55),
+            self._liquidate_eod
+        )
+
+    def _liquidate_eod(self) -> None:
+        self.liquidate(self._spy)
+        # Clearing the range stops further entries and resets it for tomorrow.
+        self._orb_high = None
+        self._orb_low = None
+
+    def on_data(self, data: Slice) -> None:
+        bar = data.bars.get(self._spy)
+        if not bar:
+            return
+
+        current_time = self.time.time()
+
+        # Build opening range from 9:30 up to (but not including) 10:00
+        if time(9, 30) <= current_time < time(10, 0):
+            if self._orb_high is None:
+                self._orb_high = bar.high
+                self._orb_low = bar.low
+            else:
+                self._orb_high = max(self._orb_high, bar.high)
+                self._orb_low = min(self._orb_low, bar.low)
+            self.plot("ORB", "High", self._orb_high)
+            self.plot("ORB", "Low", self._orb_low)
+
+        # Trade breakouts after 10:00, only one trade per day
+        elif current_time >= time(10, 0):
+            if self._orb_high and bar.close > self._orb_high:
+                self.set_holdings(self._spy, 1.0)
+                self.plot("Trades", "Direction", 1)
+                self._orb_high = self._orb_low = None
+            if self._orb_low and bar.close < self._orb_low:
+                self.set_holdings(self._spy, -1.0)
+                self.plot("Trades", "Direction", -1)
+                self._orb_high = self._orb_low = None

--- a/project-templates/python/equity-sixty-forty-portfolio/main.py
+++ b/project-templates/python/equity-sixty-forty-portfolio/main.py
@@ -1,0 +1,45 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+
+class Static6040Algorithm(QCAlgorithm):
+    _spy_weight = 0.60
+    _tlt_weight = 0.40
+    _drift_threshold = 0.05
+
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self._spy = self.add_equity("SPY", Resolution.MINUTE).symbol
+        self._tlt = self.add_equity("TLT", Resolution.MINUTE).symbol
+
+        self.schedule.on(
+            self.date_rules.quarter_start("SPY"),
+            self.time_rules.after_market_open("SPY", 1),
+            self._rebalance,
+        )
+
+        self._targets = {
+            self._spy: self._spy_weight,
+            self._tlt: self._tlt_weight,
+        }
+
+    def on_warmup_finished(self) -> None:
+        self._rebalance()
+
+    def _rebalance(self) -> None:
+        needs_rebalance = False
+        for symbol, target_weight in self._targets.items():
+            current_weight = self.portfolio[symbol].holdings_value / self.portfolio.total_portfolio_value
+            if abs(current_weight - target_weight) > self._drift_threshold:
+                needs_rebalance = True
+                break
+
+        if not needs_rebalance:
+            return
+
+        targets = [PortfolioTarget(symbol, weight) for symbol, weight in self._targets.items()]
+        self.set_holdings(targets)

--- a/project-templates/python/equity-turn-of-month-effect/main.py
+++ b/project-templates/python/equity-turn-of-month-effect/main.py
@@ -12,7 +12,7 @@ class MonthlyEdgeStrategy(QCAlgorithm):
         self.set_cash(100000)
 
         self._spy = self.add_equity("SPY", Resolution.MINUTE).symbol
-        self._month_trading_days = []
+        self._month_trading_days: list[date] = []
         self._current_month = None
 
         self.schedule.on(
@@ -39,7 +39,7 @@ class MonthlyEdgeStrategy(QCAlgorithm):
         elif not is_hold and self.portfolio[self._spy].invested:
             self.liquidate(self._spy)
 
-    def _get_month_trading_days(self, anchor_date):
+    def _get_month_trading_days(self, anchor_date: date) -> list[date]:
         start = datetime(anchor_date.year, anchor_date.month, 1)
         last_day = calendar.monthrange(anchor_date.year, anchor_date.month)[1]
         end = datetime(anchor_date.year, anchor_date.month, last_day)

--- a/project-templates/python/equity-turn-of-month-effect/main.py
+++ b/project-templates/python/equity-turn-of-month-effect/main.py
@@ -1,0 +1,48 @@
+# region imports
+from AlgorithmImports import *
+from datetime import datetime, date
+import calendar
+# endregion
+
+
+class MonthlyEdgeStrategy(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self._spy = self.add_equity("SPY", Resolution.MINUTE).symbol
+        self._month_trading_days = []
+        self._current_month = None
+
+        self.schedule.on(
+            self.date_rules.every_day(self._spy),
+            self.time_rules.after_market_open(self._spy, 1),
+            self._rebalance,
+        )
+
+    def _rebalance(self) -> None:
+        today = self.time.date()
+        current_month = (today.year, today.month)
+
+        if current_month != self._current_month:
+            self._current_month = current_month
+            self._month_trading_days = self._get_month_trading_days(today)
+
+        if not self._month_trading_days:
+            return
+
+        is_hold = today in self._month_trading_days[:3] or today in self._month_trading_days[-4:]
+
+        if is_hold and not self.portfolio[self._spy].invested:
+            self.set_holdings(self._spy, 1.0)
+        elif not is_hold and self.portfolio[self._spy].invested:
+            self.liquidate(self._spy)
+
+    def _get_month_trading_days(self, anchor_date):
+        start = datetime(anchor_date.year, anchor_date.month, 1)
+        last_day = calendar.monthrange(anchor_date.year, anchor_date.month)[1]
+        end = datetime(anchor_date.year, anchor_date.month, last_day)
+
+        trading_days = self.trading_calendar.get_trading_days(start, end)
+        return [date(d.date.year, d.date.month, d.date.day) for d in trading_days]

--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -452,8 +452,24 @@
 			"folder": "equity-roc-momentum-rank",
 			"name": "Equity ROC Momentum Rank",
 			"description": "Ranks 10 sector ETFs by 60-day ROC monthly and equal-weights the top 3 with a scheduled rebalance.",
-			"spec": "Assets: XLK,XLF,XLE,XLV,XLI,XLB,XLY,XLP,XLU,XLRE. Daily. 2022-01-01 to 2024-12-31, $200k. ROC(60). Monthly schedule (first trading day) ranks ETFs and equal-weights the top 3. Demonstrates: multi-symbol indicator dictionary, sector rotation, scheduled monthly rebalance. Edge case: liquidate names that drop out of the top 3.",
+			"spec": "Assets: XLK,XLF,XLE,XLV,XLI,XLB,XLY,XLP,XLU,XLRE. Minute. 2022-01-01 to 2024-12-31, $200k. ROC(60). Monthly schedule (first trading day) ranks ETFs and equal-weights the top 3. Demonstrates: multi-symbol indicator dictionary, sector rotation, scheduled monthly rebalance. Edge case: liquidate names that drop out of the top 3.",
 			"tags": ["Equity", "indicators", "roc", "sector-rotation"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-cmf-money-flow",
+			"name": "Equity Chaikin Money Flow",
+			"description": "Trades XLF using ChaikinMoneyFlow(20) — long when CMF > 0.1 and short when CMF < -0.1, flat in between.",
+			"spec": "Asset: XLF. Minute resolution. 2022-01-01 to 2024-12-31, $100k. ChaikinMoneyFlow(20). Long when CMF > 0.10; short when CMF < -0.10; flat in the dead zone. Demonstrates: CMF volume indicator, threshold-based regime, plotting indicator on subchart. Edge case: rebalance only on signal change.",
+			"tags": ["Equity", "indicators", "cmf", "volume"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-sixty-forty-portfolio",
+			"name": "Equity 60/40 Portfolio",
+			"description": "Holds a static 60% SPY / 40% TLT allocation with quarterly rebalance back to target weights.",
+			"spec": "Assets: SPY, TLT. Minute. 2022-01-01 to 2024-12-31, $100k. Set holdings 60/40 on first bar; schedule a quarterly rebalance (first business day of Jan/Apr/Jul/Oct) to retarget. Demonstrates: scheduled events with quarter_start rule, portfolio rebalancing logic, simple set_holdings. Edge case: drift threshold of 5% to skip no-op rebalances.",
+			"tags": ["Equity", "asset-allocation", "scheduled-event", "rebalance"],
 			"reference_template": "equities-static-universe"
 		}
 	]

--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -471,6 +471,38 @@
 			"spec": "Assets: SPY, TLT. Minute. 2022-01-01 to 2024-12-31, $100k. Set holdings 60/40 on first bar; schedule a quarterly rebalance (first business day of Jan/Apr/Jul/Oct) to retarget. Demonstrates: scheduled events with quarter_start rule, portfolio rebalancing logic, simple set_holdings. Edge case: drift threshold of 5% to skip no-op rebalances.",
 			"tags": ["Equity", "asset-allocation", "scheduled-event", "rebalance"],
 			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-all-weather-portfolio",
+			"name": "Equity All-Weather Portfolio",
+			"description": "Implements Ray Dalio's All-Weather: 30% SPY, 40% TLT, 15% IEF, 7.5% GLD, 7.5% DBC with annual rebalance.",
+			"spec": "Assets: SPY, TLT, IEF, GLD, DBC. Minute. 2022-01-01 to 2024-12-31, $200k. Set target weights on first bar; annual schedule retargets. Demonstrates: multi-asset allocation, scheduled annual rebalance, holdings drift monitoring. Edge case: skip GLD/DBC if missing in early data.",
+			"tags": ["Equity", "all-weather", "asset-allocation", "etf"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-opening-range-breakout",
+			"name": "Equity Opening Range Breakout",
+			"description": "Trades SPY breakouts of the 30-minute opening range, going long above the high and short below the low until end of day.",
+			"spec": "Asset: SPY. Minute resolution. 2024-09-01 to 2024-12-31, $100k. Build opening range 9:30-10:00; long on first cross above range high; short on first cross below range low. Force liquidate at 15:55. Demonstrates: minute resolution, scheduled events for ORB window, end-of-day flat. Edge case: only one trade per day.",
+			"tags": ["Equity", "opening-range-breakout", "intraday", "scheduled-event"],
+			"reference_template": "intraday-indicator-scans"
+		},
+		{
+			"folder": "equity-turn-of-month-effect",
+			"name": "Equity Turn-of-Month Effect",
+			"description": "Holds SPY only on the last 4 and first 3 trading days of each month and stays in cash otherwise.",
+			"spec": "Asset: SPY. Minute. 2022-01-01 to 2024-12-31, $100k. Use trading calendar to identify last 4 and first 3 trading days of each month; hold SPY on those days, otherwise liquidate. Demonstrates: trading calendar API, scheduled events with custom date logic. Edge case: handle month boundary spanning weekends/holidays.",
+			"tags": ["Equity", "calendar-anomaly", "scheduled-event", "trading-calendar"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-monthly-roc-rotation",
+			"name": "Equity Monthly ROC Rotation",
+			"description": "Rotates monthly into the 3 ETFs (SPY, EFA, EEM, AGG, GLD) with the highest 60-day ROC, equal-weighted.",
+			"spec": "Assets: SPY, EFA, EEM, AGG, GLD. Minute. 2022-01-01 to 2024-12-31, $100k. ROC(60) per ETF. Monthly schedule picks top 3 and equal-weights; liquidates the others. Demonstrates: ROC across asset classes, monthly schedule, set_holdings 1/3 each. Edge case: hold cash if all ROCs negative.",
+			"tags": ["Equity", "asset-rotation", "roc", "scheduled-event"],
+			"reference_template": "equities-static-universe"
 		}
 	]
 }

--- a/project-templates/template-ideas.json
+++ b/project-templates/template-ideas.json
@@ -4,7 +4,7 @@
       "folder": "equity-atr-volatility-stop",
       "name": "Equity ATR Volatility Stop",
       "description": "Holds SPY long with an ATR(14) chandelier-style trailing stop set 3x ATR below the trailing high.",
-      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. ATR(14). Buy on first bar; maintain trailing high; if close < trailing_high - 3*ATR, liquidate and re-enter on next bar. Demonstrates: ATR indicator, manual trailing-stop pattern, plotting stop level. Edge case: reset trailing high after each liquidation.",
+      "spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. ATR(14). Buy on first bar; maintain trailing high; if close < trailing_high - 3*ATR, liquidate and re-enter on next bar. Demonstrates: ATR indicator, manual trailing-stop pattern, plotting stop level. Edge case: reset trailing high after each liquidation.",
       "tags": [
         "Equity",
         "indicators",
@@ -17,7 +17,7 @@
       "folder": "equity-obv-divergence",
       "name": "Equity OBV Divergence",
       "description": "Detects bullish/bearish On-Balance Volume divergence on SPY versus a 20-day price ROC and trades reversals.",
-      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. OBV indicator and ROC(20) on price. Bullish divergence: price ROC < 0 but OBV ROC > 0 -> long. Bearish opposite -> short. Demonstrates: OBV automatic indicator, IndicatorExtensions to compute ROC of OBV, divergence logic. Edge case: require 5-day confirmation.",
+      "spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. OBV indicator and ROC(20) on price. Bullish divergence: price ROC < 0 but OBV ROC > 0 -> long. Bearish opposite -> short. Demonstrates: OBV automatic indicator, IndicatorExtensions to compute ROC of OBV, divergence logic. Edge case: require 5-day confirmation.",
       "tags": [
         "Equity",
         "indicators",
@@ -27,23 +27,10 @@
       "reference_template": "equities-static-universe"
     },
     {
-      "folder": "equity-cmf-money-flow",
-      "name": "Equity Chaikin Money Flow",
-      "description": "Trades XLF using ChaikinMoneyFlow(20) — long when CMF > 0.1 and short when CMF < -0.1, flat in between.",
-      "spec": "Asset: XLF. Daily resolution. 2022-01-01 to 2024-12-31, $100k. ChaikinMoneyFlow(20). Long when CMF > 0.10; short when CMF < -0.10; flat in the dead zone. Demonstrates: CMF volume indicator, threshold-based regime, plotting indicator on subchart. Edge case: rebalance only on signal change.",
-      "tags": [
-        "Equity",
-        "indicators",
-        "cmf",
-        "volume"
-      ],
-      "reference_template": "equities-static-universe"
-    },
-    {
       "folder": "equity-fisher-transform-reversal",
       "name": "Equity Fisher Transform Reversal",
       "description": "Trades NDX-tracking QQQ on FisherTransform extreme readings, fading values above 2.0 and below -2.0.",
-      "spec": "Asset: QQQ. Daily resolution. 2022-01-01 to 2024-12-31, $100k. FisherTransform(10). Short when value > 2 and turning down; long when < -2 and turning up; exit on cross of 0. Demonstrates: FisherTransform indicator, RollingWindow on indicator value to detect turns. Edge case: only one position at a time.",
+      "spec": "Asset: QQQ. Minute resolution. 2022-01-01 to 2024-12-31, $100k. FisherTransform(10). Short when value > 2 and turning down; long when < -2 and turning up; exit on cross of 0. Demonstrates: FisherTransform indicator, RollingWindow on indicator value to detect turns. Edge case: only one position at a time.",
       "tags": [
         "Equity",
         "indicators",
@@ -56,7 +43,7 @@
       "folder": "equity-aroon-trend",
       "name": "Equity Aroon Trend",
       "description": "Trades SPY using AroonOscillator(25); enters long on cross above +50 and exits on cross below -50.",
-      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. AroonOscillator(25). Long when oscillator crosses above 50; exit when it crosses below -50. Demonstrates: Aroon indicator, threshold crossing pattern, plotting oscillator on subchart. Edge case: do not flip short — long-only.",
+      "spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. AroonOscillator(25). Long when oscillator crosses above 50; exit when it crosses below -50. Demonstrates: Aroon indicator, threshold crossing pattern, plotting oscillator on subchart. Edge case: do not flip short — long-only.",
       "tags": [
         "Equity",
         "indicators",
@@ -69,7 +56,7 @@
       "folder": "equity-williams-percent-r",
       "name": "Equity Williams %R",
       "description": "Trades IWM with WilliamsPercentR(14): long entries below -80 and exits above -20.",
-      "spec": "Asset: IWM. Daily resolution. 2022-01-01 to 2024-12-31, $100k. WilliamsPercentR(14). Long when %R < -80; exit when %R > -20. Demonstrates: Williams %R indicator, oversold reversion logic, plotting against -80/-20 reference lines. Edge case: hold cap of 5 trading days.",
+      "spec": "Asset: IWM. Minute resolution. 2022-01-01 to 2024-12-31, $100k. WilliamsPercentR(14). Long when %R < -80; exit when %R > -20. Demonstrates: Williams %R indicator, oversold reversion logic, plotting against -80/-20 reference lines. Edge case: hold cap of 5 trading days.",
       "tags": [
         "Equity",
         "indicators",
@@ -82,7 +69,7 @@
       "folder": "equity-cci-overbought",
       "name": "Equity Commodity Channel Index",
       "description": "Trades XLE on CCI(20) — long when CCI < -100 and exit at 0; short when CCI > 100 and cover at 0.",
-      "spec": "Asset: XLE. Daily resolution. 2022-01-01 to 2024-12-31, $100k. CommodityChannelIndex(20). Long when CCI < -100; short when CCI > 100; both exit at 0. Demonstrates: CCI indicator, mean-reversion with explicit short side, sector ETF. Edge case: skip orders during low-volatility (ATR filter).",
+      "spec": "Asset: XLE. Minute resolution. 2022-01-01 to 2024-12-31, $100k. CommodityChannelIndex(20). Long when CCI < -100; short when CCI > 100; both exit at 0. Demonstrates: CCI indicator, mean-reversion with explicit short side, sector ETF. Edge case: skip orders during low-volatility (ATR filter).",
       "tags": [
         "Equity",
         "indicators",
@@ -95,7 +82,7 @@
       "folder": "equity-mfi-divergence",
       "name": "Equity Money Flow Index",
       "description": "Uses the built-in MFI(14) on SPY for overbought/oversold reversion — distinct from the existing custom-indicator template.",
-      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. Built-in MoneyFlowIndex(14) (NOT custom). Long when MFI < 20; short when MFI > 80; exit at 50. Demonstrates: built-in MFI indicator (vs custom), automatic warm-up, plotting against thresholds. Edge case: do nothing while indicator is_ready False.",
+      "spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. Built-in MoneyFlowIndex(14) (NOT custom). Long when MFI < 20; short when MFI > 80; exit at 50. Demonstrates: built-in MFI indicator (vs custom), automatic warm-up, plotting against thresholds. Edge case: do nothing while indicator is_ready False.",
       "tags": [
         "Equity",
         "indicators",
@@ -108,7 +95,7 @@
       "folder": "equity-tom-demark-sequential",
       "name": "Equity Tom DeMark Sequential",
       "description": "Trades SPY using TDSequential setup counts — buy on a 9-count buy setup and sell on a 9-count sell setup.",
-      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. Built-in TDSequential indicator (or custom 9-count if unavailable). Long on completed buy-setup of 9; flat/short on completed sell-setup. Demonstrates: pattern-based indicator, RollingWindow over closes, indicator plotting with annotations. Edge case: cancel partial setups on opposite-side bar.",
+      "spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. Built-in TDSequential indicator (or custom 9-count if unavailable). Long on completed buy-setup of 9; flat/short on completed sell-setup. Demonstrates: pattern-based indicator, RollingWindow over closes, indicator plotting with annotations. Edge case: cancel partial setups on opposite-side bar.",
       "tags": [
         "Equity",
         "indicators",
@@ -121,7 +108,7 @@
       "folder": "equity-kama-adaptive-trend",
       "name": "Equity Kaufman Adaptive Moving Average",
       "description": "Trades QQQ using KaufmanAdaptiveMovingAverage(10,2,30) crossover with the close price.",
-      "spec": "Asset: QQQ. Daily resolution. 2022-01-01 to 2024-12-31, $100k. KaufmanAdaptiveMovingAverage(10,2,30). Long when close crosses above KAMA; flat when close crosses below. Demonstrates: KAMA indicator, adaptive smoothing, plotting overlay. Edge case: ignore signals during the warm-up period.",
+      "spec": "Asset: QQQ. Minute resolution. 2022-01-01 to 2024-12-31, $100k. KaufmanAdaptiveMovingAverage(10,2,30). Long when close crosses above KAMA; flat when close crosses below. Demonstrates: KAMA indicator, adaptive smoothing, plotting overlay. Edge case: ignore signals during the warm-up period.",
       "tags": [
         "Equity",
         "indicators",
@@ -134,7 +121,7 @@
       "folder": "equity-hull-moving-average-cross",
       "name": "Equity Hull Moving Average Cross",
       "description": "Trades SPY using HullMovingAverage(20) and HullMovingAverage(50) crossover signals.",
-      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. HullMovingAverage(20) and HullMovingAverage(50). Long on HMA20 cross above HMA50; flat/short on HMA20 cross below HMA50. Demonstrates: Hull MA indicator (low-lag MA), classical dual-MA cross. Edge case: minimum 1-bar gap between flips.",
+      "spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. HullMovingAverage(20) and HullMovingAverage(50). Long on HMA20 cross above HMA50; flat/short on HMA20 cross below HMA50. Demonstrates: Hull MA indicator (low-lag MA), classical dual-MA cross. Edge case: minimum 1-bar gap between flips.",
       "tags": [
         "Equity",
         "indicators",
@@ -147,7 +134,7 @@
       "folder": "equity-fractal-adaptive-ma",
       "name": "Equity Fractal Adaptive Moving Average",
       "description": "Trades SPY using FractalAdaptiveMovingAverage(16) crossover with closing price.",
-      "spec": "Asset: SPY. Daily resolution. 2022-01-01 to 2024-12-31, $100k. FractalAdaptiveMovingAverage(16). Long when close > FRAMA; flat when close < FRAMA. Demonstrates: FRAMA indicator (Hurst-based adaptive), plotting overlay, automatic warm-up. Edge case: only rebalance once per day.",
+      "spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. FractalAdaptiveMovingAverage(16). Long when close > FRAMA; flat when close < FRAMA. Demonstrates: FRAMA indicator (Hurst-based adaptive), plotting overlay, automatic warm-up. Edge case: only rebalance once per day.",
       "tags": [
         "Equity",
         "indicators",
@@ -160,7 +147,7 @@
       "folder": "equity-trix-momentum",
       "name": "Equity TRIX Momentum",
       "description": "Trades AAPL with TRIX(15) signal-line crossings — long on TRIX cross above 0, exit on cross below 0.",
-      "spec": "Asset: AAPL. Daily resolution. 2022-01-01 to 2024-12-31, $100k. TRIX(15) and a 9-period SMA signal. Long on TRIX cross above signal AND TRIX > 0; exit on cross below signal. Demonstrates: TRIX indicator, IndicatorExtensions.SMA on indicator output. Edge case: skip orders within first 30 bars.",
+      "spec": "Asset: AAPL. Minute resolution. 2022-01-01 to 2024-12-31, $100k. TRIX(15) and a 9-period SMA signal. Long on TRIX cross above signal AND TRIX > 0; exit on cross below signal. Demonstrates: TRIX indicator, IndicatorExtensions.SMA on indicator output. Edge case: skip orders within first 30 bars.",
       "tags": [
         "Equity",
         "indicators",
@@ -212,7 +199,7 @@
       "folder": "equity-dual-momentum-asset-class",
       "name": "Equity Dual Momentum",
       "description": "Implements Antonacci dual momentum across SPY, EFA, and AGG: pick the top 12-month return, fall back to AGG if absolute momentum is negative.",
-      "spec": "Assets: SPY, EFA, AGG. Daily resolution. 2022-01-01 to 2024-12-31, $100k. Monthly: compute 12-month return for each; pick the highest; if highest <= AGG return then hold AGG; else hold winner 100%. Demonstrates: history-based momentum, monthly schedule, conditional hold. Edge case: rebalance only on first trading day of month.",
+      "spec": "Assets: SPY, EFA, AGG. Minute resolution. 2022-01-01 to 2024-12-31, $100k. Monthly: compute 12-month return for each; pick the highest; if highest <= AGG return then hold AGG; else hold winner 100%. Demonstrates: history-based momentum, monthly schedule, conditional hold. Edge case: rebalance only on first trading day of month.",
       "tags": [
         "Equity",
         "dual-momentum",
@@ -220,19 +207,6 @@
         "history"
       ],
       "reference_template": "history-and-etf-universe"
-    },
-    {
-      "folder": "equity-sixty-forty-portfolio",
-      "name": "Equity 60/40 Portfolio",
-      "description": "Holds a static 60% SPY / 40% TLT allocation with quarterly rebalance back to target weights.",
-      "spec": "Assets: SPY, TLT. Daily. 2022-01-01 to 2024-12-31, $100k. Set holdings 60/40 on first bar; schedule a quarterly rebalance (first business day of Jan/Apr/Jul/Oct) to retarget. Demonstrates: scheduled events with month_start rule, portfolio rebalancing logic, simple set_holdings. Edge case: drift threshold of 5% to skip no-op rebalances.",
-      "tags": [
-        "Equity",
-        "asset-allocation",
-        "scheduled-event",
-        "rebalance"
-      ],
-      "reference_template": "equities-static-universe"
     },
     {
       "folder": "equity-permanent-portfolio",
@@ -251,7 +225,7 @@
       "folder": "equity-all-weather-portfolio",
       "name": "Equity All-Weather Portfolio",
       "description": "Implements Ray Dalio's All-Weather: 30% SPY, 40% TLT, 15% IEF, 7.5% GLD, 7.5% DBC with annual rebalance.",
-      "spec": "Assets: SPY, TLT, IEF, GLD, DBC. Daily. 2022-01-01 to 2024-12-31, $200k. Set target weights on first bar; annual schedule retargets. Demonstrates: multi-asset allocation, scheduled annual rebalance, holdings drift monitoring. Edge case: skip GLD/DBC if missing in early data.",
+      "spec": "Assets: SPY, TLT, IEF, GLD, DBC. Minute. 2022-01-01 to 2024-12-31, $200k. Set target weights on first bar; annual schedule retargets. Demonstrates: multi-asset allocation, scheduled annual rebalance, holdings drift monitoring. Edge case: skip GLD/DBC if missing in early data.",
       "tags": [
         "Equity",
         "all-weather",

--- a/project-templates/template-ideas.json
+++ b/project-templates/template-ideas.json
@@ -222,19 +222,6 @@
       "reference_template": "equities-static-universe"
     },
     {
-      "folder": "equity-all-weather-portfolio",
-      "name": "Equity All-Weather Portfolio",
-      "description": "Implements Ray Dalio's All-Weather: 30% SPY, 40% TLT, 15% IEF, 7.5% GLD, 7.5% DBC with annual rebalance.",
-      "spec": "Assets: SPY, TLT, IEF, GLD, DBC. Minute. 2022-01-01 to 2024-12-31, $200k. Set target weights on first bar; annual schedule retargets. Demonstrates: multi-asset allocation, scheduled annual rebalance, holdings drift monitoring. Edge case: skip GLD/DBC if missing in early data.",
-      "tags": [
-        "Equity",
-        "all-weather",
-        "asset-allocation",
-        "etf"
-      ],
-      "reference_template": "equities-static-universe"
-    },
-    {
       "folder": "equity-vix-timed-spy",
       "name": "Equity VIX-Timed SPY",
       "description": "Holds SPY when CBOE VIX index is below 20 and switches to SHY when VIX is above 25 (hysteresis band).",
@@ -264,7 +251,7 @@
       "folder": "equity-dollar-cost-averaging",
       "name": "Equity Dollar Cost Averaging",
       "description": "Buys $5,000 worth of VOO every Monday morning regardless of price, accumulating shares over the backtest.",
-      "spec": "Asset: VOO. Daily. 2022-01-01 to 2024-12-31, $200k starting cash. Schedule: every Monday after market open buy VOO with $5,000 of cash via market_order using calculate_order_quantity. Demonstrates: weekly schedule, fixed-dollar buys, calculate_order_quantity, no liquidation. Edge case: skip if insufficient cash; never sell.",
+      "spec": "Asset: VOO. Minute. 2022-01-01 to 2024-12-31, $200k starting cash. Schedule: every Monday after market open buy VOO with $5,000 of cash via market_order using calculate_order_quantity. Demonstrates: weekly schedule, fixed-dollar buys, calculate_order_quantity, no liquidation. Edge case: skip if insufficient cash; never sell.",
       "tags": [
         "Equity",
         "dca",
@@ -272,19 +259,6 @@
         "buy-and-hold"
       ],
       "reference_template": "equities-static-universe"
-    },
-    {
-      "folder": "equity-opening-range-breakout",
-      "name": "Equity Opening Range Breakout",
-      "description": "Trades SPY breakouts of the 30-minute opening range, going long above the high and short below the low until end of day.",
-      "spec": "Asset: SPY. Minute resolution. 2024-09-01 to 2024-12-31, $100k. Build opening range 9:30-10:00; long on first cross above range high; short on first cross below range low. Force liquidate at 15:55. Demonstrates: minute resolution, scheduled events for ORB window, end-of-day flat. Edge case: only one trade per day.",
-      "tags": [
-        "Equity",
-        "opening-range-breakout",
-        "intraday",
-        "scheduled-event"
-      ],
-      "reference_template": "intraday-indicator-scans"
     },
     {
       "folder": "equity-gap-and-go",
@@ -300,19 +274,6 @@
       "reference_template": "intraday-indicator-scans"
     },
     {
-      "folder": "equity-turn-of-month-effect",
-      "name": "Equity Turn-of-Month Effect",
-      "description": "Holds SPY only on the last 4 and first 3 trading days of each month and stays in cash otherwise.",
-      "spec": "Asset: SPY. Daily. 2022-01-01 to 2024-12-31, $100k. Use trading calendar to identify last 4 and first 3 trading days of each month; hold SPY on those days, otherwise liquidate. Demonstrates: trading calendar API, scheduled events with custom date logic. Edge case: handle month boundary spanning weekends/holidays.",
-      "tags": [
-        "Equity",
-        "calendar-anomaly",
-        "scheduled-event",
-        "trading-calendar"
-      ],
-      "reference_template": "equities-static-universe"
-    },
-    {
       "folder": "equity-mean-reversion-zscore",
       "name": "Equity Mean Reversion Z-Score Basket",
       "description": "Buys S&P 100 names whose 5-day return z-score relative to a 60-day window is below -2, exits at z=0.",
@@ -324,19 +285,6 @@
         "history"
       ],
       "reference_template": "equities-universe"
-    },
-    {
-      "folder": "equity-monthly-roc-rotation",
-      "name": "Equity Monthly ROC Rotation",
-      "description": "Rotates monthly into the 3 ETFs (SPY, EFA, EEM, AGG, GLD) with the highest 60-day ROC, equal-weighted.",
-      "spec": "Assets: SPY, EFA, EEM, AGG, GLD. Daily. 2022-01-01 to 2024-12-31, $100k. ROC(60) per ETF. Monthly schedule picks top 3 and equal-weights; liquidates the others. Demonstrates: ROC across asset classes, monthly schedule, set_holdings 1/3 each. Edge case: hold cash if all ROCs negative.",
-      "tags": [
-        "Equity",
-        "asset-rotation",
-        "roc",
-        "scheduled-event"
-      ],
-      "reference_template": "equities-static-universe"
     },
     {
       "folder": "equity-relative-strength-leaders",


### PR DESCRIPTION
@
## Summary

Adds six equity strategy project templates (Python `main.py` + C# `Main.cs` each) with their `templates.json` registrations:

- **equity-60-40-portfolio** — 60/40 SPY/TLT with quarterly rebalance
- **equity-cmf-money-flow** — Chaikin Money Flow signal
- **equity-all-weather-portfolio** — Ray Dalio All-Weather allocation, annual rebalance
- **equity-opening-range-breakout** — SPY 30-minute opening range breakout, end-of-day flat
- **equity-turn-of-month-effect** — SPY held only on last 4 / first 3 trading days of each month
- **equity-monthly-roc-rotation** — monthly rotation into the top 3 ETFs by 60-day ROC

Built entries are removed from `template-ideas.json`.

## Test plan

- Each template compiles and backtests on QuantConnect Cloud.
- For every template, the C# port reproduces the Python reference backtest (same order count and key statistics).
@