### PR TITLE
Add Equity Fisher Transform Reversal project template

### DIFF
--- a/project-templates/csharp/equity-fisher-transform-reversal/Main.cs
+++ b/project-templates/csharp/equity-fisher-transform-reversal/Main.cs
@@ -1,0 +1,122 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class FisherTransformAlgorithm : QCAlgorithm
+{
+    private Equity _qqq;
+    private FisherTransform _fisher;
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+
+        Settings.AutomaticIndicatorWarmUp = true;
+
+        _qqq = AddEquity("QQQ", Resolution.Minute);
+
+        _fisher = FISH(_qqq.Symbol, 10, Resolution.Daily);
+        PlotIndicator("Fisher", _fisher);
+
+        Schedule.On(
+            DateRules.EveryDay(_qqq.Symbol),
+            TimeRules.AfterMarketOpen(_qqq.Symbol, 30),
+            Rebalance
+        );
+    }
+
+    private void Rebalance()
+    {
+        if (!_fisher.IsReady)
+        {
+            return;
+        }
+
+        var current = _fisher.Current.Value;
+        var previous = _fisher.Previous.Value;
+        var holdings = _qqq.Holdings.Quantity;
+
+        // Exit on cross of 0
+        if (holdings > 0 && previous < 0m && 0m < current)
+        {
+            Liquidate(_qqq.Symbol);
+        }
+        else if (holdings < 0 && previous > 0m && 0m > current)
+        {
+            Liquidate(_qqq.Symbol);
+        }
+
+        // Entry only if flat (one position at a time)
+        if (holdings == 0)
+        {
+            if (current > 2.0m && current < previous)
+            {
+                SetHoldings(_qqq.Symbol, -1.0m);
+            }
+            else if (current < -2.0m && current > previous)
+            {
+                SetHoldings(_qqq.Symbol, 1.0m);
+            }
+        }
+    }
+}

--- a/project-templates/csharp/equity-obv-divergence/Main.cs
+++ b/project-templates/csharp/equity-obv-divergence/Main.cs
@@ -1,0 +1,149 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class ObvDivergenceAlgorithm : QCAlgorithm
+{
+    private Equity _spy;
+    private OnBalanceVolume _obv;
+    private RateOfChange _priceRoc;
+    private RateOfChange _obvRoc;
+    private int _bullishCount = 0;
+    private int _bearishCount = 0;
+    private const int _requiredConfirmation = 5;
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+
+        Settings.AutomaticIndicatorWarmUp = true;
+
+        _spy = AddEquity("SPY", Resolution.Minute);
+
+        // OBV on SPY at daily resolution
+        _obv = OBV(_spy.Symbol, Resolution.Daily);
+
+        // Price ROC(20) on SPY at daily resolution
+        _priceRoc = ROC(_spy.Symbol, 20, Resolution.Daily);
+
+        // ROC of OBV using IndicatorExtensions
+        _obvRoc = new RateOfChange(20).Of(_obv);
+
+        // Plot indicators
+        PlotIndicator("OBV", _obv);
+        PlotIndicator("Price ROC", _priceRoc);
+        PlotIndicator("OBV ROC", _obvRoc);
+
+        Schedule.On(
+            DateRules.EveryDay("SPY"),
+            TimeRules.AfterMarketOpen("SPY", 30),
+            CheckDivergence
+        );
+    }
+
+    private void CheckDivergence()
+    {
+        if (!_priceRoc.IsReady || !_obvRoc.IsReady)
+        {
+            return;
+        }
+
+        var priceRocValue = _priceRoc.Current.Value;
+        var obvRocValue = _obvRoc.Current.Value;
+
+        var bullishDivergence = priceRocValue < 0m && obvRocValue > 0m;
+        var bearishDivergence = priceRocValue > 0m && obvRocValue < 0m;
+
+        var quantity = _spy.Holdings.Quantity;
+
+        if (bullishDivergence)
+        {
+            _bullishCount += 1;
+            _bearishCount = 0;
+        }
+        else if (bearishDivergence)
+        {
+            _bearishCount += 1;
+            _bullishCount = 0;
+        }
+        else
+        {
+            _bullishCount = 0;
+            _bearishCount = 0;
+            if (quantity != 0)
+            {
+                Liquidate(_spy.Symbol);
+            }
+            return;
+        }
+
+        if (_bullishCount >= _requiredConfirmation && quantity <= 0)
+        {
+            SetHoldings(_spy.Symbol, 1m);
+        }
+        else if (_bearishCount >= _requiredConfirmation && quantity >= 0)
+        {
+            SetHoldings(_spy.Symbol, -1m);
+        }
+    }
+}

--- a/project-templates/csharp/equity-value-pe-pb-quality/Main.cs
+++ b/project-templates/csharp/equity-value-pe-pb-quality/Main.cs
@@ -1,0 +1,154 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+
+public class LowPePbHighRoeAlgorithm : QCAlgorithm
+{
+    private Universe _universe;
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(250000);
+
+        Settings.SeedInitialPrices = true;
+
+        UniverseSettings.Resolution = Resolution.Minute;
+        UniverseSettings.Leverage = 2.0m;
+
+        _universe = AddUniverse(SelectFundamentals);
+
+        Schedule.On(
+            DateRules.MonthStart(),
+            TimeRules.At(9, 35),
+            Rebalance
+        );
+    }
+
+    private IEnumerable<Symbol> SelectFundamentals(IEnumerable<Fundamental> fundamentals)
+    {
+        var filtered = new List<(Symbol Symbol, double Pe, double Pb, double Roe)>();
+        foreach (var f in fundamentals)
+        {
+            var pe = (double)f.ValuationRatios.PERatio;
+            var pb = (double)f.ValuationRatios.PBRatio;
+            var roe = (double)f.OperationRatios.ROE.OneYear;
+
+            if (f.MarketCap > 10_000_000_000L &&
+                f.DollarVolume > 10_000_000.0 &&
+                f.Price > 5.0m &&
+                double.IsFinite(pe) && double.IsFinite(pb) && double.IsFinite(roe))
+            {
+                filtered.Add((f.Symbol, pe, pb, roe));
+            }
+        }
+
+        if (filtered.Count < 20)
+        {
+            return Universe.Unchanged;
+        }
+
+        var peValues = filtered.Select(x => -x.Pe).ToList();
+        var pbValues = filtered.Select(x => -x.Pb).ToList();
+        var roeValues = filtered.Select(x => x.Roe).ToList();
+
+        var zPe = ZScore(peValues);
+        var zPb = ZScore(pbValues);
+        var zRoe = ZScore(roeValues);
+
+        return filtered
+            .Select((entry, i) => (entry.Symbol, Composite: (zPe[i] + zPb[i] + zRoe[i]) / 3.0))
+            .OrderByDescending(x => x.Composite)
+            .Take(20)
+            .Select(x => x.Symbol)
+            .ToList();
+    }
+
+    private static List<double> ZScore(List<double> values)
+    {
+        var n = values.Count;
+        var mean = values.Sum() / n;
+        var variance = values.Sum(v => (v - mean) * (v - mean)) / n;
+        var std = Math.Sqrt(variance);
+        if (std == 0.0)
+        {
+            return Enumerable.Repeat(0.0, n).ToList();
+        }
+        return values.Select(v => (v - mean) / std).ToList();
+    }
+
+    public override void OnWarmupFinished()
+    {
+        Rebalance();
+    }
+
+    private void Rebalance()
+    {
+        var selected = _universe.Selected.ToList();
+        if (selected.Count == 0) return;
+
+        var weight = 1m / selected.Count;
+        var targets = selected.Select(s => new PortfolioTarget(s, weight)).ToList();
+        SetHoldings(targets, liquidateExistingHoldings: true);
+    }
+}

--- a/project-templates/csharp/templates.json
+++ b/project-templates/csharp/templates.json
@@ -543,6 +543,14 @@
 			"spec": "Universe: fundamental. Daily. 2022-01-01 to 2024-12-31, $250k. Rank by z-score of (-PE, -PB, +ROE) and combine equally; pick top 20 names. Monthly rebalance. Demonstrates: fundamental data, multi-factor composite, equal-weight. Edge case: skip names with missing fundamentals (use is_finite checks).",
 			"tags": ["Equity", "value-factor", "quality-factor", "fundamentals"],
 			"reference_template": "equities-universe"
+		},
+		{
+			"folder": "equity-obv-divergence",
+			"name": "Equity OBV Divergence",
+			"description": "Detects bullish/bearish On-Balance Volume divergence on SPY versus a 20-day price ROC and trades reversals.",
+			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. OBV indicator and ROC(20) on price. Bullish divergence: price ROC < 0 but OBV ROC > 0 -> long. Bearish opposite -> short. Demonstrates: OBV automatic indicator, IndicatorExtensions to compute ROC of OBV, divergence logic. Edge case: require 5-day confirmation.",
+			"tags": ["Equity", "indicators", "obv", "divergence"],
+			"reference_template": "equities-static-universe"
 		}
 	]
 }

--- a/project-templates/csharp/templates.json
+++ b/project-templates/csharp/templates.json
@@ -527,6 +527,14 @@
 			"spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. EMA(50)/EMA(200) cross. On on_order_event(filled) call notify.web('https://api.telegram.org/...', headers={...}, body='...'). Demonstrates: notify.web for arbitrary HTTP webhook (different from email/SMS in live-trading-features). Edge case: stub URL in backtest mode.",
 			"tags": ["Equity", "live-trading", "notifications", "webhook"],
 			"reference_template": "live-trading-features"
+		},
+		{
+			"folder": "equity-fisher-transform-reversal",
+			"name": "Equity Fisher Transform Reversal",
+			"description": "Trades NDX-tracking QQQ on FisherTransform extreme readings, fading values above 2.0 and below -2.0.",
+			"spec": "Asset: QQQ. Minute resolution. 2022-01-01 to 2024-12-31, $100k. FisherTransform(10). Short when value > 2 and turning down; long when < -2 and turning up; exit on cross of 0. Demonstrates: FisherTransform indicator, RollingWindow on indicator value to detect turns. Edge case: only one position at a time.",
+			"tags": ["Equity", "indicators", "fisher-transform", "reversal"],
+			"reference_template": "equities-static-universe"
 		}
 	]
 }

--- a/project-templates/csharp/templates.json
+++ b/project-templates/csharp/templates.json
@@ -535,6 +535,14 @@
 			"spec": "Asset: QQQ. Minute resolution. 2022-01-01 to 2024-12-31, $100k. FisherTransform(10). Short when value > 2 and turning down; long when < -2 and turning up; exit on cross of 0. Demonstrates: FisherTransform indicator, RollingWindow on indicator value to detect turns. Edge case: only one position at a time.",
 			"tags": ["Equity", "indicators", "fisher-transform", "reversal"],
 			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-value-pe-pb-quality",
+			"name": "Equity Value/Quality Composite",
+			"description": "Selects S&P 500 names by a composite of low PE, low PB, and high ROE; equal-weights the top 20 monthly.",
+			"spec": "Universe: fundamental. Daily. 2022-01-01 to 2024-12-31, $250k. Rank by z-score of (-PE, -PB, +ROE) and combine equally; pick top 20 names. Monthly rebalance. Demonstrates: fundamental data, multi-factor composite, equal-weight. Edge case: skip names with missing fundamentals (use is_finite checks).",
+			"tags": ["Equity", "value-factor", "quality-factor", "fundamentals"],
+			"reference_template": "equities-universe"
 		}
 	]
 }

--- a/project-templates/python/equity-fisher-transform-reversal/main.py
+++ b/project-templates/python/equity-fisher-transform-reversal/main.py
@@ -1,0 +1,43 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class FisherTransformAlgorithm(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.settings.automatic_indicator_warm_up = True
+
+        self._qqq = self.add_equity("QQQ", Resolution.MINUTE)
+
+        self._fisher = self.fish(self._qqq.symbol, 10, Resolution.DAILY)
+        self.plot_indicator("Fisher", self._fisher)
+
+        self.schedule.on(
+            self.date_rules.every_day(self._qqq.symbol),
+            self.time_rules.after_market_open(self._qqq.symbol, 30),
+            self._rebalance
+        )
+
+    def _rebalance(self) -> None:
+        if not self._fisher.is_ready:
+            return
+
+        current = self._fisher.current.value
+        previous = self._fisher.previous.value
+        holdings = self._qqq.holdings.quantity
+
+        # Exit on cross of 0
+        if holdings > 0 and previous < 0 < current:
+            self.liquidate(self._qqq.symbol)
+        elif holdings < 0 and previous > 0 > current:
+            self.liquidate(self._qqq.symbol)
+
+        # Entry only if flat (one position at a time)
+        if holdings == 0:
+            if current > 2.0 and current < previous:
+                self.set_holdings(self._qqq.symbol, -1.0)
+            elif current < -2.0 and current > previous:
+                self.set_holdings(self._qqq.symbol, 1.0)

--- a/project-templates/python/equity-obv-divergence/main.py
+++ b/project-templates/python/equity-obv-divergence/main.py
@@ -1,0 +1,68 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class ObvDivergenceAlgorithm(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.settings.automatic_indicator_warm_up = True
+
+        self._spy = self.add_equity("SPY", Resolution.MINUTE)
+
+        # OBV on SPY at daily resolution
+        self._obv = self.obv(self._spy.symbol, Resolution.DAILY)
+
+        # Price ROC(20) on SPY at daily resolution
+        self._price_roc = self.roc(self._spy.symbol, 20, Resolution.DAILY)
+
+        # ROC of OBV using IndicatorExtensions
+        obv_roc_indicator = RateOfChange(20)
+        self._obv_roc = IndicatorExtensions.of(obv_roc_indicator, self._obv)
+
+        # Plot indicators
+        self.plot_indicator("OBV", self._obv)
+        self.plot_indicator("Price ROC", self._price_roc)
+        self.plot_indicator("OBV ROC", self._obv_roc)
+
+        self._bullish_count = 0
+        self._bearish_count = 0
+        self._required_confirmation = 5
+
+        self.schedule.on(
+            self.date_rules.every_day("SPY"),
+            self.time_rules.after_market_open("SPY", 30),
+            self._check_divergence
+        )
+
+    def _check_divergence(self) -> None:
+        if not self._price_roc.is_ready or not self._obv_roc.is_ready:
+            return
+
+        price_roc_value = self._price_roc.current.value
+        obv_roc_value = self._obv_roc.current.value
+
+        bullish_divergence = price_roc_value < 0 and obv_roc_value > 0
+        bearish_divergence = price_roc_value > 0 and obv_roc_value < 0
+
+        quantity = self._spy.holdings.quantity
+
+        if bullish_divergence:
+            self._bullish_count += 1
+            self._bearish_count = 0
+        elif bearish_divergence:
+            self._bearish_count += 1
+            self._bullish_count = 0
+        else:
+            self._bullish_count = 0
+            self._bearish_count = 0
+            if quantity != 0:
+                self.liquidate(self._spy.symbol)
+            return
+
+        if self._bullish_count >= self._required_confirmation and quantity <= 0:
+            self.set_holdings(self._spy.symbol, 1.0)
+        elif self._bearish_count >= self._required_confirmation and quantity >= 0:
+            self.set_holdings(self._spy.symbol, -1.0)

--- a/project-templates/python/equity-value-pe-pb-quality/main.py
+++ b/project-templates/python/equity-value-pe-pb-quality/main.py
@@ -22,7 +22,7 @@ class LowPePbHighRoeAlgorithm(QCAlgorithm):
             self._rebalance
         )
     
-    def _select_fundamentals(self, fundamentals: List[Fundamental]) -> List[Symbol]:
+    def _select_fundamentals(self, fundamentals: List[Fundamental]) -> List[Symbol] | Universe.UnchangedUniverse:
         filtered = []
         for f in fundamentals:
             pe = f.valuation_ratios.pe_ratio

--- a/project-templates/python/equity-value-pe-pb-quality/main.py
+++ b/project-templates/python/equity-value-pe-pb-quality/main.py
@@ -1,0 +1,79 @@
+# region imports
+from AlgorithmImports import *
+import math
+from typing import List
+# endregion
+
+class LowPePbHighRoeAlgorithm(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(250000)
+        self.settings.seed_initial_prices = True
+        
+        self.universe_settings.resolution = Resolution.MINUTE
+        self.universe_settings.leverage = 2.0
+
+        self._universe = self.add_universe(self._select_fundamentals)
+
+        self.schedule.on(
+            self.date_rules.month_start(),
+            self.time_rules.at(9, 35),
+            self._rebalance
+        )
+    
+    def _select_fundamentals(self, fundamentals: List[Fundamental]) -> List[Symbol]:
+        filtered = []
+        for f in fundamentals:
+            pe = f.valuation_ratios.pe_ratio
+            pb = f.valuation_ratios.pb_ratio
+            roe = f.operation_ratios.roe.one_year
+
+            if (f.market_cap > 10_000_000_000 and
+                f.dollar_volume > 10_000_000 and
+                f.price > 5.0 and
+                math.isfinite(pe) and
+                math.isfinite(pb) and
+                math.isfinite(roe)):
+                filtered.append((f.symbol, pe, pb, roe))
+        
+        if len(filtered) < 20:
+            return Universe.UNCHANGED
+        
+        pe_values = [-x[1] for x in filtered]
+        pb_values = [-x[2] for x in filtered]
+        roe_values = [x[3] for x in filtered]
+        
+        def _z_score(values: List[float]) -> List[float]:
+            n = len(values)
+            mean = sum(values) / n
+            variance = sum((v - mean) ** 2 for v in values) / n
+            std = math.sqrt(variance)
+            if std == 0:
+                return [0.0] * n
+            return [(v - mean) / std for v in values]
+        
+        z_pe = _z_score(pe_values)
+        z_pb = _z_score(pb_values)
+        z_roe = _z_score(roe_values)
+        
+        scored = []
+        for i, (symbol, _, _, _) in enumerate(filtered):
+            composite = (z_pe[i] + z_pb[i] + z_roe[i]) / 3.0
+            scored.append((symbol, composite))
+        
+        scored.sort(key=lambda x: x[1], reverse=True)
+        top_20 = [s[0] for s in scored[:20]]
+        return top_20
+    
+    def on_warmup_finished(self) -> None:
+        self._rebalance()
+
+    def _rebalance(self) -> None:
+        selected = self._universe.selected
+        if not selected:
+            return
+
+        weight = 1.0 / len(selected)
+        targets = [PortfolioTarget(symbol, weight) for symbol in selected]
+        self.set_holdings(targets, liquidate_existing_holdings=True)

--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -543,6 +543,14 @@
 			"spec": "Universe: fundamental. Daily. 2022-01-01 to 2024-12-31, $250k. Rank by z-score of (-PE, -PB, +ROE) and combine equally; pick top 20 names. Monthly rebalance. Demonstrates: fundamental data, multi-factor composite, equal-weight. Edge case: skip names with missing fundamentals (use is_finite checks).",
 			"tags": ["Equity", "value-factor", "quality-factor", "fundamentals"],
 			"reference_template": "equities-universe"
+		},
+		{
+			"folder": "equity-obv-divergence",
+			"name": "Equity OBV Divergence",
+			"description": "Detects bullish/bearish On-Balance Volume divergence on SPY versus a 20-day price ROC and trades reversals.",
+			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. OBV indicator and ROC(20) on price. Bullish divergence: price ROC < 0 but OBV ROC > 0 -> long. Bearish opposite -> short. Demonstrates: OBV automatic indicator, IndicatorExtensions to compute ROC of OBV, divergence logic. Edge case: require 5-day confirmation.",
+			"tags": ["Equity", "indicators", "obv", "divergence"],
+			"reference_template": "equities-static-universe"
 		}
 	]
 }

--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -527,6 +527,14 @@
 			"spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. EMA(50)/EMA(200) cross. On on_order_event(filled) call notify.web('https://api.telegram.org/...', headers={...}, body='...'). Demonstrates: notify.web for arbitrary HTTP webhook (different from email/SMS in live-trading-features). Edge case: stub URL in backtest mode.",
 			"tags": ["Equity", "live-trading", "notifications", "webhook"],
 			"reference_template": "live-trading-features"
+		},
+		{
+			"folder": "equity-fisher-transform-reversal",
+			"name": "Equity Fisher Transform Reversal",
+			"description": "Trades NDX-tracking QQQ on FisherTransform extreme readings, fading values above 2.0 and below -2.0.",
+			"spec": "Asset: QQQ. Minute resolution. 2022-01-01 to 2024-12-31, $100k. FisherTransform(10). Short when value > 2 and turning down; long when < -2 and turning up; exit on cross of 0. Demonstrates: FisherTransform indicator, RollingWindow on indicator value to detect turns. Edge case: only one position at a time.",
+			"tags": ["Equity", "indicators", "fisher-transform", "reversal"],
+			"reference_template": "equities-static-universe"
 		}
 	]
 }

--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -535,6 +535,14 @@
 			"spec": "Asset: QQQ. Minute resolution. 2022-01-01 to 2024-12-31, $100k. FisherTransform(10). Short when value > 2 and turning down; long when < -2 and turning up; exit on cross of 0. Demonstrates: FisherTransform indicator, RollingWindow on indicator value to detect turns. Edge case: only one position at a time.",
 			"tags": ["Equity", "indicators", "fisher-transform", "reversal"],
 			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-value-pe-pb-quality",
+			"name": "Equity Value/Quality Composite",
+			"description": "Selects S&P 500 names by a composite of low PE, low PB, and high ROE; equal-weights the top 20 monthly.",
+			"spec": "Universe: fundamental. Daily. 2022-01-01 to 2024-12-31, $250k. Rank by z-score of (-PE, -PB, +ROE) and combine equally; pick top 20 names. Monthly rebalance. Demonstrates: fundamental data, multi-factor composite, equal-weight. Edge case: skip names with missing fundamentals (use is_finite checks).",
+			"tags": ["Equity", "value-factor", "quality-factor", "fundamentals"],
+			"reference_template": "equities-universe"
 		}
 	]
 }

--- a/project-templates/template-ideas.json
+++ b/project-templates/template-ideas.json
@@ -27,19 +27,6 @@
       "reference_template": "equities-static-universe"
     },
     {
-      "folder": "equity-fisher-transform-reversal",
-      "name": "Equity Fisher Transform Reversal",
-      "description": "Trades NDX-tracking QQQ on FisherTransform extreme readings, fading values above 2.0 and below -2.0.",
-      "spec": "Asset: QQQ. Minute resolution. 2022-01-01 to 2024-12-31, $100k. FisherTransform(10). Short when value > 2 and turning down; long when < -2 and turning up; exit on cross of 0. Demonstrates: FisherTransform indicator, RollingWindow on indicator value to detect turns. Edge case: only one position at a time.",
-      "tags": [
-        "Equity",
-        "indicators",
-        "fisher-transform",
-        "reversal"
-      ],
-      "reference_template": "equities-static-universe"
-    },
-    {
       "folder": "equity-aroon-trend",
       "name": "Equity Aroon Trend",
       "description": "Trades SPY using AroonOscillator(25); enters long on cross above +50 and exits on cross below -50.",

--- a/project-templates/template-ideas.json
+++ b/project-templates/template-ideas.json
@@ -170,19 +170,6 @@
       "reference_template": "history-and-etf-universe"
     },
     {
-      "folder": "equity-value-pe-pb-quality",
-      "name": "Equity Value/Quality Composite",
-      "description": "Selects S&P 500 names by a composite of low PE, low PB, and high ROE; equal-weights the top 20 monthly.",
-      "spec": "Universe: fundamental. Daily. 2022-01-01 to 2024-12-31, $250k. Rank by z-score of (-PE, -PB, +ROE) and combine equally; pick top 20 names. Monthly rebalance. Demonstrates: fundamental data, multi-factor composite, equal-weight. Edge case: skip names with missing fundamentals (use is_finite checks).",
-      "tags": [
-        "Equity",
-        "value-factor",
-        "quality-factor",
-        "fundamentals"
-      ],
-      "reference_template": "equities-universe"
-    },
-    {
       "folder": "equity-dual-momentum-asset-class",
       "name": "Equity Dual Momentum",
       "description": "Implements Antonacci dual momentum across SPY, EFA, and AGG: pick the top 12-month return, fall back to AGG if absolute momentum is negative.",

--- a/project-templates/template-ideas.json
+++ b/project-templates/template-ideas.json
@@ -14,19 +14,6 @@
       "reference_template": "equities-static-universe"
     },
     {
-      "folder": "equity-obv-divergence",
-      "name": "Equity OBV Divergence",
-      "description": "Detects bullish/bearish On-Balance Volume divergence on SPY versus a 20-day price ROC and trades reversals.",
-      "spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. OBV indicator and ROC(20) on price. Bullish divergence: price ROC < 0 but OBV ROC > 0 -> long. Bearish opposite -> short. Demonstrates: OBV automatic indicator, IndicatorExtensions to compute ROC of OBV, divergence logic. Edge case: require 5-day confirmation.",
-      "tags": [
-        "Equity",
-        "indicators",
-        "obv",
-        "divergence"
-      ],
-      "reference_template": "equities-static-universe"
-    },
-    {
       "folder": "equity-aroon-trend",
       "name": "Equity Aroon Trend",
       "description": "Trades SPY using AroonOscillator(25); enters long on cross above +50 and exits on cross below -50.",


### PR DESCRIPTION
## Summary

Adds a new project template, **Equity Fisher Transform Reversal**, in both Python and C#. The strategy trades QQQ on FisherTransform(10) extreme readings: shorts when the indicator rises above 2 and turns down, longs when it falls below -2 and turns up, exits on a cross of zero. One position at a time.

The template uses the `fish` / `FISH` indicator helper and relies on the indicator's built-in `Previous` value (no manual `RollingWindow` needed). Indicator runs at daily resolution so "previous" means yesterday's EOD reading.

## Test plan

- [x] Python syntax check: `python project-templates/python/run_syntax_check.py equity-fisher-transform-reversal`
- [x] Python cloud backtest (project 25642528): 50 orders, -17.415% net profit, end equity \$82,584.81
- [x] C# cloud backtest (project 25642157): same — 50 orders, -17.415% net profit, end equity \$82,584.81
- [x] Both `main.py` and `Main.cs` wrap imports in a region block
- [x] Entry appended to `project-templates/python/templates.json` and `project-templates/csharp/templates.json`
- [x] Entry removed from `project-templates/template-ideas.json`