### PR TITLE
Add Bitcoin block-time, live commands listener, and Telegram webhook project templates

### DIFF
--- a/project-templates/csharp/dataset-blockchain-bitcoin-metadata/Main.cs
+++ b/project-templates/csharp/dataset-blockchain-bitcoin-metadata/Main.cs
@@ -1,0 +1,127 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class BitcoinBlockTimeAlgorithm : QCAlgorithm
+{
+    private Crypto _btc;
+    private Symbol _metadata;
+    // 30-day rate of change on median block time (network speed regime).
+    private RateOfChange _roc = new(30);
+    // Stale-data guard: liquidate if the daily feed lags more than 3 days.
+    private DateTime? _lastMetadataTime;
+    private readonly TimeSpan _staleThreshold = TimeSpan.FromDays(3);
+
+    public override void Initialize()
+    {
+        SetStartDate(2023, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100_000);
+        // BTCUSD on Coinbase, minute resolution for fills.
+        _btc = AddCrypto("BTCUSD", Resolution.Minute, Market.Coinbase);
+        // Blockchain Bitcoin Metadata for daily on-chain network readings.
+        _metadata = AddData<BitcoinMetadata>(_btc.Symbol, Resolution.Daily).Symbol;
+        // Warm up the ROC from history so we can trade from the first bar.
+        var history = History<BitcoinMetadata>(_metadata, 30, Resolution.Daily);
+        foreach (var data in history)
+        {
+            Update(data);
+        }
+    }
+
+    private void Update(BitcoinMetadata data)
+    {
+        var blockTime = data.MedianTransactionConfirmationTime;
+        if (blockTime > 0)
+        {
+            _roc.Update(data.EndTime, blockTime);
+            _lastMetadataTime = data.EndTime;
+        }
+    }
+
+    public override void OnData(Slice slice)
+    {
+        // Daily metadata feed: only react when a fresh reading arrives.
+        if (slice.TryGet<BitcoinMetadata>(_metadata, out var data))
+        {
+            Update(data);
+        }
+        if (!_roc.IsReady)
+        {
+            return;
+        }
+        // Stop trading if the feed has gone stale (e.g. provider outage).
+        if (_lastMetadataTime == null || Time - _lastMetadataTime > _staleThreshold)
+        {
+            Liquidate(_btc.Symbol);
+            return;
+        }
+        // Faster blocks (block time trending down) -> long; slower -> flat.
+        if (_roc.Current.Value < 0m)
+        {
+            SetHoldings(_btc.Symbol, 1m);
+        }
+        else
+        {
+            Liquidate(_btc.Symbol);
+        }
+    }
+}

--- a/project-templates/csharp/live-commands-listener/Main.cs
+++ b/project-templates/csharp/live-commands-listener/Main.cs
@@ -1,0 +1,137 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+
+public class CommandPauseEmaCrossAlgorithm : QCAlgorithm
+{
+    private Symbol _spy;
+    private ExponentialMovingAverage _emaFast;
+    private ExponentialMovingAverage _emaSlow;
+    private bool _paused;
+
+    public override void Initialize()
+    {
+        SetStartDate(2024, 9, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+
+        // Request SPY at minute resolution so OnData (and the pause check) fires every minute
+        _spy = AddEquity("SPY", Resolution.Minute).Symbol;
+
+        // Enable automatic indicator warm-up
+        Settings.AutomaticIndicatorWarmUp = true;
+
+        // Create EMA indicators for trend detection
+        _emaFast = EMA(_spy, 50, Resolution.Daily);
+        _emaSlow = EMA(_spy, 200, Resolution.Daily);
+
+        // Restore pause state from Object Store so the flag survives restarts
+        if (ObjectStore.ContainsKey("paused"))
+        {
+            var stored = ObjectStore.Read("paused");
+            if (!string.IsNullOrEmpty(stored))
+            {
+                _paused = stored.Trim().ToLowerInvariant() == "true";
+                Log($"Restored pause state: paused={_paused}");
+            }
+        }
+    }
+
+    public override void OnData(Slice slice)
+    {
+        // Do not trade while paused
+        if (_paused) return;
+
+        // Wait for indicators to warm up
+        if (!_emaFast.IsReady || !_emaSlow.IsReady) return;
+
+        var fast = _emaFast.Current.Value;
+        var slow = _emaSlow.Current.Value;
+
+        // EMA cross trend-following strategy
+        if (fast > slow && !Portfolio[_spy].IsLong)
+        {
+            SetHoldings(_spy, 1.0);
+            Log($"Buy SPY at {slice.Time}: EMA50={fast:F2} > EMA200={slow:F2}");
+        }
+        else if (fast < slow && !Portfolio[_spy].IsShort)
+        {
+            SetHoldings(_spy, -1.0);
+            Log($"Short SPY at {slice.Time}: EMA50={fast:F2} < EMA200={slow:F2}");
+        }
+    }
+
+    public override bool? OnCommand(dynamic data)
+    {
+        // Handles pause/resume payload sent via REST or LEAN CLI:
+        // {"Command": "pause", "Paused": true|false}
+        // Going through OnCommand (instead of a Command subclass) lets us
+        // mutate algorithm-private state like _paused directly.
+        // Sender-script docs:
+        // https://www.quantconnect.com/docs/v2/writing-algorithms/live-trading/commands#06-Send-Commands-by-API
+        if ((string)data.Command != "pause") return false;
+        _paused = (bool)data.Paused;
+        ObjectStore.Save("paused", _paused ? "true" : "false");
+        Log($"OnCommand pause: paused={_paused}");
+        return true;
+    }
+}

--- a/project-templates/csharp/live-notifications-telegram-webhook/Main.cs
+++ b/project-templates/csharp/live-notifications-telegram-webhook/Main.cs
@@ -1,0 +1,130 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class TelegramNotificationAlgorithm : QCAlgorithm
+{
+    private Symbol _spy;
+    private ExponentialMovingAverage _ema50;
+    private ExponentialMovingAverage _ema200;
+    private bool? _previousEma50Above;
+
+    public override void Initialize()
+    {
+        SetStartDate(2024, 9, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+
+        Settings.AutomaticIndicatorWarmUp = true;
+
+        _spy = AddEquity("SPY", Resolution.Minute).Symbol;
+
+        _ema50 = EMA(_spy, 50, Resolution.Daily);
+        _ema200 = EMA(_spy, 200, Resolution.Daily);
+
+        _previousEma50Above = null;
+    }
+
+    public override void OnData(Slice slice)
+    {
+        if (!_ema50.IsReady || !_ema200.IsReady)
+        {
+            return;
+        }
+
+        var ema50Above = _ema50.Current.Value > _ema200.Current.Value;
+
+        if (_previousEma50Above == null)
+        {
+            _previousEma50Above = ema50Above;
+            return;
+        }
+
+        if (ema50Above && _previousEma50Above == false)
+        {
+            SetHoldings(_spy, 1.0);
+        }
+        else if (!ema50Above && _previousEma50Above == true)
+        {
+            SetHoldings(_spy, -1.0);
+        }
+
+        _previousEma50Above = ema50Above;
+    }
+
+    public override void OnOrderEvent(OrderEvent orderEvent)
+    {
+        if (orderEvent.Status != OrderStatus.Filled || !LiveMode)
+        {
+            return;
+        }
+
+        var direction = orderEvent.Direction == OrderDirection.Buy ? "BUY" : "SELL";
+        var message = $"SPY {direction} filled: {Math.Abs(orderEvent.FillQuantity)} @ {orderEvent.FillPrice:F2}";
+
+        var url = "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/sendMessage";
+        var body = $"{{\"chat_id\":\"<YOUR_CHAT_ID>\",\"text\":\"{message}\"}}";
+        var headers = new Dictionary<string, string> { { "Content-Type", "application/json" } };
+
+        Notify.Web(url, body, headers);
+        Log($"Notification sent: {message}");
+    }
+}

--- a/project-templates/csharp/templates.json
+++ b/project-templates/csharp/templates.json
@@ -511,6 +511,22 @@
 			"spec": "Asset: BTCUSD on Coinbase + BitcoinMetadata custom data. Minute. 2023-01-01 to 2024-12-31, $100k. add_data(BitcoinMetadata) for block time and difficulty fields. ROC(30) of average block time; long BTCUSD when ROC < 0, flat when > 0. Demonstrates: Blockchain Bitcoin Metadata dataset, on-chain regime switch (distinct from MVRV/hashrate templates). Edge case: handle stale data.",
 			"tags": ["Crypto", "alternative-data", "blockchain", "btc"],
 			"reference_template": "alternative-data-universe-coingeckouniverse"
+		},
+		{
+			"folder": "live-commands-listener",
+			"name": "Live: Commands Listener",
+			"description": "Pauses/resumes an SPY EMA cross strategy via the OnCommand handler, with pause state persisted in the Object Store.",
+			"spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. Override OnCommand(data): when data.Command=='pause', set _paused = data.Paused and persist via ObjectStore. EMA(50)/EMA(200) trades only when not paused. Demonstrates: OnCommand pattern with direct algorithm-attribute mutation. Edge case: restore pause state across restarts from Object Store.",
+			"tags": ["Equity", "live-trading", "commands", "object-store"],
+			"reference_template": "live-trading-features"
+		},
+		{
+			"folder": "live-notifications-telegram-webhook",
+			"name": "Live: Telegram Webhook Notifications",
+			"description": "Sends notifications to a Telegram bot via notify.web on every trade fill.",
+			"spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. EMA(50)/EMA(200) cross. On on_order_event(filled) call notify.web('https://api.telegram.org/...', headers={...}, body='...'). Demonstrates: notify.web for arbitrary HTTP webhook (different from email/SMS in live-trading-features). Edge case: stub URL in backtest mode.",
+			"tags": ["Equity", "live-trading", "notifications", "webhook"],
+			"reference_template": "live-trading-features"
 		}
 	]
 }

--- a/project-templates/csharp/templates.json
+++ b/project-templates/csharp/templates.json
@@ -503,6 +503,14 @@
 			"spec": "Assets: SPY, EFA, EEM, AGG, GLD. Minute. 2022-01-01 to 2024-12-31, $100k. ROC(60) per ETF. Monthly schedule picks top 3 and equal-weights; liquidates the others. Demonstrates: ROC across asset classes, monthly schedule, set_holdings 1/3 each. Edge case: hold cash if all ROCs negative.",
 			"tags": ["Equity", "asset-rotation", "roc", "scheduled-event"],
 			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "dataset-blockchain-bitcoin-metadata",
+			"name": "Dataset: Blockchain Bitcoin Metadata",
+			"description": "Trades BTCUSD long when 30-day Bitcoin block-time metadata trends down (faster blocks => more activity), flat when up.",
+			"spec": "Asset: BTCUSD on Coinbase + BitcoinMetadata custom data. Minute. 2023-01-01 to 2024-12-31, $100k. add_data(BitcoinMetadata) for block time and difficulty fields. ROC(30) of average block time; long BTCUSD when ROC < 0, flat when > 0. Demonstrates: Blockchain Bitcoin Metadata dataset, on-chain regime switch (distinct from MVRV/hashrate templates). Edge case: handle stale data.",
+			"tags": ["Crypto", "alternative-data", "blockchain", "btc"],
+			"reference_template": "alternative-data-universe-coingeckouniverse"
 		}
 	]
 }

--- a/project-templates/python/dataset-blockchain-bitcoin-metadata/main.py
+++ b/project-templates/python/dataset-blockchain-bitcoin-metadata/main.py
@@ -1,0 +1,47 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+
+class BitcoinBlockTimeAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2023, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100_000)
+        # BTCUSD on Coinbase, minute resolution for fills.
+        self._btc = self.add_crypto("BTCUSD", Resolution.MINUTE, Market.COINBASE)
+        # Blockchain Bitcoin Metadata for daily on-chain network readings.
+        self._metadata = self.add_data(BitcoinMetadata, self._btc.symbol, Resolution.DAILY).symbol
+        # 30-day rate of change on median block time (network speed regime).
+        self._roc = RateOfChange(30)
+        # Stale-data guard: liquidate if the daily feed lags more than 3 days.
+        self._last_metadata_time: datetime | None = None
+        self._stale_threshold = timedelta(days=3)
+        # Warm up the ROC from history so we can trade from the first bar.
+        history = self.history[BitcoinMetadata](self._metadata, 30, Resolution.DAILY)
+        for data in history:
+            self._update(data)
+
+    def _update(self, data: BitcoinMetadata) -> None:
+        block_time = data.median_transaction_confirmation_time
+        if block_time and block_time > 0:
+            self._roc.update(data.end_time, block_time)
+            self._last_metadata_time = data.end_time
+
+    def on_data(self, slice: Slice) -> None:
+        # Daily metadata feed: only react when a fresh reading arrives.
+        data = slice.get(self._metadata)
+        if data:
+            self._update(data)
+        if not self._roc.is_ready:
+            return
+        # Stop trading if the feed has gone stale (e.g. provider outage).
+        if self._last_metadata_time is None or self.time - self._last_metadata_time > self._stale_threshold:
+            self.liquidate(self._btc.symbol)
+            return
+        # Faster blocks (block time trending down) -> long; slower -> flat.
+        if self._roc.current.value < 0:
+            self.set_holdings(self._btc.symbol, 1.0)
+        else:
+            self.liquidate(self._btc.symbol)

--- a/project-templates/python/live-commands-listener/main.py
+++ b/project-templates/python/live-commands-listener/main.py
@@ -1,0 +1,63 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+
+class CommandPauseEmaCrossAlgorithm(QCAlgorithm):
+    _paused = False
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        # Request SPY at minute resolution so on_data (and the pause check) fires every minute
+        self._spy = self.add_equity("SPY", Resolution.MINUTE).symbol
+
+        # Enable automatic indicator warm-up
+        self.settings.automatic_indicator_warm_up = True
+
+        # Create EMA indicators for trend detection
+        self._ema_fast = self.ema(self._spy, 50, Resolution.DAILY)
+        self._ema_slow = self.ema(self._spy, 200, Resolution.DAILY)
+
+        # Restore pause state from Object Store so the flag survives restarts
+        if self.object_store.contains_key("paused"):
+            stored = self.object_store.read("paused")
+            if stored:
+                self._paused = stored.strip().lower() == "true"
+                self.log(f"Restored pause state: paused={self._paused}")
+
+    def on_data(self, slice: Slice) -> None:
+        # Skip trading while paused
+        if self._paused:
+            return
+
+        # Wait for indicators to warm up
+        if not self._ema_fast.is_ready or not self._ema_slow.is_ready:
+            return
+
+        fast = self._ema_fast.current.value
+        slow = self._ema_slow.current.value
+
+        # EMA cross trend-following strategy
+        if fast > slow and not self.portfolio[self._spy].is_long:
+            self.set_holdings(self._spy, 1.0)
+            self.log(f"Buy SPY at {slice.time}: EMA50={fast:.2f} > EMA200={slow:.2f}")
+        elif fast < slow and not self.portfolio[self._spy].is_short:
+            self.set_holdings(self._spy, -1.0)
+            self.log(f"Short SPY at {slice.time}: EMA50={fast:.2f} < EMA200={slow:.2f}")
+
+    def on_command(self, data: DynamicData) -> Optional[bool]:
+        # Handles pause/resume payload sent via REST or LEAN CLI:
+        # {"command": "pause", "paused": true|false}
+        # Going through on_command (instead of a Command subclass) lets us
+        # mutate algorithm-private state like self._paused directly.
+        # Sender-script docs:
+        # https://www.quantconnect.com/docs/v2/writing-algorithms/live-trading/commands#06-Send-Commands-by-API
+        if data.command != "pause":
+            return False
+        self._paused = bool(data.paused)
+        self.object_store.save("paused", "true" if self._paused else "false")
+        self.log(f"on_command pause: paused={self._paused}")
+        return True

--- a/project-templates/python/live-notifications-telegram-webhook/main.py
+++ b/project-templates/python/live-notifications-telegram-webhook/main.py
@@ -1,0 +1,48 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class TelegramNotificationAlgorithm(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.settings.automatic_indicator_warm_up = True
+
+        self._spy = self.add_equity("SPY", Resolution.MINUTE).symbol
+
+        self._ema50 = self.ema(self._spy, 50, Resolution.DAILY)
+        self._ema200 = self.ema(self._spy, 200, Resolution.DAILY)
+
+        self._previous_ema50_above = self._ema50.current.value > self._ema200.current.value
+
+    def on_data(self, slice: Slice) -> None:
+        if not self._ema50.is_ready or not self._ema200.is_ready:
+            return
+
+        ema50_above = self._ema50.current.value > self._ema200.current.value
+
+        if ema50_above and not self._previous_ema50_above:
+            self.set_holdings(self._spy, 1.0)
+        elif not ema50_above and self._previous_ema50_above:
+            self.set_holdings(self._spy, -1.0)
+
+        self._previous_ema50_above = ema50_above
+
+    def on_order_event(self, order_event: OrderEvent) -> None:
+        if order_event.status != OrderStatus.FILLED:
+            return
+
+        if not self.live_mode:
+            return
+
+        direction = "BUY" if order_event.direction == OrderDirection.BUY else "SELL"
+        message = f"SPY {direction} filled: {abs(order_event.fill_quantity)} @ {order_event.fill_price:.2f}"
+
+        url = "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/sendMessage"
+        headers = {"Content-Type": "application/json"}
+        body = f'{{"chat_id":"<YOUR_CHAT_ID>","text":"{message}"}}'
+
+        self.notify.web(url, data=body, headers=headers)
+        self.log(f"Notification sent: {message}")

--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -511,6 +511,22 @@
 			"spec": "Asset: BTCUSD on Coinbase + BitcoinMetadata custom data. Minute. 2023-01-01 to 2024-12-31, $100k. add_data(BitcoinMetadata) for block time and difficulty fields. ROC(30) of average block time; long BTCUSD when ROC < 0, flat when > 0. Demonstrates: Blockchain Bitcoin Metadata dataset, on-chain regime switch (distinct from MVRV/hashrate templates). Edge case: handle stale data.",
 			"tags": ["Crypto", "alternative-data", "blockchain", "btc"],
 			"reference_template": "alternative-data-universe-coingeckouniverse"
+		},
+		{
+			"folder": "live-commands-listener",
+			"name": "Live: Commands Listener",
+			"description": "Pauses/resumes an SPY EMA cross strategy via the on_command handler, with pause state persisted in the Object Store.",
+			"spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. Override on_command(data): when data.command=='pause', set self._paused = data.paused and persist via object_store. EMA(50)/EMA(200) trades only when not paused. Demonstrates: on_command pattern with direct algorithm-attribute mutation. Edge case: restore pause state across restarts from Object Store.",
+			"tags": ["Equity", "live-trading", "commands", "object-store"],
+			"reference_template": "live-trading-features"
+		},
+		{
+			"folder": "live-notifications-telegram-webhook",
+			"name": "Live: Telegram Webhook Notifications",
+			"description": "Sends notifications to a Telegram bot via notify.web on every trade fill.",
+			"spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. EMA(50)/EMA(200) cross. On on_order_event(filled) call notify.web('https://api.telegram.org/...', headers={...}, body='...'). Demonstrates: notify.web for arbitrary HTTP webhook (different from email/SMS in live-trading-features). Edge case: stub URL in backtest mode.",
+			"tags": ["Equity", "live-trading", "notifications", "webhook"],
+			"reference_template": "live-trading-features"
 		}
 	]
 }

--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -503,6 +503,14 @@
 			"spec": "Assets: SPY, EFA, EEM, AGG, GLD. Minute. 2022-01-01 to 2024-12-31, $100k. ROC(60) per ETF. Monthly schedule picks top 3 and equal-weights; liquidates the others. Demonstrates: ROC across asset classes, monthly schedule, set_holdings 1/3 each. Edge case: hold cash if all ROCs negative.",
 			"tags": ["Equity", "asset-rotation", "roc", "scheduled-event"],
 			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "dataset-blockchain-bitcoin-metadata",
+			"name": "Dataset: Blockchain Bitcoin Metadata",
+			"description": "Trades BTCUSD long when 30-day Bitcoin block-time metadata trends down (faster blocks => more activity), flat when up.",
+			"spec": "Asset: BTCUSD on Coinbase + BitcoinMetadata custom data. Minute. 2023-01-01 to 2024-12-31, $100k. add_data(BitcoinMetadata) for block time and difficulty fields. ROC(30) of average block time; long BTCUSD when ROC < 0, flat when > 0. Demonstrates: Blockchain Bitcoin Metadata dataset, on-chain regime switch (distinct from MVRV/hashrate templates). Edge case: handle stale data.",
+			"tags": ["Crypto", "alternative-data", "blockchain", "btc"],
+			"reference_template": "alternative-data-universe-coingeckouniverse"
 		}
 	]
 }

--- a/project-templates/template-ideas.json
+++ b/project-templates/template-ideas.json
@@ -3862,19 +3862,6 @@
       "reference_template": "alternative-data-universe"
     },
     {
-      "folder": "dataset-blockchain-bitcoin-metadata",
-      "name": "Dataset: Blockchain Bitcoin Metadata",
-      "description": "Trades BTCUSD long when 30-day Bitcoin block-time metadata trends down (faster blocks => more activity), flat when up.",
-      "spec": "Asset: BTCUSD on Coinbase + BitcoinMetadata custom data. Daily. 2023-01-01 to 2024-12-31, $100k. add_data(BitcoinMetadata) for block time and difficulty fields. ROC(30) of average block time; long BTCUSD when ROC < 0, flat when > 0. Demonstrates: Blockchain Bitcoin Metadata dataset, on-chain regime switch (distinct from MVRV/hashrate templates). Edge case: handle stale data.",
-      "tags": [
-        "Crypto",
-        "alternative-data",
-        "blockchain",
-        "btc"
-      ],
-      "reference_template": "alternative-data-universe-coingeckouniverse"
-    },
-    {
       "folder": "dataset-tickdata-international-futures",
       "name": "Dataset: TickData International Futures",
       "description": "Subscribes to the TickData International Futures feed for FDAX (Eurex DAX future) and trades a 50/200 SMA crossover at hourly resolution.",

--- a/project-templates/template-ideas.json
+++ b/project-templates/template-ideas.json
@@ -3589,32 +3589,6 @@
       "reference_template": "live-trading-features"
     },
     {
-      "folder": "live-commands-listener",
-      "name": "Live: Commands Listener",
-      "description": "Implements a custom Command class to manually pause/resume an SPY EMA cross strategy via API.",
-      "spec": "Asset: SPY. Daily. 2024-09-01 to 2024-12-31, $100k. Define class PauseCommand(Command): def run(...). add_command(PauseCommand). EMA(50)/EMA(200) trades only when not paused. Demonstrates: live commands pattern (different from existing live-trading-features), parameterized command. Edge case: persist pause state across restarts via Object Store.",
-      "tags": [
-        "Equity",
-        "live-trading",
-        "commands",
-        "object-store"
-      ],
-      "reference_template": "live-trading-features"
-    },
-    {
-      "folder": "live-notifications-telegram-webhook",
-      "name": "Live: Telegram Webhook Notifications",
-      "description": "Sends notifications to a Telegram bot via notify.web on every trade fill.",
-      "spec": "Asset: SPY. Daily. 2024-09-01 to 2024-12-31, $100k. EMA(50)/EMA(200) cross. On on_order_event(filled) call notify.web('https://api.telegram.org/...', headers={...}, body='...'). Demonstrates: notify.web for arbitrary HTTP webhook (different from email/SMS in live-trading-features). Edge case: stub URL in backtest mode.",
-      "tags": [
-        "Equity",
-        "live-trading",
-        "notifications",
-        "webhook"
-      ],
-      "reference_template": "live-trading-features"
-    },
-    {
       "folder": "alternative-data-universe-brainwikipediapageviews",
       "name": "Alternative Data Universe for Brain Wikipedia Page Views",
       "description": "Selects US Equities ranked by 5-day change in Brain Wikipedia page views; equal-weights the top 10 with a daily scheduled rebalance.",


### PR DESCRIPTION
## Summary

- Adds three project templates (Python `main.py` + C# `Main.cs` each), registers them in `project-templates/{python,csharp}/templates.json`, and removes the matching ideas from `project-templates/template-ideas.json`:
  - `dataset-blockchain-bitcoin-metadata` — trades BTCUSD on Coinbase using the 30-day ROC of the Blockchain Bitcoin Metadata median block time (long when ROC trends down, flat when up).
  - `live-commands-listener` — pauses/resumes an SPY EMA(50)/EMA(200) cross strategy via the `on_command` / `OnCommand` handler, with the pause flag persisted in the Object Store across restarts.
  - `live-notifications-telegram-webhook` — sends Telegram notifications via `notify.web` on every trade fill of an SPY EMA cross strategy.

## Test plan

- [x] `python project-templates/python/run_syntax_check.py` passes for each new template
- [x] dataset-blockchain-bitcoin-metadata — Python and C# backtests match: 308 orders, Net Profit 171.329%, Sharpe 1.549, End Equity $271,329.20 (2023-01-01 to 2024-12-31, $100k)
- [x] live-commands-listener — Python and C# backtests match: 1 order, Net Profit 5.189%, Sharpe 0.599, End Equity $105,188.64 (2024-09-01 to 2024-12-31, $100k, SPY minute)
