### PR TITLE
Fix broken links reported in docs link check

### DIFF
--- a/01 Cloud Platform/04 Organizations/05 Support/02 Features.php
+++ b/01 Cloud Platform/04 Organizations/05 Support/02 Features.php
@@ -47,7 +47,7 @@
       </tr>
    </tbody>
 </table>
-<p>For more information on this feature, see <a href="/docs/v2/ai-assistance/strategy-development">Strategy Development</a>.</p>
+<p>For more information on this feature, see <a href="/docs/v2/ai-assistance/getting-started">AI Assistance</a>.</p>
 
 <h4>Email Support </h4>
 <p>Our support ticket system enables you to privately email with our Support Team. We address support tickets in a first-in, first-out order, but we give priority to tickets opened by members with higher support seats.</p>

--- a/01 Cloud Platform/04 Organizations/05 Support/10 Ticket Quotas.html
+++ b/01 Cloud Platform/04 Organizations/05 Support/10 Ticket Quotas.html
@@ -40,6 +40,6 @@
 </p>
 
 <p>
-    Chat with <a href="/docs/v2/ai-assistance/strategy-development">Mia</a> for immediate assistance. We trained it on hundreds of algorithms and thousands of documentation pages to provide contextual assistance for most issues you may encounter when developing a strategy.
+    Chat with <a href="/docs/v2/ai-assistance/getting-started">Mia</a> for immediate assistance. We trained it on hundreds of algorithms and thousands of documentation pages to provide contextual assistance for most issues you may encounter when developing a strategy.
 </p>
 

--- a/01 Cloud Platform/12 Research Pipeline/01 Introduction.html
+++ b/01 Cloud Platform/12 Research Pipeline/01 Introduction.html
@@ -9,7 +9,7 @@
 <img src="https://cdn.quantconnect.com/i/tu/research-pipeline.png" class="docs-image" style="border: 2px solid #e4e6ea;" alt="Research Pipeline kanban board with cards across Ideas, Research, Backtest, Paper Trading, and Live Trading lists."/>
 
 <p>
-  To supercharge your productivity, add some <a href="/docs/v2/ai-assistance/assistants/key-concepts">AI assistants</a> to your Research Pipeline.
+  To supercharge your productivity, add some <a href="/docs/v2/ai-assistance/assistants">AI assistants</a> to your Research Pipeline.
   We offer a set of highly-skilled AI assistants that you can add to your organization.
   They are each pre-configured to specialize in a particular phase of the Research Pipeline, but you can always define custom assistants to fit your organization's needs.
 </p>

--- a/01 Cloud Platform/12 Research Pipeline/02 Stage 0%3A Ideas.html
+++ b/01 Cloud Platform/12 Research Pipeline/02 Stage 0%3A Ideas.html
@@ -4,7 +4,7 @@
 </p>
 
 <p>
-  If you need some help generating some trading ideas, an <a href="/docs/v2/ai-assistance/assistants/ideas-assistant">Ideas Assistant</a> can add a steady stream of novel trading ideas to your organization's <span class="page-section-name">Ideas</span> list.
+  If you need some help generating some trading ideas, an <a href="/docs/v2/ai-assistance/predefined-assistants/ideas-assistant">Ideas Assistant</a> can add a steady stream of novel trading ideas to your organization's <span class="page-section-name">Ideas</span> list.
   This assistant analyzes recent financial news articles and trading blog posts.
   It then adds a card to the list with a concise description of the strategy, including the underlying logic, the types of assets it would trade, and any specific indicators or datasets it would utilize.
 </p>

--- a/01 Cloud Platform/12 Research Pipeline/03 Stage 1%3A Research.html
+++ b/01 Cloud Platform/12 Research Pipeline/03 Stage 1%3A Research.html
@@ -10,7 +10,7 @@
 </p>
 
 <p>
-  If you need some help researching ideas, add <a href="/docs/v2/ai-assistance/assistants/research-assistant">Research</a> and <a href="/docs/v2/ai-assistance/assistants/research-validation-assistant">Research Validation Assistants</a> to your organization.
+  If you need some help researching ideas, add <a href="/docs/v2/ai-assistance/predefined-assistants/research-assistant">Research</a> and <a href="/docs/v2/ai-assistance/predefined-assistants/research-validation-assistant">Research Validation Assistants</a> to your organization.
   The Research Assistant has access to tools that let it write, read, and execute research notebooks, and it produces a research report in the project that documents its process and findings &mdash; typically covering empirical evidence, statistical significance, and a deep analysis of the fundamental reason for the edge of the trading idea.
 </p>
 

--- a/01 Cloud Platform/12 Research Pipeline/04 Stage 2%3A Backtest.html
+++ b/01 Cloud Platform/12 Research Pipeline/04 Stage 2%3A Backtest.html
@@ -10,7 +10,7 @@
 </p>
 
 <p>
-  If you need some help backtesting ideas, add a <a href="/docs/v2/ai-assistance/assistants/backtest-assistant">Backtest Assistant</a> to your organization.
+  If you need some help backtesting ideas, add a <a href="/docs/v2/ai-assistance/predefined-assistants/backtest-assistant">Backtest Assistant</a> to your organization.
   This assistant has access to tools that enable it to write algorithms, fix coding errors, run backtests, interpret backtest results, and optimize parameters.
   The output of this assistant is an algorithm that's proven to underperform the market or an algorithm that's ready for testing in the paper trading environment.
 </p>

--- a/01 Cloud Platform/12 Research Pipeline/05 Stage 3%3A Paper Trading.html
+++ b/01 Cloud Platform/12 Research Pipeline/05 Stage 3%3A Paper Trading.html
@@ -8,7 +8,7 @@
 </p>
 
 <p>
-  If you need some help validating ideas with paper trading, add a <a href="/docs/v2/ai-assistance/assistants/paper-testing-assistant">Paper Testing Assistant</a> to your organization.
+  If you need some help validating ideas with paper trading, add a <a href="/docs/v2/ai-assistance/predefined-assistants/paper-testing-assistant">Paper Testing Assistant</a> to your organization.
   This assistant has access to tools to deploy algorithms, analyze their live performance, and adjust the algorithm logic if necessary.
   As it runs, it verifies the following questions:
 </p>

--- a/01 Cloud Platform/12 Research Pipeline/06 Stage 4%3A Live Trading.html
+++ b/01 Cloud Platform/12 Research Pipeline/06 Stage 4%3A Live Trading.html
@@ -5,7 +5,7 @@
 </p>
 
 <p>
-  If you need some help monitoring your live algorithms, add a <a href="/docs/v2/ai-assistance/assistants/live-monitoring-assistant">Live Monitoring Assistant</a> to your organization.
+  If you need some help monitoring your live algorithms, add a <a href="/docs/v2/ai-assistance/predefined-assistants/live-monitoring-assistant">Live Monitoring Assistant</a> to your organization.
   This assistant has access to tools to deploy algorithms, read their current positions, and scan for material news events that affect the positions.
   As it runs, it assesses the directional risk of your holdings given breaking news events.
   When it detects an event that can significantly reduce the value of your holdings, it notifies you so you can act.

--- a/09 AI Assistance/01 Getting Started/08 Quotas.html
+++ b/09 AI Assistance/01 Getting Started/08 Quotas.html
@@ -45,4 +45,4 @@
     We provide this value-added wrapper on the major providers so we can offer powerful tools without violating our data licenses, enabling you to easily use the major models and still have the full benefits of QuantConnect.
 </p>
 
-<p><i>*This quota is only for the <a href='/docs/v2/ai-assistance/strategy-development#07-Models'>Community model</a>.</i></p>
+<p><i>*This quota is only for the <a href='/docs/v2/ai-assistance/getting-started#07-Models'>Community model</a>.</i></p>

--- a/09 AI Assistance/03 Tasks/04 Schedule Work.html
+++ b/09 AI Assistance/03 Tasks/04 Schedule Work.html
@@ -1,6 +1,6 @@
 <p>
   By default, tasks require manual deployment where you open the task and click <span class='button-name'>Deploy Now</span>.
-  Organizations on the <a href='/docs/v2/cloud-platform/organizations/tier-features#05-Trading-Firm-Tier'>Trading Firm</a> or <a href='/docs/v2/cloud-platform/organizations/tier-features#06-Institution-Tier'>Institution</a> tier can schedule assistant tasks to run using the same <a href="/docs/v2/writing-algorithms/scheduled-events/key-concepts">Scheduled Event</a> system available in QuantConnect algorithms.
+  Organizations on the <a href='/docs/v2/cloud-platform/organizations/tier-features#05-Trading-Firm-Tier'>Trading Firm</a> or <a href='/docs/v2/cloud-platform/organizations/tier-features#06-Institution-Tier'>Institution</a> tier can schedule assistant tasks to run using the same <a href="/docs/v2/writing-algorithms/scheduled-events">Scheduled Event</a> system available in QuantConnect algorithms.
   These schedules include market open, fifteen minutes before close, the first trading day of the month, and more.
   Since Scheduled Events are aware of the <a href='/docs/v2/writing-algorithms/securities/market-hours'>market hours</a>, you can ensure your assistants won't run on weekends or US market holidays if that's your intention.
   This saves you from maintaining a holiday calendar or weekday filter in your prompts.

--- a/09 AI Assistance/03 Tasks/06 Chained Assistants.html
+++ b/09 AI Assistance/03 Tasks/06 Chained Assistants.html
@@ -4,6 +4,6 @@
   Use a chain when the work breaks naturally into stages that each have a different specialist, for example an Ideas Assistant feeding a Research Assistant feeding a Backtest Assistant.
 </p>
 <p>
-  You configure the chain in the <a href="/docs/v2/ai-assistance/assistants#08-Sub-Assistant-Orchestration">Sub-Assistant Orchestration</a> section of the assigned assistant rather than on the task.
+  You configure the chain in the <a href="/docs/v2/ai-assistance/assistants">Sub-Assistant Orchestration</a> section of the assigned assistant rather than on the task.
   Each assistant in the chain runs once per deployment in the order you set.
 </p>

--- a/09 AI Assistance/03 Tasks/07 Callable Assistants.html
+++ b/09 AI Assistance/03 Tasks/07 Callable Assistants.html
@@ -6,5 +6,5 @@
 <p>
   Use callable assistants when the path through the work is not known in advance.
   An assistant might call a Research Assistant in one deployment and a Live Monitoring Assistant in another, depending on what it finds.
-  You configure callable assistants in the <a href="/docs/v2/ai-assistance/assistants#08-Sub-Assistant-Orchestration">Sub-Assistant Orchestration</a> section of the assigned assistant rather than on the task.
+  You configure callable assistants in the <a href="/docs/v2/ai-assistance/assistants">Sub-Assistant Orchestration</a> section of the assigned assistant rather than on the task.
 </p>


### PR DESCRIPTION
#### Description

This PR fixes the broken documentation links reported by `url_check.py`.

Changes include:
- Updated old AI Assistance strategy development links to current AI Assistance pages.
- Updated old assistant links in the Research Pipeline documentation to the current predefined assistants pages.
- Updated the scheduled events key concepts link to the scheduled events page.
- Removed broken section anchors reported by the checker.

#### Related Issue

Fixes #2412

#### Motivation and Context

The documentation link checker reported several broken links and missing section anchors in #2412. This PR updates those links so the affected documentation pages no longer point to soft 404 pages or missing anchors.

Validation:
- Verified the #2412 link errors are resolved.
- A full local check with a runtime-only path filtering workaround completed with 0 errors.
- Result: `PASSED with 253 warning(s)`

Note:
The original `python url_check.py` cannot run a full scan in my local path `E:\.github\Documentation` because the current path filtering logic treats `.github` as matching `.git`.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`