### PR TITLE
Add cloud match check for project templates

### DIFF
--- a/.github/workflows/syntax-tests.yml
+++ b/.github/workflows/syntax-tests.yml
@@ -3,17 +3,20 @@ name: Syntax Tests
 on:
   push:
     paths:
-      - 'project-templates/python/**'
+      - 'project-templates/**'
       - '.github/workflows/syntax-tests.yml'
   pull_request:
     branches: [master]
     paths:
-      - 'project-templates/python/**'
+      - 'project-templates/**'
       - '.github/workflows/syntax-tests.yml'
 
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -36,11 +39,33 @@ jobs:
           docker run -d \
             --workdir /__w/Documentation/Documentation \
             -v /home/runner/work:/__w \
+            -e DOCS_TEMPLATE_USER_ID=${{ secrets.QUANTCONNECT_USER_ID }} \
+            -e DOCS_TEMPLATE_USER_TOKEN="${{ secrets.QUANTCONNECT_API_TOKEN }}" \
+            -e DOCS_TEMPLATE_ORG_ID=${{ secrets.DOCUMENTATION_ORG_ID }} \
             --name test-container \
             quantconnect/lean:foundation \
             tail -f /dev/null
 
       - name: Run Syntax Test
         run: |
-          runInContainer bash -c "pip install --no-cache-dir quantconnect-stubs types-requests==2.32.* types-pytz==2025.2.0.* mypy==1.20.2"
+          runInContainer bash -c "pip install --no-cache-dir quantconnect-stubs requests types-requests==2.32.* types-pytz==2025.2.0.* mypy==1.20.2"
           runInContainer python -u project-templates/python/run_syntax_check.py
+
+      - name: Run Project Match Check
+        run: |
+          runInContainer python -u project-templates/run_project_match_check.py
+
+      - name: Open PR for templates.json changes
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: auto/update-template-project-ids
+          title: Update templates.json with new project IDs
+          commit-message: Update templates.json with new project IDs
+          body: |
+            Project IDs created automatically by the `Run Project Match Check`
+            step in the `Syntax Tests` workflow. Merge to keep cloud project
+            IDs in sync with the templates in this repo.
+          add-paths: |
+            project-templates/templates.json
+          delete-branch: true

--- a/project-templates/python/run_syntax_check.py
+++ b/project-templates/python/run_syntax_check.py
@@ -6,24 +6,26 @@ import re
 from pathlib import Path
 from subprocess import run
 from multiprocessing import Pool, Lock, freeze_support
+from multiprocessing.synchronize import Lock as LockType
 
-target_files = []
-lock = None
+target_files: list[str] = []
+lock: LockType | None = None
 start_time = time.time()
 
 LOG_PATH = Path(__file__).resolve().parent / "syntax-check.log"
 
 
-def init_pool(l):
+def init_pool(l: LockType) -> None:
     global lock
     lock = l
 
-def log(message: str):
+def log(message: str) -> None:
     print(message)
     with open(LOG_PATH, "a") as file:
         file.write(message)
 
-def sync_log(message: str):
+def sync_log(message: str) -> None:
+    assert lock is not None
     with lock:
         log(message)
 
@@ -34,7 +36,7 @@ for subdir, dirs, files_in_folder in os.walk("./project-templates/python"):
             target_files.append(file_path)
 target_files.sort()
 
-def adjust_file_contents(target_file: str):
+def adjust_file_contents(target_file: str) -> tempfile._TemporaryFileWrapper[bytes] | None:
     try:
         file = Path(target_file)
         file_content = file.read_text(encoding='utf-8')
@@ -110,7 +112,7 @@ def should_ignore(line: str, prev_line_ignored: bool) -> bool:
     return False
 
 
-def run_syntax_check(target_file: str):
+def run_syntax_check(target_file: str) -> bool:
     tmp_file = adjust_file_contents(target_file)
     if not tmp_file:
         return False

--- a/project-templates/run_project_match_check.py
+++ b/project-templates/run_project_match_check.py
@@ -1,0 +1,394 @@
+"""Verify project templates against their QuantConnect Cloud projects.
+
+For each entry in ``project-templates/templates.json``:
+
+  * If ``projectIdCs`` is ``null``, create a new C# project named after the
+    template, upload ``project-templates/csharp/<folder>/Main.cs``, compile,
+    and run a backtest.
+  * Otherwise, fetch ``Main.cs`` from the cloud project, compare with the
+    local file, and if they differ upload the local copy, compile, and run a
+    backtest.
+  * Same flow for ``projectIdPy`` / ``project-templates/python/<folder>/main.py``.
+
+Python and C# work runs in parallel, capped at 3 concurrent tasks per
+language (6 total). Newly created project IDs are written back to
+``templates.json`` so subsequent runs reuse the same projects.
+
+Credentials come from the environment (preferred) or, as a fallback for
+local runs, from ``~/.lean/credentials``:
+
+    DOCS_TEMPLATE_USER_ID       <- user-id
+    DOCS_TEMPLATE_USER_TOKEN    <- api-token
+    DOCS_TEMPLATE_ORG_ID        <- organization-id  (optional in env, required
+                                                     so new projects land in the
+                                                     documentation org)
+
+Usage:
+    python run_project_match_check.py            # check every template
+    python run_project_match_check.py <folder>   # check just one folder
+"""
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import sys
+import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, NamedTuple, cast
+
+import requests
+
+
+def _load_credentials() -> tuple[str, str, str | None]:
+    user_id = os.environ.get("DOCS_TEMPLATE_USER_ID")
+    user_token = os.environ.get("DOCS_TEMPLATE_USER_TOKEN")
+    org_id = os.environ.get("DOCS_TEMPLATE_ORG_ID")
+    if user_id and user_token:
+        return user_id, user_token, org_id
+
+    creds_file = Path.home() / ".lean" / "credentials"
+    if not creds_file.exists():
+        raise RuntimeError(
+            "Set DOCS_TEMPLATE_USER_ID and DOCS_TEMPLATE_USER_TOKEN, "
+            f"or create {creds_file} via `lean login`."
+        )
+    file_creds = json.loads(creds_file.read_text(encoding="utf-8"))
+    return (
+        user_id or str(file_creds["user-id"]),
+        user_token or str(file_creds["api-token"]),
+        org_id or file_creds.get("organization-id"),
+    )
+
+
+USER_ID, USER_TOKEN, ORG_ID = _load_credentials()
+BASE_URL = "https://www.quantconnect.com/api/v2"
+COLLABORATOR_USER_IDS = ["alexandre_catarino"]
+
+WORKERS_PER_LANG = 3
+RETRY_ATTEMPTS = 5
+COMPILE_POLL_SEC = 2
+COMPILE_MAX_ATTEMPTS = 90          # ~3 minutes
+BACKTEST_POLL_SEC = 10
+BACKTEST_MAX_ATTEMPTS = 360        # ~1 hour
+REQUEST_TIMEOUT_SEC = 60
+
+TEMPLATES_ROOT = Path(__file__).resolve().parent
+TEMPLATES_FILE = TEMPLATES_ROOT / "templates.json"
+
+LANG_CONFIG: dict[str, dict[str, str]] = {
+    "python": {
+        "api_lang": "Py",
+        "subdir": "python",
+        "filename": "main.py",
+        "project_key": "projectIdPy",
+    },
+    "csharp": {
+        "api_lang": "C#",
+        "subdir": "csharp",
+        "filename": "Main.cs",
+        "project_key": "projectIdCs",
+    },
+}
+
+_print_lock = threading.Lock()
+
+
+def log(msg: str) -> None:
+    with _print_lock:
+        print(msg, flush=True)
+
+
+# ---------------------------------------------------------------- QC Cloud API
+
+
+def _headers() -> dict[str, str]:
+    ts = str(int(time.time()))
+    digest = hashlib.sha256(f"{USER_TOKEN}:{ts}".encode()).hexdigest()
+    auth = base64.b64encode(f"{USER_ID}:{digest}".encode()).decode()
+    return {"Authorization": f"Basic {auth}", "Timestamp": ts}
+
+
+def _post(path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    last_error: str = ""
+    for attempt in range(RETRY_ATTEMPTS):
+        try:
+            resp = requests.post(
+                BASE_URL + path,
+                headers=_headers(),
+                json=payload,
+                timeout=REQUEST_TIMEOUT_SEC,
+            )
+            body = resp.json()
+        except (requests.RequestException, ValueError) as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            time.sleep(2)
+            continue
+        if body.get("success"):
+            return cast(dict[str, Any], body)
+        last_error = json.dumps(body.get("errors") or body)
+        time.sleep(2)
+    raise RuntimeError(f"{path} failed after {RETRY_ATTEMPTS} attempts: {last_error}")
+
+
+def create_project(name: str, language: str) -> tuple[int, set[str]]:
+    """Create a project and return (projectId, set of existing collaborator publicIds).
+
+    The set includes the owner and anyone already attached to the project
+    (e.g. auto-added org admins, or collaborators added manually before this
+    run), so the caller can skip them when inviting new ones.
+    """
+    payload: dict[str, Any] = {"name": name, "language": language}
+    if ORG_ID:
+        payload["organizationId"] = ORG_ID
+    body = _post("/projects/create", payload)
+    project = body["projects"][0]
+    existing_collaborators = {c["publicId"] for c in project.get("collaborators", [])}
+    return int(project["projectId"]), existing_collaborators
+
+
+def add_collaborator(project_id: int, collaborator_user_id: str) -> None:
+    _post(
+        "/projects/collaboration/create",
+        {
+            "projectId": project_id,
+            "collaboratorUserId": collaborator_user_id,
+            "collaborationLiveControl": True,
+            "collaborationWrite": True,
+        },
+    )
+
+
+def get_collaborators(project_id: int) -> set[str]:
+    """Return publicIds of every collaborator currently on the project."""
+    body = _post("/projects/collaboration/read", {"projectId": project_id})
+    return {c["publicId"] for c in body.get("collaborators", [])}
+
+
+def update_file(project_id: int, filename: str, content: str) -> None:
+    _post("/files/update", {"projectId": project_id, "name": filename, "content": content})
+
+
+def read_file(project_id: int, filename: str) -> str | None:
+    body = _post("/files/read", {"projectId": project_id, "name": filename})
+    files = body.get("files") or []
+    if not files:
+        return None
+    return cast("str | None", files[0].get("content"))
+
+
+def compile_project(project_id: int) -> str:
+    body = _post("/compile/create", {"projectId": project_id})
+    compile_id = body["compileId"]
+    for _ in range(COMPILE_MAX_ATTEMPTS):
+        body = _post("/compile/read", {"projectId": project_id, "compileId": compile_id})
+        state = body.get("state")
+        if state == "BuildSuccess":
+            return cast(str, compile_id)
+        if state == "BuildError":
+            raise RuntimeError(f"compile failed: {body.get('logs')}")
+        time.sleep(COMPILE_POLL_SEC)
+    raise RuntimeError("compile timed out")
+
+
+def run_backtest(project_id: int, compile_id: str, name: str) -> dict[str, Any]:
+    body = _post(
+        "/backtests/create",
+        {"projectId": project_id, "compileId": compile_id, "backtestName": name},
+    )
+    bt = body["backtest"]
+    if isinstance(bt, list):
+        bt = bt[0]
+    backtest_id = bt["backtestId"]
+
+    for _ in range(BACKTEST_MAX_ATTEMPTS):
+        body = _post("/backtests/read", {"projectId": project_id, "backtestId": backtest_id})
+        bt = body["backtest"]
+        if isinstance(bt, list):
+            bt = bt[0]
+        if bt.get("completed"):
+            return cast(dict[str, Any], bt)
+        time.sleep(BACKTEST_POLL_SEC)
+    raise RuntimeError("backtest timed out")
+
+
+def validate_backtest(bt: dict[str, Any]) -> str | None:
+    if bt.get("error"):
+        return f"backtest error: {bt['error']}"
+    if bt.get("stacktrace"):
+        return f"backtest stacktrace: {bt['stacktrace']}"
+    return None
+
+
+# ---------------------------------------------------------- per-template work
+
+
+class CheckResult(NamedTuple):
+    folder: str
+    lang_key: str
+    project_id: int | None
+    created: bool
+    ok: bool
+    message: str
+
+
+def process_template(entry: dict[str, Any], lang_key: str) -> CheckResult:
+    cfg = LANG_CONFIG[lang_key]
+    folder = entry["folder"]
+    name = entry["name"]
+    file_path = TEMPLATES_ROOT / cfg["subdir"] / folder / cfg["filename"]
+    label = f"[{cfg['api_lang']}] {folder}"
+
+    if not file_path.exists():
+        return CheckResult(folder, lang_key, None, False, False,
+                           f"missing local file {file_path}")
+
+    local_code = file_path.read_text(encoding="utf-8")
+    project_id_raw = entry.get(cfg["project_key"])
+    project_id: int | None = int(project_id_raw) if project_id_raw else None
+    created = False
+
+    try:
+        if not project_id:
+            project_id, existing_collaborators = create_project(
+                f"Template/{name} ({cfg['api_lang']})", cfg["api_lang"]
+            )
+            created = True
+            log(f"{label}: created project {project_id}")
+            cloud_code: str | None = None
+        else:
+            cloud_code = read_file(project_id, cfg["filename"])
+            if not cloud_code:
+                return CheckResult(folder, lang_key, project_id, created, False,
+                                   f"could not read {cfg['filename']} from project {project_id}")
+            existing_collaborators = get_collaborators(project_id)
+
+        for collaborator in COLLABORATOR_USER_IDS:
+            if collaborator in existing_collaborators:
+                continue
+            try:
+                add_collaborator(project_id, collaborator)
+                log(f"{label}: added collaborator {collaborator} to project {project_id}")
+            except RuntimeError as exc:
+                log(f"{label}: WARNING — could not add collaborator {collaborator}: {exc}")
+
+        if cloud_code == local_code:
+            log(f"{label}: project {project_id} matches local — skipping backtest")
+            return CheckResult(folder, lang_key, project_id, created, True, "")
+
+        if cloud_code:
+            log(f"{label}: project {project_id} differs from local — uploading")
+        
+        update_file(project_id, cfg["filename"], local_code)
+        compile_id = compile_project(project_id)
+        bt = run_backtest(project_id, compile_id, f"match-check-{int(time.time())}")
+        err = validate_backtest(bt)
+        if err:
+            return CheckResult(folder, lang_key, project_id, created, False,
+                               f"project {project_id}: {err}")
+        log(f"{label}: project {project_id} backtest passed")
+        return CheckResult(folder, lang_key, project_id, created, True, "")
+    except RuntimeError as exc:
+        return CheckResult(folder, lang_key, project_id, created, False, str(exc))
+
+
+# ----------------------------------------------------------- templates.json IO
+
+
+def _render_templates_json(templates: list[dict[str, Any]]) -> str:
+    """Serialize templates.json the way the repo stores it: tab indent, CRLF,
+    list values (tags) kept inline."""
+    lines = ["{", '\t"templates": [']
+    for i, entry in enumerate(templates):
+        lines.append("\t\t{")
+        keys = list(entry)
+        for j, key in enumerate(keys):
+            value = entry[key]
+            if isinstance(value, list):
+                rendered = "[" + ", ".join(
+                    json.dumps(v, ensure_ascii=False) for v in value
+                ) + "]"
+            else:
+                rendered = json.dumps(value, ensure_ascii=False)
+            tail = "," if j < len(keys) - 1 else ""
+            lines.append(f"\t\t\t{json.dumps(key)}: {rendered}{tail}")
+        lines.append("\t\t}" + ("," if i < len(templates) - 1 else ""))
+    lines.append("\t]")
+    lines.append("}")
+    return "\r\n".join(lines) + "\r\n"
+
+
+def save_templates(data: dict[str, Any]) -> None:
+    # newline="" disables Windows CRLF translation; the renderer already emits \r\n.
+    with open(TEMPLATES_FILE, "w", encoding="utf-8", newline="") as f:
+        f.write(_render_templates_json(data["templates"]))
+
+
+# -------------------------------------------------------------------- main
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "folder", nargs="?",
+        help="Optional folder name; if given, only that template is checked.",
+    )
+    args = parser.parse_args()
+
+    data = json.loads(TEMPLATES_FILE.read_text(encoding="utf-8"))
+    templates: list[dict[str, Any]] = data["templates"]
+    if args.folder:
+        templates = [t for t in templates if t["folder"] == args.folder]
+        if not templates:
+            log(f"No template found with folder={args.folder!r}")
+            return 1
+
+    log(f"Checking {len(templates)} template(s) against QuantConnect Cloud"
+        + (f" in org {ORG_ID}" if ORG_ID else ""))
+
+    by_folder: dict[str, dict[str, Any]] = {t["folder"]: t for t in templates}
+    results: list[CheckResult] = []
+
+    with (
+        ThreadPoolExecutor(max_workers=WORKERS_PER_LANG, thread_name_prefix="py") as py_pool,
+        ThreadPoolExecutor(max_workers=WORKERS_PER_LANG, thread_name_prefix="cs") as cs_pool,
+    ):
+        futures: list[Future[CheckResult]] = []
+        for entry in templates:
+            futures.append(py_pool.submit(process_template, entry, "python"))
+            futures.append(cs_pool.submit(process_template, entry, "csharp"))
+
+        for fut in as_completed(futures):
+            result = fut.result()
+            results.append(result)
+            if not result.ok:
+                log(f"FAIL [{result.lang_key}] {result.folder}: {result.message}")
+
+    # Persist any newly created project IDs back to templates.json.
+    new_ids = False
+    for result in results:
+        if result.created and result.project_id:
+            entry = by_folder[result.folder]
+            key = LANG_CONFIG[result.lang_key]["project_key"]
+            entry[key] = result.project_id
+            new_ids = True
+    if new_ids:
+        save_templates(data)
+        log(f"Updated {TEMPLATES_FILE} with newly created project IDs — commit the change.")
+
+    failures = [r for r in results if not r.ok]
+    log("=" * 60)
+    log(f"Passed: {len(results) - len(failures)}/{len(results)}")
+    if failures:
+        log(f"Failed: {len(failures)}")
+        for r in failures:
+            log(f"  [{r.lang_key}] {r.folder}: {r.message}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/project-templates/templates.json
+++ b/project-templates/templates.json
@@ -1,0 +1,800 @@
+{
+	"templates": [
+		{
+			"name": "Equity Parabolic SAR Trailing Stop",
+			"folder": "equity-parabolic-sar-trailing",
+			"description": "Trades SPY long-only with Parabolic SAR providing dynamic trailing-stop levels and re-entries.",
+			"tags": ["Equity", "indicators", "parabolic-sar", "trailing-stop", "indicator-plotting"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-aroon-trend",
+			"name": "Equity Aroon Trend",
+			"description": "Trades SPY using AroonOscillator(25); enters long on cross above +50 and exits on cross below -50.",
+			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. AroonOscillator(25). Long when oscillator crosses above 50; exit when it crosses below -50. Demonstrates: Aroon indicator, threshold crossing pattern, plotting oscillator on subchart. Edge case: do not flip short — long-only.",
+			"tags": ["Equity", "indicators", "aroon", "trend"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity Bollinger Mean Reversion",
+			"folder": "equity-bollinger-mean-reversion",
+			"description": "Trades SPY on a 20-period, 2-standard-deviation Bollinger Bands mean-reversion signal — buys when price closes below the lower band and liquidates on a return to the middle band — with a daily scheduled rebalance.",
+			"tags": ["Equity", "indicators", "bollinger-bands", "mean-reversion", "z-score"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity RSI Overbought/Oversold",
+			"folder": "equity-rsi-overbought-oversold",
+			"description": "Trades QQQ on a 14-period RSI: long when RSI < 30 and exit at RSI > 50; short when RSI > 70 and cover at RSI < 50.",
+			"tags": ["Equity", "indicators", "rsi", "intraday"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity Stochastic Oscillator",
+			"folder": "equity-stochastic-oscillator",
+			"description": "Trades IWM with a 14/3/3 Stochastic oscillator, going long on %K crossing %D from below 20 and exiting on a cross from above 80.",
+			"tags": ["Equity", "indicators", "stochastic", "oscillator", "indicator-history"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Crypto Static Universe",
+			"folder": "crypto-static",
+			"description": "Trades a fixed list of Cryptocurrencies on Bitfinex at minute resolution with a weekly rebalance.",
+			"tags": ["position-sizing", "scheduled-event", "Crypto"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Index Options Universe",
+			"folder": "index-options-universe",
+			"description": "Filters the SPXW Index Option chain to 0DTE strikes near ATM and buys the call with the lower strike.",
+			"tags": ["option-filter", "0dte", "IndexOption"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "CFD",
+			"folder": "cfd",
+			"description": "Trades CFDs across German, Asian, and US index markets with Scheduled Events aligned to each market's hours.",
+			"tags": ["market-hours", "scheduled-event", "Cfd"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equities Static Universe",
+			"folder": "equities-static-universe",
+			"description": "Simple template with a fixed list of assets, indicators, and a scheduled event.",
+			"tags": ["indicators", "scheduled-event", "Equity"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity Options Universe",
+			"folder": "equity-options-universe",
+			"description": "Filters SPY weekly Equity Options to ATM calls and puts and executes a long straddle.",
+			"tags": ["Option", "straddle", "option-strategies"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Crypto Futures",
+			"folder": "crypto-futures",
+			"description": "Trades Crypto Futures (BTC, ETH, LTC) on Binance margin in USDT with weekly rebalancing and margin-interest tracking.",
+			"tags": ["charting", "margin", "CryptoFuture"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for EODHD Upcoming Splits",
+			"folder": "alternative-data-universe-eodhdupcomingsplits",
+			"description": "Selects US Equities with a forward split in the next 3 days and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["splits", "universe", "alternative-data", "Equity", "eod-historical-data", "upcoming-splits"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity ADX Trend Filter",
+			"folder": "equity-adx-trend-filter",
+			"description": "Combines a 50/200 EMA crossover signal with an ADX(14) > 25 filter to trade SPY only in trending regimes.",
+			"tags": ["Equity", "indicators", "adx", "trend-filter", "indicator-plotting", "scheduled-event", "indicator-extensions"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-roc-momentum-rank",
+			"name": "Equity ROC Momentum Rank",
+			"description": "Ranks 10 sector ETFs by 60-day ROC monthly and equal-weights the top 3 with a scheduled rebalance.",
+			"spec": "Assets: XLK,XLF,XLE,XLV,XLI,XLB,XLY,XLP,XLU,XLRE. Minute. 2022-01-01 to 2024-12-31, $200k. ROC(60). Monthly schedule (first trading day) ranks ETFs and equal-weights the top 3. Demonstrates: multi-symbol indicator dictionary, sector rotation, scheduled monthly rebalance. Edge case: liquidate names that drop out of the top 3.",
+			"tags": ["Equity", "indicators", "roc", "sector-rotation"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for US Congress Trading",
+			"folder": "alternative-data-universe-quiverquantcongressuniverse",
+			"description": "Selects US Equities recently bought by US Congress members in trades over $200K and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "Equity", "quiver-quantitative", "us-congress-trading"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-sixty-forty-portfolio",
+			"name": "Equity 60/40 Portfolio",
+			"description": "Holds a static 60% SPY / 40% TLT allocation with quarterly rebalance back to target weights.",
+			"spec": "Assets: SPY, TLT. Minute. 2022-01-01 to 2024-12-31, $100k. Set holdings 60/40 on first bar; schedule a quarterly rebalance (first business day of Jan/Apr/Jul/Oct) to retarget. Demonstrates: scheduled events with quarter_start rule, portfolio rebalancing logic, simple set_holdings. Edge case: drift threshold of 5% to skip no-op rebalances.",
+			"tags": ["Equity", "asset-allocation", "scheduled-event", "rebalance"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for EODHD Upcoming IPOs",
+			"folder": "alternative-data-universe-eodhdupcomingipos",
+			"description": "Selects expected/priced non-penny IPOs with a confirmed IPO date and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "ipos", "Equity", "eod-historical-data", "upcoming-ipos"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for Corporate Lobbying",
+			"folder": "alternative-data-universe-quiverlobbyinguniverse",
+			"description": "Selects US Equities whose corporate lobbying spend totals at least $100K and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "Equity", "quiver-quantitative", "corporate-lobbying"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-monthly-roc-rotation",
+			"name": "Equity Monthly ROC Rotation",
+			"description": "Rotates monthly into the 3 ETFs (SPY, EFA, EEM, AGG, GLD) with the highest 60-day ROC, equal-weighted.",
+			"spec": "Assets: SPY, EFA, EEM, AGG, GLD. Minute. 2022-01-01 to 2024-12-31, $100k. ROC(60) per ETF. Monthly schedule picks top 3 and equal-weights; liquidates the others. Demonstrates: ROC across asset classes, monthly schedule, set_holdings 1/3 each. Edge case: hold cash if all ROCs negative.",
+			"tags": ["Equity", "asset-rotation", "roc", "scheduled-event"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-fisher-transform-reversal",
+			"name": "Equity Fisher Transform Reversal",
+			"description": "Trades NDX-tracking QQQ on FisherTransform extreme readings, fading values above 2.0 and below -2.0.",
+			"spec": "Asset: QQQ. Minute resolution. 2022-01-01 to 2024-12-31, $100k. FisherTransform(10). Short when value > 2 and turning down; long when < -2 and turning up; exit on cross of 0. Demonstrates: FisherTransform indicator, RollingWindow on indicator value to detect turns. Edge case: only one position at a time.",
+			"tags": ["Equity", "indicators", "fisher-transform", "reversal"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for Brain ML Stock Ranking",
+			"folder": "alternative-data-universe-brainstockrankinguniverse",
+			"description": "Selects US Equities with positive Brain ML rankings across 2-, 3-, and 5-day horizons and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "Equity", "brain", "brain-ml-stock-ranking"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Crypto Universe",
+			"folder": "crypto-universe",
+			"description": "Selects the top 10 Cryptos by USD volume on Coinbase and rebalances daily at noon.",
+			"tags": ["universe", "scheduled-event", "Crypto"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for EODHD Upcoming Earnings",
+			"folder": "alternative-data-universe-eodhdupcomingearnings",
+			"description": "Selects US Equities reporting earnings in the next 3 days with a positive analyst estimate and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "earnings", "Equity", "eod-historical-data", "upcoming-earnings"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for EODHD Upcoming Dividends",
+			"folder": "alternative-data-universe-eodhdupcomingdividends",
+			"description": "Selects US Equities going ex-dividend in the next day with a payout above $0.05 and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "dividends", "Equity", "eod-historical-data", "upcoming-dividends"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for US Government Contracts",
+			"folder": "alternative-data-universe-quivergovernmentcontractuniverse",
+			"description": "Selects US Equities with at least 3 government contracts totalling over $50K and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "Equity", "quiver-quantitative", "us-government-contracts"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for Insider Trading",
+			"folder": "alternative-data-universe-quiverinsidertradinguniverse",
+			"description": "Selects the 10 US Equities with the largest insider-trading dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "Equity", "quiver-quantitative", "insider-trading"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-cmf-money-flow",
+			"name": "Equity Chaikin Money Flow",
+			"description": "Trades XLF using ChaikinMoneyFlow(20) — long when CMF > 0.1 and short when CMF < -0.1, flat in between.",
+			"spec": "Asset: XLF. Minute resolution. 2022-01-01 to 2024-12-31, $100k. ChaikinMoneyFlow(20). Long when CMF > 0.10; short when CMF < -0.10; flat in the dead zone. Demonstrates: CMF volume indicator, threshold-based regime, plotting indicator on subchart. Edge case: rebalance only on signal change.",
+			"tags": ["Equity", "indicators", "cmf", "volume"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for Smart Insider Transactions",
+			"folder": "alternative-data-universe-smartinsidertransactionuniverse",
+			"description": "Selects $100M+ market-cap US Equities executing buybacks over 0.5% of shares and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "Equity", "smart-insider", "corporate-buybacks"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for Smart Insider Intentions",
+			"folder": "alternative-data-universe-smartinsiderintentionuniverse",
+			"description": "Selects $100M+ market-cap US Equities announcing buyback intentions over 0.5% of shares and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "Equity", "smart-insider", "corporate-buybacks"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Futures",
+			"folder": "futures",
+			"description": "Trades the continuous E-mini SP 500 Future and rolls between contract months on SymbolChangedEvents.",
+			"tags": ["contract-rolling", "continuous-contracts", "indices", "Future"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Forex",
+			"folder": "forex",
+			"description": "Trades three Forex pairs using a Minimum indicator on the bid-ask spread to enter when spreads are tightest.",
+			"tags": ["bid-ask-spread", "indicators", "quote-bars", "Forex"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data",
+			"folder": "alternative-data",
+			"description": "Ranks Equities with the Brain ML Ranking dataset and sizes positions from predicted returns via portfolio targets.",
+			"tags": ["position-sizing", "Equity", "machine-learning", "alternative-data", "ranking", "brain", "brain-ml-stock-ranking"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for Brain Sentiment Indicator",
+			"folder": "alternative-data-universe-brainsentimentindicatoruniverse",
+			"description": "Selects US Equities with positive 7-day media sentiment and active mention coverage and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "Equity", "brain", "brain-sentiment-indicator"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-atr-volatility-stop",
+			"name": "Equity ATR Volatility Stop",
+			"description": "Holds SPY long with an ATR(14) chandelier-style trailing stop set 3x ATR below the trailing high.",
+			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. ATR(14). Buy on first bar; maintain trailing high; if close < trailing_high - 3*ATR, liquidate and re-enter on next bar. Demonstrates: ATR indicator, manual trailing-stop pattern, plotting stop level. Edge case: reset trailing high after each liquidation.",
+			"tags": ["Equity", "indicators", "atr", "trailing-stop"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity Donchian Turtle Breakout",
+			"folder": "equity-donchian-breakout-turtle",
+			"description": "Implements a 20/10 Donchian channel turtle breakout on a basket of liquid US ETFs with ATR-based position sizing.",
+			"tags": ["Equity", "indicators", "donchian", "turtle", "atr", "position-sizing"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for CNBC Trading",
+			"folder": "alternative-data-universe-quivercnbcsuniverse",
+			"description": "Selects US Equities with 3+ BUY recommendations from CNBC personalities and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "Equity", "quiver-quantitative", "cnbc-trading"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Crypto BTC vs PAXG Fed Funds Toggle",
+			"folder": "crypto-fred-rates-toggle",
+			"description": "Rotates between BTCUSD and gold-backed PAXGUSD on Kraken based on the 3-month change in the FRED Fed Funds Rate — long BTC when easing, gold when hiking or flat.",
+			"tags": ["Crypto", "alternative-data", "macro", "regime-switch", "indicators", "history", "fred", "us-federal-reserve"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-turn-of-month-effect",
+			"name": "Equity Turn-of-Month Effect",
+			"description": "Holds SPY only on the last 4 and first 3 trading days of each month and stays in cash otherwise.",
+			"spec": "Asset: SPY. Minute. 2022-01-01 to 2024-12-31, $100k. Use trading calendar to identify last 4 and first 3 trading days of each month; hold SPY on those days, otherwise liquidate. Demonstrates: trading calendar API, scheduled events with custom date logic. Edge case: handle month boundary spanning weekends/holidays.",
+			"tags": ["Equity", "calendar-anomaly", "scheduled-event", "trading-calendar"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "History and ETF Universe",
+			"folder": "history-and-etf-universe",
+			"description": "Selects QQQ constituents, ranks them by a daily ATR, and rebalances using ETF weights.",
+			"tags": ["universe", "Equity", "etf", "indicators", "history"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "live-notifications-telegram-webhook",
+			"name": "Live: Telegram Webhook Notifications",
+			"description": "Sends notifications to a Telegram bot via notify.web on every trade fill.",
+			"spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. EMA(50)/EMA(200) cross. On on_order_event(filled) call notify.web('https://api.telegram.org/...', headers={...}, body='...'). Demonstrates: notify.web for arbitrary HTTP webhook (different from email/SMS in live-trading-features). Edge case: stub URL in backtest mode.",
+			"tags": ["Equity", "live-trading", "notifications", "webhook"],
+			"reference_template": "live-trading-features",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for Brain Language Metrics on Company Filings",
+			"folder": "alternative-data-universe-braincompanyfilinglanguagemetricsuniverseall",
+			"description": "Selects US Equities with positive sentiment in both the report and MD&A sections of their latest SEC filings and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "Equity", "brain", "brain-language-metrics-on-company-filings"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Chained Universe",
+			"folder": "chained-universe",
+			"description": "Chains an ETF-constituents universe (QQQ) into a fundamental PE filter to select the most undervalued stocks.",
+			"tags": ["universe", "etf", "Equity", "fundamentals", "chained-universe"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Trade Management",
+			"folder": "trade-management",
+			"description": "Implements a One-Cancels-Other (OCO) pattern with a market order entry and paired stop-loss and take-profit orders, where one of the paired orders cancels when the other fills.",
+			"tags": ["order-tickets", "take-profit", "oco-orders", "stop-loss", "order-management", "Equity"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity MACD Histogram Divergence",
+			"folder": "equity-macd-histogram-divergence",
+			"description": "Detects MACD histogram divergence on AAPL and trades crossovers of the signal line, holding until the histogram flips sign.",
+			"tags": ["Equity", "indicators", "macd", "indicator-plotting", "indicator-history"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity SuperTrend Trend Following",
+			"folder": "equity-supertrend-trend-following",
+			"description": "Trades SPY with a 10-period 3x ATR SuperTrend, flipping long/short on direction changes of the band.",
+			"tags": ["Equity", "indicators", "supertrend", "indicator-event-handler"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-williams-percent-r",
+			"name": "Equity Williams %R",
+			"description": "Trades IWM with WilliamsPercentR(14): long entries below -80 and exits above -20.",
+			"spec": "Asset: IWM. Minute resolution. 2022-01-01 to 2024-12-31, $100k. WilliamsPercentR(14). Long when %R < -80; exit when %R > -20. Demonstrates: Williams %R indicator, oversold reversion logic, plotting against -80/-20 reference lines. Edge case: hold cap of 5 trading days.",
+			"tags": ["Equity", "indicators", "williams-r", "oscillator"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Crypto On-Chain Network Activity",
+			"folder": "crypto-onchain-network-activity",
+			"description": "Holds BTCUSD long when both Bitcoin transaction count and hash rate are above their 30-day SMAs (demand and supply expanding); flat otherwise.",
+			"tags": ["Crypto", "alternative-data", "blockchain", "btc", "bitcoin-metadata"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for EODHD Upcoming Dividends",
+			"folder": "alternative-data-chain-universe-eodhdupcomingdividends",
+			"description": "Selects US Equities going ex-dividend in the next day with a payout above $0.05 from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "dividends", "eod-historical-data", "upcoming-dividends"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-cci-overbought",
+			"name": "Equity Commodity Channel Index",
+			"description": "Trades XLE on CCI(20) — long when CCI < -100 and exit at 0; short when CCI > 100 and cover at 0.",
+			"spec": "Asset: XLE. Minute resolution. 2022-01-01 to 2024-12-31, $100k. CommodityChannelIndex(20). Long when CCI < -100; short when CCI > 100; both exit at 0. Demonstrates: CCI indicator, mean-reversion with explicit short side, sector ETF. Edge case: skip orders during low-volatility (ATR filter).",
+			"tags": ["Equity", "indicators", "cci", "mean-reversion"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for US Congress Trading",
+			"folder": "alternative-data-chain-universe-quiverquantcongressuniverse",
+			"description": "Selects US Equities recently bought by US Congress members in trades over $200K from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "quiver-quantitative", "us-congress-trading"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Financial Advisors",
+			"folder": "financial-advisors",
+			"description": "Demonstrates Interactive Brokers Financial Advisor group/account allocations via order properties along with live brokerage messages.",
+			"tags": ["interactive-brokers", "order-properties", "financial-advisor", "live-trading", "notifications", "Equity", "brokerage-messages"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for Brain Sentiment Indicator",
+			"folder": "alternative-data-chain-universe-brainsentimentindicatoruniverse",
+			"description": "Selects US Equities with positive 7-day media sentiment and active mention coverage from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "brain", "brain-sentiment-indicator"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Future Options",
+			"folder": "future-options",
+			"description": "Builds a bull call spread on E-mini SP500 Future Options.",
+			"tags": ["FutureOption", "option-strategies"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for EODHD Upcoming Splits",
+			"folder": "alternative-data-chain-universe-eodhdupcomingsplits",
+			"description": "Selects US Equities with a forward split in the next 3 days from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "splits", "eod-historical-data", "upcoming-splits"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-opening-range-breakout",
+			"name": "Equity Opening Range Breakout",
+			"description": "Trades SPY breakouts of the 30-minute opening range, going long above the high and short below the low until end of day.",
+			"spec": "Asset: SPY. Minute resolution. 2024-09-01 to 2024-12-31, $100k. Build opening range 9:30-10:00; long on first cross above range high; short on first cross below range low. Force liquidate at 15:55. Demonstrates: minute resolution, scheduled events for ORB window, end-of-day flat. Edge case: only one trade per day.",
+			"tags": ["Equity", "opening-range-breakout", "intraday", "scheduled-event"],
+			"reference_template": "intraday-indicator-scans",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for Brain ML Stock Ranking",
+			"folder": "alternative-data-chain-universe-brainstockrankinguniverse",
+			"description": "Selects US Equities with positive Brain ML rankings across 2-, 3-, and 5-day horizons from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "brain", "brain-ml-stock-ranking"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for EODHD Upcoming Earnings",
+			"folder": "alternative-data-chain-universe-eodhdupcomingearnings",
+			"description": "Selects US Equities reporting earnings in the next 3 days with a positive analyst estimate from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "earnings", "eod-historical-data", "upcoming-earnings"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for Smart Insider Transactions",
+			"folder": "alternative-data-chain-universe-smartinsidertransactionuniverse",
+			"description": "Selects $100M+ market-cap US Equities executing buybacks over 0.5% of shares from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "smart-insider", "corporate-buybacks"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "dataset-blockchain-bitcoin-metadata",
+			"name": "Dataset: Blockchain Bitcoin Metadata",
+			"description": "Trades BTCUSD long when 30-day Bitcoin block-time metadata trends down (faster blocks => more activity), flat when up.",
+			"spec": "Asset: BTCUSD on Coinbase + BitcoinMetadata custom data. Minute. 2023-01-01 to 2024-12-31, $100k. add_data(BitcoinMetadata) for block time and difficulty fields. ROC(30) of average block time; long BTCUSD when ROC < 0, flat when > 0. Demonstrates: Blockchain Bitcoin Metadata dataset, on-chain regime switch (distinct from MVRV/hashrate templates). Edge case: handle stale data.",
+			"tags": ["Crypto", "alternative-data", "blockchain", "btc"],
+			"reference_template": "alternative-data-universe-coingeckouniverse",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for Smart Insider Intentions",
+			"folder": "alternative-data-chain-universe-smartinsiderintentionuniverse",
+			"description": "Selects $100M+ market-cap US Equities announcing buyback intentions over 0.5% of shares from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "smart-insider", "corporate-buybacks"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Intraday Indicator Scans",
+			"folder": "intraday-indicator-scans",
+			"description": "Scans QQQ constituents every 15 minutes with a minute-resolution ATR to select the most volatile constituents intraday.",
+			"tags": ["universe", "intraday", "Equity", "etf", "indicators"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity Ichimoku Cloud",
+			"folder": "equity-ichimoku-cloud",
+			"description": "Trades QQQ using the Ichimoku Kinko Hyo cloud, entering long on Tenkan/Kijun bullish cross above the cloud.",
+			"tags": ["Equity", "indicators", "ichimoku", "indicator-plotting", "scheduled-event", "indicator-history"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity Country GDP Growth Rotation",
+			"folder": "dataset-eodhd-macro-indicators",
+			"description": "Equal-weights the 3 country ETFs with the highest annual GDP growth from a basket of 8 major economies, using the EODHD Macro Indicators dataset.",
+			"tags": ["Equity", "alternative-data", "macro", "etf", "rotation", "eod-historical-data", "macro-indicators"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for CNBC Trading",
+			"folder": "alternative-data-chain-universe-quivercnbcsuniverse",
+			"description": "Selects US Equities with 3+ BUY recommendations from CNBC personalities from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "quiver-quantitative", "cnbc-trading"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe for CoinGecko Crypto Market Cap",
+			"folder": "alternative-data-universe-coingeckouniverse",
+			"description": "Selects the top 10 Cryptocurrencies by CoinGecko market cap that are tradable on Coinbase and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["universe", "alternative-data", "Crypto", "coingecko", "crypto-market-cap"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for Corporate Lobbying",
+			"folder": "alternative-data-chain-universe-quiverlobbyinguniverse",
+			"description": "Selects US Equities whose corporate lobbying spend totals at least $100K from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "quiver-quantitative", "corporate-lobbying"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Index Options Static",
+			"folder": "index-options-static",
+			"description": "Trades SPX Index Options, buying the ATM contract with the closest expiration.",
+			"tags": ["option-chain", "IndexOption", "spx"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for US Government Contracts",
+			"folder": "alternative-data-chain-universe-quivergovernmentcontractuniverse",
+			"description": "Selects US Equities with at least 3 government contracts totalling over $50K from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "quiver-quantitative", "us-government-contracts"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for Insider Trading",
+			"folder": "alternative-data-chain-universe-quiverinsidertradinguniverse",
+			"description": "Selects the 10 US Equities with the largest insider-trading dollar volume from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "quiver-quantitative", "insider-trading"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Custom Data with Ticker Mapping",
+			"folder": "custom-data-ticker-mapping",
+			"description": "Loads custom data tied to an Equity whose ticker changed (FB to META) using point-in-time SecurityIdentifier mapping from the Object Store.",
+			"tags": ["ticker-mapping", "custom-data", "object-store", "Equity"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-obv-divergence",
+			"name": "Equity OBV Divergence",
+			"description": "Detects bullish/bearish On-Balance Volume divergence on SPY versus a 20-day price ROC and trades reversals.",
+			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. OBV indicator and ROC(20) on price. Bullish divergence: price ROC < 0 but OBV ROC > 0 -> long. Bearish opposite -> short. Demonstrates: OBV automatic indicator, IndicatorExtensions to compute ROC of OBV, divergence logic. Edge case: require 5-day confirmation.",
+			"tags": ["Equity", "indicators", "obv", "divergence"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for Brain Language Metrics on Company Filings",
+			"folder": "alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall",
+			"description": "Selects US Equities with positive sentiment in both the report and MD&A sections of their latest SEC filings from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "brain", "brain-language-metrics-on-company-filings"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity Options Static",
+			"folder": "equity-options-static",
+			"description": "Trades a fixed SPY Equity Option chain, constructing and rebalancing a covered call on a weekly schedule.",
+			"tags": ["Option", "scheduled-event", "covered-call"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-momentum-cross-sectional-decile",
+			"name": "Equity Cross-Sectional Momentum Decile",
+			"description": "Selects the top decile of S&P 500 stocks by 12-1 month momentum and rebalances monthly into an equal-weight long portfolio.",
+			"spec": "Universe: S&P 500 (etf-constituents on SPY) capped at 100 by dollar volume. Minute. 2022-01-01 to 2024-12-31, $250k. Compute 252-21 day return (12-1 momentum) via history. Monthly schedule selects top decile (~10 names) and equal-weights. Demonstrates: ETF universe, history-based factor, monthly rebalance, set_holdings on top decile.",
+			"tags": ["Equity", "momentum", "etf-universe", "factor"],
+			"reference_template": "history-and-etf-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Custom Consolidators",
+			"folder": "custom-consolidators",
+			"description": "Builds a calendar-based QuoteBar consolidator anchored to 5 PM ET, applies an EMA on the consolidated Forex bars, and trades crossovers.",
+			"tags": ["indicators", "custom-consolidators", "consolidators", "Forex"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-all-weather-portfolio",
+			"name": "Equity All-Weather Portfolio",
+			"description": "Implements Ray Dalio's All-Weather: 30% SPY, 40% TLT, 15% IEF, 7.5% GLD, 7.5% DBC with annual rebalance.",
+			"spec": "Assets: SPY, TLT, IEF, GLD, DBC. Minute. 2022-01-01 to 2024-12-31, $200k. Set target weights on first bar; annual schedule retargets. Demonstrates: multi-asset allocation, scheduled annual rebalance, holdings drift monitoring. Edge case: skip GLD/DBC if missing in early data.",
+			"tags": ["Equity", "all-weather", "asset-allocation", "etf"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equities Universe",
+			"folder": "equities-universe",
+			"description": "Fundamental universe selecting top undervalued large-caps ranked by an EMA100/EMA300 cross, rebalanced daily.",
+			"tags": ["fundamentals", "indicators", "universe", "Equity"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "live-commands-listener",
+			"name": "Live: Commands Listener",
+			"description": "Pauses/resumes an SPY EMA cross strategy via the on_command handler, with pause state persisted in the Object Store.",
+			"spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. Override on_command(data): when data.command=='pause', set self._paused = data.paused and persist via object_store. EMA(50)/EMA(200) trades only when not paused. Demonstrates: on_command pattern with direct algorithm-attribute mutation. Edge case: restore pause state across restarts from Object Store.",
+			"tags": ["Equity", "live-trading", "commands", "object-store"],
+			"reference_template": "live-trading-features",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Equity Keltner Squeeze Breakout",
+			"folder": "equity-keltner-squeeze",
+			"description": "Trades a basket of US ETFs on Bollinger-inside-Keltner squeeze releases — long on a close above the upper Bollinger Band, short below the lower, exiting at the midline.",
+			"tags": ["Equity", "indicators", "keltner", "squeeze", "bollinger-bands", "scheduled-event"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-value-pe-pb-quality",
+			"name": "Equity Value/Quality Composite",
+			"description": "Selects S&P 500 names by a composite of low PE, low PB, and high ROE; equal-weights the top 20 monthly.",
+			"spec": "Universe: fundamental. Daily. 2022-01-01 to 2024-12-31, $250k. Rank by z-score of (-PE, -PB, +ROE) and combine equally; pick top 20 names. Monthly rebalance. Demonstrates: fundamental data, multi-factor composite, equal-weight. Edge case: skip names with missing fundamentals (use is_finite checks).",
+			"tags": ["Equity", "value-factor", "quality-factor", "fundamentals"],
+			"reference_template": "equities-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Chained Universe for EODHD Upcoming IPOs",
+			"folder": "alternative-data-chain-universe-eodhdupcomingipos",
+			"description": "Selects expected/priced non-penny IPOs with a confirmed IPO date from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
+			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "ipos", "eod-historical-data", "upcoming-ipos"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Option SPY Iron Condor",
+			"folder": "option-iron-condor-spy",
+			"description": "Sells weekly SPY iron condors with short strikes ~10 delta and long wings 3 strikes wider.",
+			"tags": ["Option", "iron-condor", "option-strategies", "weekly"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Live Trading Features",
+			"folder": "live-trading-features",
+			"description": "Demonstrates live email and SMS notifications, brokerage disconnect/reconnect handling, and commands.",
+			"tags": ["live-trading", "sms", "notifications", "Equity", "emails", "commands", "brokerage-messages"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Custom Indicator",
+			"folder": "custom-indicator",
+			"description": "Implements a custom Money Flow Index indicator and trades SPY on its signals.",
+			"tags": ["indicators", "custom-indicator", "Equity"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Intraday Greeks-Based Options Selection",
+			"folder": "intraday-greeks-based-options-selection",
+			"description": "Selects RUT Index Options intraday by target delta from EMA-driven signals with paced order submission.",
+			"tags": ["intraday", "IndexOption", "greeks"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Custom Data",
+			"folder": "custom-data",
+			"description": "Defines a custom data source type that ingests Bitstamp data and plots daily Bitcoin prices.",
+			"tags": ["python-data", "custom-data", "Crypto"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Intraday Index Options Selection",
+			"folder": "intraday-index-options-selection",
+			"description": "Loads the SPX weekly chain daily and re-filters ATM calls every 5 minutes to trade as contracts update intraday.",
+			"tags": ["0dte", "IndexOption", "intraday"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "AI",
+			"folder": "ai",
+			"description": "Trains a TensorFlow MLP weekly on warmed-up history to predict SPY direction.",
+			"tags": ["machine-learning", "tensorflow", "indicators", "Equity"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-pairs-trading-cointegration",
+			"name": "Equity Pairs Trading (Cointegration)",
+			"description": "Trades the spread between KO and PEP using a 60-day OLS hedge ratio and z-score thresholds for entries/exits.",
+			"spec": "Assets: KO, PEP. Minute resolution. 2022-01-01 to 2024-12-31, $100k. Compute hedge ratio via 60-day rolling OLS on closes; z-score the spread; long-spread when z<-2 (long KO, short PEP); short-spread when z>2; exit when |z|<0.5. Demonstrates: history requests for OLS, RollingWindow, dollar-neutral sizing. Edge case: re-fit hedge ratio weekly.",
+			"tags": ["Equity", "pairs-trading", "statistical-arbitrage", "history"],
+			"reference_template": "history-and-etf-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Alternative Data Universe",
+			"folder": "alternative-data-universe",
+			"description": "Uses EODHD upcoming-earnings data to select Equities and trades straddles around earnings announcements.",
+			"tags": ["Option", "universe", "alternative-data", "earnings", "eod-historical-data", "upcoming-earnings"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"name": "Custom Models",
+			"folder": "custom-models",
+			"description": "Replaces the default fee, fill, slippage, and buying-power models through a security initializer.",
+			"tags": ["reality-models", "slippage", "fill-model", "fee-model", "Equity"],
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-permanent-portfolio",
+			"name": "Equity Permanent Portfolio",
+			"description": "Holds 25% each of SPY, TLT, GLD, and SHY with annual rebalance — Browne's Permanent Portfolio.",
+			"spec": "Assets: SPY, TLT, GLD, SHY. Minute. 2022-01-01 to 2024-12-31, $100k. Equal-weight 25% on first bar; annual rebalance every January 2nd. Demonstrates: 4-asset allocation, annual scheduled event, scheduled-event rule chaining. Edge case: skip rebalance if drift < 3% from target.",
+			"tags": ["Equity", "permanent-portfolio", "asset-allocation", "scheduled-event"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-dual-momentum-asset-class",
+			"name": "Equity Dual Momentum",
+			"description": "Implements Antonacci dual momentum across SPY, EFA, and AGG: pick the top 12-month return, fall back to AGG if absolute momentum is negative.",
+			"spec": "Assets: SPY, EFA, AGG. Minute resolution. 2022-01-01 to 2024-12-31, $100k. Monthly: compute 12-month return for each; pick the highest; if highest <= AGG return then hold AGG; else hold winner 100%. Demonstrates: history-based momentum, monthly schedule, conditional hold. Edge case: rebalance only on first trading day of month.",
+			"tags": ["Equity", "dual-momentum", "asset-allocation", "history"],
+			"reference_template": "history-and-etf-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		},
+		{
+			"folder": "equity-dollar-cost-averaging",
+			"name": "Equity Dollar Cost Averaging",
+			"description": "Buys $5,000 worth of VOO every Monday morning regardless of price, accumulating shares over the backtest.",
+			"spec": "Asset: VOO. Minute. 2022-01-01 to 2024-12-31, $200k starting cash. Schedule: every Monday after market open buy VOO with $5,000 of cash via market_order using calculate_order_quantity. Demonstrates: weekly schedule, fixed-dollar buys, calculate_order_quantity, no liquidation. Edge case: skip if insufficient cash; never sell.",
+			"tags": ["Equity", "dca", "scheduled-event", "buy-and-hold"],
+			"reference_template": "equities-static-universe",
+			"projectIdCs": null,
+			"projectIdPy": null
+		}
+	]
+}


### PR DESCRIPTION
## Summary

- Add `project-templates/run_project_match_check.py`: for each entry in `templates.json`, either creates a new QC Cloud project and runs an end-to-end compile + backtest, or fetches the existing project, compares against the local source file, and only re-uploads / re-runs when they differ. Python and C# run in parallel (3 workers per language).
- Add a `Run Project Match Check` step to the `Syntax Tests` workflow, widen its path filter to `project-templates/**`, and pass the documentation org's credentials into the container as `DOCS_TEMPLATE_USER_ID`, `DOCS_TEMPLATE_USER_TOKEN`, `DOCS_TEMPLATE_ORG_ID`.
- On master pushes only, open a PR with any new project IDs the script wrote back to `templates.json`.
- Commit the local `templates.json` registry so CI has a starting point.

## Test plan

- [ ] CI passes the existing syntax check step.
- [ ] CI runs the new project match check step against every entry in `templates.json`.
- [ ] On master push, when any `projectIdCs` / `projectIdPy` is null, the script creates the project, invites `alexandre_catarino` as collaborator (skipping if already attached), uploads the local source, compiles, runs a backtest, and persists the new ID back to `templates.json`; a follow-up PR is opened with the updated registry.
- [ ] On a feature-branch push or PR run, no auto-PR is opened.

Verified locally with `equity-aroon-trend` and `equity-rsi-overbought-oversold`: bootstrap created both projects, ran backtests, persisted IDs; a second pass against the same templates hit the match path, skipped backtests, and did not modify `templates.json`.