### PR TITLE
Fix sub-assistant anchor normalization

### DIFF
--- a/url_check.py
+++ b/url_check.py
@@ -103,6 +103,7 @@ SECTION_REPLACEMENTS = [
     ("mixed mode consolidators", "mixed-mode consolidators"),
     ("Multi Alpha",  "Multi-Alpha"),
     ("Self Managed", "Self-Managed"),
+    ("Sub Assistant", "Sub-Assistant"),
     ("Margin3F",     "Margin%3F"),
     ("Greeks3F",     "Greeks%3F"),
     ("Smile3F",      "Smile%3F"),


### PR DESCRIPTION
#### Description

Fixes #2426.

This updates `url_check.py` so section anchor normalization handles `Sub-Assistant` correctly. The broken link checker was normalizing:

`#08-Sub-Assistant-Orchestration`

to:

`08 Sub Assistant Orchestration`

but the existing documentation section file is:

`08 Sub-Assistant Orchestration.html`

Adding this replacement lets the checker match the existing section without renaming the documentation page.

#### Testing

- Ran `python -m py_compile url_check.py`
- Verified the #2426 anchor check returns `OK`
- Ran `python url_check.py`