### PR TITLE
Add equity indicator project templates (batch 3)

### DIFF
--- a/project-templates/csharp/equity-aroon-trend/Main.cs
+++ b/project-templates/csharp/equity-aroon-trend/Main.cs
@@ -1,0 +1,105 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class AroonOscillatorAlgorithm : QCAlgorithm
+{
+    private Symbol _spy;
+    private AroonOscillator _aroon;
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+
+        Settings.AutomaticIndicatorWarmUp = true;
+
+        _spy = AddEquity("SPY", Resolution.Minute).Symbol;
+
+        _aroon = AROON(_spy, 25, Resolution.Minute);
+
+        PlotIndicator("Aroon Oscillator", _aroon);
+    }
+
+    public override void OnData(Slice data)
+    {
+        if (!_aroon.IsReady)
+        {
+            return;
+        }
+
+        var current = _aroon.Current.Value;
+        var previous = _aroon.Previous.Value;
+
+        if (Portfolio[_spy].IsLong)
+        {
+            if (previous >= -50m && current < -50m)
+            {
+                Liquidate(_spy);
+            }
+        }
+        else if (previous <= 50m && current > 50m)
+        {
+            SetHoldings(_spy, 1.0m);
+        }
+    }
+}

--- a/project-templates/csharp/equity-atr-volatility-stop/Main.cs
+++ b/project-templates/csharp/equity-atr-volatility-stop/Main.cs
@@ -1,0 +1,133 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class AtrChandelierTrailingStopAlgorithm : QCAlgorithm
+{
+    private Equity _spy;
+    private AverageTrueRange _atr;
+    private decimal _trailingHigh;
+    private bool _waitingToReenter;
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+        Settings.AutomaticIndicatorWarmUp = true;
+
+        _spy = AddEquity("SPY", Resolution.Minute);
+        _atr = ATR(_spy.Symbol, 14);
+        _trailingHigh = 0m;
+        _waitingToReenter = false;
+
+        Plot("Stop", "ATR Stop", 0);
+        Plot("Stop", "Trailing High", 0);
+    }
+
+    public override void OnData(Slice data)
+    {
+        if (!_atr.IsReady)
+        {
+            return;
+        }
+
+        if (!data.Bars.TryGetValue(_spy.Symbol, out var bar))
+        {
+            return;
+        }
+
+        var close = bar.Close;
+
+        if (_waitingToReenter)
+        {
+            SetHoldings(_spy.Symbol, 1.0);
+            _trailingHigh = close;
+            _waitingToReenter = false;
+            return;
+        }
+
+        if (!Portfolio.Invested)
+        {
+            SetHoldings(_spy.Symbol, 1.0);
+            _trailingHigh = close;
+            return;
+        }
+
+        if (close > _trailingHigh)
+        {
+            _trailingHigh = close;
+        }
+
+        var atrValue = _atr.Current.Value;
+        var stopLevel = _trailingHigh - 3.0m * atrValue;
+
+        Plot("Stop", "ATR Stop", stopLevel);
+        Plot("Stop", "Trailing High", _trailingHigh);
+
+        if (close < stopLevel)
+        {
+            Liquidate(_spy.Symbol);
+            _waitingToReenter = true;
+            _trailingHigh = 0m;
+        }
+    }
+}

--- a/project-templates/csharp/equity-cci-overbought/Main.cs
+++ b/project-templates/csharp/equity-cci-overbought/Main.cs
@@ -1,0 +1,143 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class XleCciMeanReversionAlgorithm : QCAlgorithm
+{
+    private const decimal _atrThreshold = 0.01m;
+
+    private Equity _xle;
+    private CommodityChannelIndex _cci;
+    private AverageTrueRange _atr;
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+        Settings.AutomaticIndicatorWarmUp = true;
+
+        _xle = AddEquity("XLE", Resolution.Minute);
+
+        _cci = CCI(_xle.Symbol, 20, MovingAverageType.Simple, Resolution.Daily);
+        _atr = ATR(_xle.Symbol, 14, MovingAverageType.Simple, Resolution.Daily);
+
+        PlotIndicator("CCI", _cci);
+
+        Schedule.On(
+            DateRules.EveryDay(_xle.Symbol),
+            TimeRules.AfterMarketOpen(_xle.Symbol, 1),
+            Rebalance
+        );
+    }
+
+    private void Rebalance()
+    {
+        if (!_cci.IsReady || !_atr.IsReady)
+        {
+            return;
+        }
+
+        var price = Securities[_xle.Symbol].Price;
+        if (price == 0m)
+        {
+            return;
+        }
+
+        var atrRatio = _atr.Current.Value / price;
+        Plot("ATR Ratio", "Ratio", atrRatio);
+        Plot("ATR Ratio", "Threshold", _atrThreshold);
+        if (atrRatio < _atrThreshold)
+        {
+            return;
+        }
+
+        var cci = _cci.Current.Value;
+        var holdings = _xle.Holdings.Quantity;
+
+        // Exit long at CCI >= 0
+        if (holdings > 0 && cci >= 0m)
+        {
+            Liquidate(_xle.Symbol, tag: $"Exit long XLE at CCI = {cci:F2}");
+            holdings = 0;
+        }
+
+        // Cover short at CCI <= 0
+        if (holdings < 0 && cci <= 0m)
+        {
+            Liquidate(_xle.Symbol, tag: $"Cover short XLE at CCI = {cci:F2}");
+            holdings = 0;
+        }
+
+        // Enter new positions
+        if (holdings == 0)
+        {
+            if (cci < -100m)
+            {
+                SetHoldings(_xle.Symbol, 1.0m, tag: $"Long XLE at CCI = {cci:F2}");
+            }
+            else if (cci > 100m)
+            {
+                SetHoldings(_xle.Symbol, -1.0m, tag: $"Short XLE at CCI = {cci:F2}");
+            }
+        }
+    }
+}

--- a/project-templates/csharp/equity-williams-percent-r/Main.cs
+++ b/project-templates/csharp/equity-williams-percent-r/Main.cs
@@ -1,0 +1,140 @@
+#region imports
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Globalization;
+    using System.Drawing;
+    using QuantConnect;
+    using QuantConnect.Algorithm.Framework;
+    using QuantConnect.Algorithm.Framework.Selection;
+    using QuantConnect.Algorithm.Framework.Alphas;
+    using QuantConnect.Algorithm.Framework.Portfolio;
+    using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+    using QuantConnect.Algorithm.Framework.Execution;
+    using QuantConnect.Algorithm.Framework.Risk;
+    using QuantConnect.Algorithm.Selection;
+    using QuantConnect.Api;
+    using QuantConnect.Parameters;
+    using QuantConnect.Benchmarks;
+    using QuantConnect.Brokerages;
+    using QuantConnect.Commands;
+    using QuantConnect.Configuration;
+    using QuantConnect.Util;
+    using QuantConnect.Interfaces;
+    using QuantConnect.Algorithm;
+    using QuantConnect.Indicators;
+    using QuantConnect.Data;
+    using QuantConnect.Data.Auxiliary;
+    using QuantConnect.Data.Consolidators;
+    using QuantConnect.Data.Custom;
+    using QuantConnect.Data.Custom.IconicTypes;
+    using QuantConnect.DataSource;
+    using QuantConnect.Data.Fundamental;
+    using QuantConnect.Data.Market;
+    using QuantConnect.Data.Shortable;
+    using QuantConnect.Data.UniverseSelection;
+    using QuantConnect.Notifications;
+    using QuantConnect.Orders;
+    using QuantConnect.Orders.Fees;
+    using QuantConnect.Orders.Fills;
+    using QuantConnect.Orders.OptionExercise;
+    using QuantConnect.Orders.Slippage;
+    using QuantConnect.Orders.TimeInForces;
+    using QuantConnect.Python;
+    using QuantConnect.Scheduling;
+    using QuantConnect.Securities;
+    using QuantConnect.Securities.Equity;
+    using QuantConnect.Securities.Future;
+    using QuantConnect.Securities.Option;
+    using QuantConnect.Securities.Positions;
+    using QuantConnect.Securities.Forex;
+    using QuantConnect.Securities.Crypto;
+    using QuantConnect.Securities.CryptoFuture;
+    using QuantConnect.Securities.IndexOption;
+    using QuantConnect.Securities.Interfaces;
+    using QuantConnect.Securities.Volatility;
+    using QuantConnect.Storage;
+    using QuantConnect.Statistics;
+    using QCAlgorithmFramework = QuantConnect.Algorithm.QCAlgorithm;
+    using QCAlgorithmFrameworkBridge = QuantConnect.Algorithm.QCAlgorithm;
+    using Calendar = QuantConnect.Data.Consolidators.Calendar;
+#endregion
+public class WilliamsPercentRIWMAlgorithm : QCAlgorithm
+{
+    private const decimal _wmrBuyThreshold = -80m;
+    private const decimal _wmrSellThreshold = -20m;
+    private const int _maxHoldDays = 5;
+
+    private Symbol _symbol;
+    private WilliamsPercentR _wmr;
+    private int _holdDays;
+
+    public override void Initialize()
+    {
+        SetStartDate(2022, 1, 1);
+        SetEndDate(2024, 12, 31);
+        SetCash(100000);
+        Settings.AutomaticIndicatorWarmUp = true;
+
+        _symbol = AddEquity("IWM", Resolution.Minute).Symbol;
+        _wmr = WILR(_symbol, 14, Resolution.Minute);
+
+        Schedule.On(
+            DateRules.EveryDay(_symbol),
+            TimeRules.BeforeMarketClose(_symbol, 1),
+            CheckHoldDuration
+        );
+    }
+
+    public override void OnData(Slice data)
+    {
+        if (!_wmr.IsReady)
+        {
+            return;
+        }
+
+        var wmrValue = _wmr.Current.Value;
+        var quantity = Portfolio[_symbol].Quantity;
+
+        if (Time.Minute % 10 == 0)
+        {
+            PlotWilliams(wmrValue);
+        }
+
+        if (quantity > 0 && wmrValue > _wmrSellThreshold)
+        {
+            Liquidate(_symbol);
+            _holdDays = 0;
+            PlotWilliams(wmrValue);
+            return;
+        }
+
+        if (quantity <= 0 && wmrValue < _wmrBuyThreshold)
+        {
+            SetHoldings(_symbol, 1.0m);
+            _holdDays = 0;
+            PlotWilliams(wmrValue);
+        }
+    }
+
+    private void PlotWilliams(decimal wmrValue)
+    {
+        Plot("Williams %R", "IWM", wmrValue);
+        Plot("Williams %R", "-80", _wmrBuyThreshold);
+        Plot("Williams %R", "-20", _wmrSellThreshold);
+    }
+
+    private void CheckHoldDuration()
+    {
+        if (Portfolio[_symbol].Quantity > 0)
+        {
+            _holdDays += 1;
+            if (_holdDays >= _maxHoldDays)
+            {
+                Liquidate(_symbol);
+                _holdDays = 0;
+            }
+        }
+    }
+}

--- a/project-templates/csharp/templates.json
+++ b/project-templates/csharp/templates.json
@@ -551,6 +551,38 @@
 			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. OBV indicator and ROC(20) on price. Bullish divergence: price ROC < 0 but OBV ROC > 0 -> long. Bearish opposite -> short. Demonstrates: OBV automatic indicator, IndicatorExtensions to compute ROC of OBV, divergence logic. Edge case: require 5-day confirmation.",
 			"tags": ["Equity", "indicators", "obv", "divergence"],
 			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-atr-volatility-stop",
+			"name": "Equity ATR Volatility Stop",
+			"description": "Holds SPY long with an ATR(14) chandelier-style trailing stop set 3x ATR below the trailing high.",
+			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. ATR(14). Buy on first bar; maintain trailing high; if close < trailing_high - 3*ATR, liquidate and re-enter on next bar. Demonstrates: ATR indicator, manual trailing-stop pattern, plotting stop level. Edge case: reset trailing high after each liquidation.",
+			"tags": ["Equity", "indicators", "atr", "trailing-stop"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-aroon-trend",
+			"name": "Equity Aroon Trend",
+			"description": "Trades SPY using AroonOscillator(25); enters long on cross above +50 and exits on cross below -50.",
+			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. AroonOscillator(25). Long when oscillator crosses above 50; exit when it crosses below -50. Demonstrates: Aroon indicator, threshold crossing pattern, plotting oscillator on subchart. Edge case: do not flip short — long-only.",
+			"tags": ["Equity", "indicators", "aroon", "trend"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-cci-overbought",
+			"name": "Equity Commodity Channel Index",
+			"description": "Trades XLE on CCI(20) — long when CCI < -100 and exit at 0; short when CCI > 100 and cover at 0.",
+			"spec": "Asset: XLE. Minute resolution. 2022-01-01 to 2024-12-31, $100k. CommodityChannelIndex(20). Long when CCI < -100; short when CCI > 100; both exit at 0. Demonstrates: CCI indicator, mean-reversion with explicit short side, sector ETF. Edge case: skip orders during low-volatility (ATR filter).",
+			"tags": ["Equity", "indicators", "cci", "mean-reversion"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-williams-percent-r",
+			"name": "Equity Williams %R",
+			"description": "Trades IWM with WilliamsPercentR(14): long entries below -80 and exits above -20.",
+			"spec": "Asset: IWM. Minute resolution. 2022-01-01 to 2024-12-31, $100k. WilliamsPercentR(14). Long when %R < -80; exit when %R > -20. Demonstrates: Williams %R indicator, oversold reversion logic, plotting against -80/-20 reference lines. Edge case: hold cap of 5 trading days.",
+			"tags": ["Equity", "indicators", "williams-r", "oscillator"],
+			"reference_template": "equities-static-universe"
 		}
 	]
 }

--- a/project-templates/python/equity-aroon-trend/main.py
+++ b/project-templates/python/equity-aroon-trend/main.py
@@ -1,0 +1,30 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class AroonOscillatorAlgorithm(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+
+        self.settings.automatic_indicator_warm_up = True
+
+        self._spy = self.add_equity("SPY", Resolution.MINUTE).symbol
+
+        self._aroon = self.aroon(self._spy, 25, Resolution.MINUTE)
+
+        self.plot_indicator("Aroon Oscillator", self._aroon)
+
+    def on_data(self, data: Slice) -> None:
+        if not self._aroon.is_ready:
+            return
+
+        current = self._aroon.current.value
+        previous = self._aroon.previous.value
+
+        if self.portfolio[self._spy].is_long:
+            if previous >= -50 and current < -50:
+                self.liquidate(self._spy)
+        elif previous <= 50 and current > 50:
+            self.set_holdings(self._spy, 1.0)

--- a/project-templates/python/equity-atr-volatility-stop/main.py
+++ b/project-templates/python/equity-atr-volatility-stop/main.py
@@ -1,0 +1,53 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class AtrChandelierTrailingStopAlgorithm(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+        self.settings.automatic_indicator_warm_up = True
+
+        self._spy = self.add_equity("SPY", Resolution.MINUTE)
+        self._atr = self.atr(self._spy.symbol, 14)
+        self._trailing_high: float = 0.0
+        self._waiting_to_reenter = False
+
+        self.plot("Stop", "ATR Stop", 0)
+        self.plot("Stop", "Trailing High", 0)
+
+    def on_data(self, data: Slice) -> None:
+        if not self._atr.is_ready:
+            return
+
+        bar = data.bars.get(self._spy.symbol)
+        if bar is None:
+            return
+
+        close = bar.close
+
+        if self._waiting_to_reenter:
+            self.set_holdings(self._spy.symbol, 1.0)
+            self._trailing_high = close
+            self._waiting_to_reenter = False
+            return
+
+        if not self.portfolio.invested:
+            self.set_holdings(self._spy.symbol, 1.0)
+            self._trailing_high = close
+            return
+
+        if close > self._trailing_high:
+            self._trailing_high = close
+
+        atr_value = self._atr.current.value
+        stop_level = self._trailing_high - 3.0 * atr_value
+
+        self.plot("Stop", "ATR Stop", stop_level)
+        self.plot("Stop", "Trailing High", self._trailing_high)
+
+        if close < stop_level:
+            self.liquidate(self._spy.symbol)
+            self._waiting_to_reenter = True
+            self._trailing_high = 0.0

--- a/project-templates/python/equity-cci-overbought/main.py
+++ b/project-templates/python/equity-cci-overbought/main.py
@@ -1,0 +1,59 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class XleCciMeanReversionAlgorithm(QCAlgorithm):
+    _atr_threshold = 0.01  # Skip if ATR / price < 1%
+
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+        self.settings.automatic_indicator_warm_up = True
+
+        self._xle = self.add_equity("XLE", Resolution.MINUTE).symbol
+
+        self._cci = self.cci(self._xle, 20, MovingAverageType.SIMPLE, Resolution.DAILY)
+        self._atr = self.atr(self._xle, 14, MovingAverageType.SIMPLE, Resolution.DAILY)
+
+        self.plot_indicator("CCI", self._cci)
+
+        self.schedule.on(
+            self.date_rules.every_day(self._xle),
+            self.time_rules.after_market_open(self._xle, 1),
+            self._rebalance
+        )
+
+    def _rebalance(self) -> None:
+        if not self._cci.is_ready or not self._atr.is_ready:
+            return
+
+        price = self.securities[self._xle].price
+        if price == 0:
+            return
+
+        atr_ratio = self._atr.current.value / price
+        self.plot("ATR Ratio", "Ratio", atr_ratio)
+        self.plot("ATR Ratio", "Threshold", self._atr_threshold)
+        if atr_ratio < self._atr_threshold:
+            return
+
+        cci = self._cci.current.value
+        holdings = self.portfolio[self._xle].quantity
+
+        # Exit long at CCI >= 0
+        if holdings > 0 and cci >= 0:
+            self.liquidate(self._xle, tag=f"Exit long XLE at CCI = {cci:.2f}")
+            holdings = 0
+
+        # Cover short at CCI <= 0
+        if holdings < 0 and cci <= 0:
+            self.liquidate(self._xle, tag=f"Cover short XLE at CCI = {cci:.2f}")
+            holdings = 0
+
+        # Enter new positions
+        if holdings == 0:
+            if cci < -100:
+                self.set_holdings(self._xle, 1.0, tag=f"Long XLE at CCI = {cci:.2f}")
+            elif cci > 100:
+                self.set_holdings(self._xle, -1.0, tag=f"Short XLE at CCI = {cci:.2f}")

--- a/project-templates/python/equity-williams-percent-r/main.py
+++ b/project-templates/python/equity-williams-percent-r/main.py
@@ -1,0 +1,58 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class WilliamsPercentRIWMAlgorithm(QCAlgorithm):
+    def initialize(self) -> None:
+        self.set_start_date(2022, 1, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100000)
+        self.settings.automatic_indicator_warm_up = True
+
+        self._wmr_buy_threshold = -80
+        self._wmr_sell_threshold = -20
+        self._max_hold_days = 5
+
+        self._symbol = self.add_equity("IWM", Resolution.MINUTE).symbol
+        self._wmr = self.wilr(self._symbol, 14, Resolution.MINUTE)
+
+        self._hold_days = 0
+
+        self.schedule.on(
+            self.date_rules.every_day(self._symbol),
+            self.time_rules.before_market_close(self._symbol, 1),
+            self._check_hold_duration
+        )
+
+    def on_data(self, data: Slice) -> None:
+        if not self._wmr.is_ready:
+            return
+
+        wmr_value = self._wmr.current.value
+        quantity = self.portfolio[self._symbol].quantity
+
+        if self.time.minute % 10 == 0:
+            self._plot(wmr_value)
+
+        if quantity > 0 and wmr_value > self._wmr_sell_threshold:
+            self.liquidate(self._symbol)
+            self._hold_days = 0
+            self._plot(wmr_value)
+            return
+
+        if quantity <= 0 and wmr_value < self._wmr_buy_threshold:
+            self.set_holdings(self._symbol, 1.0)
+            self._hold_days = 0
+            self._plot(wmr_value)
+
+    def _plot(self, wmr_value: float) -> None:
+        self.plot("Williams %R", "IWM", wmr_value)
+        self.plot("Williams %R", "-80", self._wmr_buy_threshold)
+        self.plot("Williams %R", "-20", self._wmr_sell_threshold)
+
+    def _check_hold_duration(self) -> None:
+        if self.portfolio[self._symbol].quantity > 0:
+            self._hold_days += 1
+            if self._hold_days >= self._max_hold_days:
+                self.liquidate(self._symbol)
+                self._hold_days = 0

--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -551,6 +551,38 @@
 			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. OBV indicator and ROC(20) on price. Bullish divergence: price ROC < 0 but OBV ROC > 0 -> long. Bearish opposite -> short. Demonstrates: OBV automatic indicator, IndicatorExtensions to compute ROC of OBV, divergence logic. Edge case: require 5-day confirmation.",
 			"tags": ["Equity", "indicators", "obv", "divergence"],
 			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-atr-volatility-stop",
+			"name": "Equity ATR Volatility Stop",
+			"description": "Holds SPY long with an ATR(14) chandelier-style trailing stop set 3x ATR below the trailing high.",
+			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. ATR(14). Buy on first bar; maintain trailing high; if close < trailing_high - 3*ATR, liquidate and re-enter on next bar. Demonstrates: ATR indicator, manual trailing-stop pattern, plotting stop level. Edge case: reset trailing high after each liquidation.",
+			"tags": ["Equity", "indicators", "atr", "trailing-stop"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-aroon-trend",
+			"name": "Equity Aroon Trend",
+			"description": "Trades SPY using AroonOscillator(25); enters long on cross above +50 and exits on cross below -50.",
+			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. AroonOscillator(25). Long when oscillator crosses above 50; exit when it crosses below -50. Demonstrates: Aroon indicator, threshold crossing pattern, plotting oscillator on subchart. Edge case: do not flip short — long-only.",
+			"tags": ["Equity", "indicators", "aroon", "trend"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-cci-overbought",
+			"name": "Equity Commodity Channel Index",
+			"description": "Trades XLE on CCI(20) — long when CCI < -100 and exit at 0; short when CCI > 100 and cover at 0.",
+			"spec": "Asset: XLE. Minute resolution. 2022-01-01 to 2024-12-31, $100k. CommodityChannelIndex(20). Long when CCI < -100; short when CCI > 100; both exit at 0. Demonstrates: CCI indicator, mean-reversion with explicit short side, sector ETF. Edge case: skip orders during low-volatility (ATR filter).",
+			"tags": ["Equity", "indicators", "cci", "mean-reversion"],
+			"reference_template": "equities-static-universe"
+		},
+		{
+			"folder": "equity-williams-percent-r",
+			"name": "Equity Williams %R",
+			"description": "Trades IWM with WilliamsPercentR(14): long entries below -80 and exits above -20.",
+			"spec": "Asset: IWM. Minute resolution. 2022-01-01 to 2024-12-31, $100k. WilliamsPercentR(14). Long when %R < -80; exit when %R > -20. Demonstrates: Williams %R indicator, oversold reversion logic, plotting against -80/-20 reference lines. Edge case: hold cap of 5 trading days.",
+			"tags": ["Equity", "indicators", "williams-r", "oscillator"],
+			"reference_template": "equities-static-universe"
 		}
 	]
 }

--- a/project-templates/template-ideas.json
+++ b/project-templates/template-ideas.json
@@ -1,58 +1,6 @@
 {
   "ideas": [
     {
-      "folder": "equity-atr-volatility-stop",
-      "name": "Equity ATR Volatility Stop",
-      "description": "Holds SPY long with an ATR(14) chandelier-style trailing stop set 3x ATR below the trailing high.",
-      "spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. ATR(14). Buy on first bar; maintain trailing high; if close < trailing_high - 3*ATR, liquidate and re-enter on next bar. Demonstrates: ATR indicator, manual trailing-stop pattern, plotting stop level. Edge case: reset trailing high after each liquidation.",
-      "tags": [
-        "Equity",
-        "indicators",
-        "atr",
-        "trailing-stop"
-      ],
-      "reference_template": "equities-static-universe"
-    },
-    {
-      "folder": "equity-aroon-trend",
-      "name": "Equity Aroon Trend",
-      "description": "Trades SPY using AroonOscillator(25); enters long on cross above +50 and exits on cross below -50.",
-      "spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. AroonOscillator(25). Long when oscillator crosses above 50; exit when it crosses below -50. Demonstrates: Aroon indicator, threshold crossing pattern, plotting oscillator on subchart. Edge case: do not flip short — long-only.",
-      "tags": [
-        "Equity",
-        "indicators",
-        "aroon",
-        "trend"
-      ],
-      "reference_template": "equities-static-universe"
-    },
-    {
-      "folder": "equity-williams-percent-r",
-      "name": "Equity Williams %R",
-      "description": "Trades IWM with WilliamsPercentR(14): long entries below -80 and exits above -20.",
-      "spec": "Asset: IWM. Minute resolution. 2022-01-01 to 2024-12-31, $100k. WilliamsPercentR(14). Long when %R < -80; exit when %R > -20. Demonstrates: Williams %R indicator, oversold reversion logic, plotting against -80/-20 reference lines. Edge case: hold cap of 5 trading days.",
-      "tags": [
-        "Equity",
-        "indicators",
-        "williams-r",
-        "oscillator"
-      ],
-      "reference_template": "equities-static-universe"
-    },
-    {
-      "folder": "equity-cci-overbought",
-      "name": "Equity Commodity Channel Index",
-      "description": "Trades XLE on CCI(20) — long when CCI < -100 and exit at 0; short when CCI > 100 and cover at 0.",
-      "spec": "Asset: XLE. Minute resolution. 2022-01-01 to 2024-12-31, $100k. CommodityChannelIndex(20). Long when CCI < -100; short when CCI > 100; both exit at 0. Demonstrates: CCI indicator, mean-reversion with explicit short side, sector ETF. Edge case: skip orders during low-volatility (ATR filter).",
-      "tags": [
-        "Equity",
-        "indicators",
-        "cci",
-        "mean-reversion"
-      ],
-      "reference_template": "equities-static-universe"
-    },
-    {
       "folder": "equity-mfi-divergence",
       "name": "Equity Money Flow Index",
       "description": "Uses the built-in MFI(14) on SPY for overbought/oversold reversion — distinct from the existing custom-indicator template.",


### PR DESCRIPTION
## Summary

Adds four equity indicator project templates (Python `main.py` + C# `Main.cs` each) with their `templates.json` registrations:

- **equity-aroon-trend** — SPY long on AroonOscillator(25) crosses above +50, exit on cross below -50
- **equity-atr-volatility-stop** — SPY long with an ATR(14) chandelier-style trailing stop at 3x ATR below the trailing high
- **equity-cci-overbought** — XLE mean-reversion on CCI(20): long < -100 / short > 100, both exit at 0
- **equity-williams-percent-r** — IWM oversold reversion on WilliamsPercentR(14): long < -80, exit > -20, 5-day hold cap

Built entries are removed from `template-ideas.json`.

## Test plan

- Each template compiles and backtests on QuantConnect Cloud.
- For every template, the C# port reproduces the Python reference backtest (same order count and key statistics).
- `python project-templates/python/run_syntax_check.py <folder>` passes for each new template (100% success rate).