### PR TITLE
Populate template project IDs and add --no-backtest flag

### DIFF
--- a/.github/workflows/syntax-tests.yml
+++ b/.github/workflows/syntax-tests.yml
@@ -41,7 +41,7 @@ jobs:
             -v /home/runner/work:/__w \
             -e DOCS_TEMPLATE_USER_ID=${{ secrets.QUANTCONNECT_USER_ID }} \
             -e DOCS_TEMPLATE_USER_TOKEN="${{ secrets.QUANTCONNECT_API_TOKEN }}" \
-            -e DOCS_TEMPLATE_ORG_ID=${{ secrets.DOCUMENTATION_ORG_ID }} \
+            -e DOCS_TEMPLATE_ORG_ID=${{ secrets.QUANTCONNECT_ORG_ID }} \
             --name test-container \
             quantconnect/lean:foundation \
             tail -f /dev/null

--- a/project-templates/run_project_match_check.py
+++ b/project-templates/run_project_match_check.py
@@ -24,8 +24,9 @@ local runs, from ``~/.lean/credentials``:
                                                      documentation org)
 
 Usage:
-    python run_project_match_check.py            # check every template
-    python run_project_match_check.py <folder>   # check just one folder
+    python run_project_match_check.py                 # check every template
+    python run_project_match_check.py <folder>        # check just one folder
+    python run_project_match_check.py --no-backtest   # upload only, no compile/backtest
 """
 
 import argparse
@@ -68,13 +69,15 @@ USER_ID, USER_TOKEN, ORG_ID = _load_credentials()
 BASE_URL = "https://www.quantconnect.com/api/v2"
 COLLABORATOR_USER_IDS = ["alexandre_catarino"]
 
-WORKERS_PER_LANG = 3
+WORKERS_PER_LANG = 1
 RETRY_ATTEMPTS = 5
 COMPILE_POLL_SEC = 2
 COMPILE_MAX_ATTEMPTS = 90          # ~3 minutes
 BACKTEST_POLL_SEC = 10
 BACKTEST_MAX_ATTEMPTS = 360        # ~1 hour
 REQUEST_TIMEOUT_SEC = 60
+
+SKIP_BACKTEST = False  # set by --no-backtest in main()
 
 TEMPLATES_ROOT = Path(__file__).resolve().parent
 TEMPLATES_FILE = TEMPLATES_ROOT / "templates.json"
@@ -283,6 +286,9 @@ def process_template(entry: dict[str, Any], lang_key: str) -> CheckResult:
             log(f"{label}: project {project_id} differs from local — uploading")
         
         update_file(project_id, cfg["filename"], local_code)
+        if SKIP_BACKTEST:
+            log(f"{label}: project {project_id} uploaded (backtest skipped)")
+            return CheckResult(folder, lang_key, project_id, created, True, "")
         compile_id = compile_project(project_id)
         bt = run_backtest(project_id, compile_id, f"match-check-{int(time.time())}")
         err = validate_backtest(bt)
@@ -336,7 +342,13 @@ def main() -> int:
         "folder", nargs="?",
         help="Optional folder name; if given, only that template is checked.",
     )
+    parser.add_argument(
+        "--no-backtest", action="store_true",
+        help="Create/upload projects but skip compile and backtest.",
+    )
     args = parser.parse_args()
+    global SKIP_BACKTEST
+    SKIP_BACKTEST = args.no_backtest
 
     data = json.loads(TEMPLATES_FILE.read_text(encoding="utf-8"))
     templates: list[dict[str, Any]] = data["templates"]

--- a/project-templates/templates.json
+++ b/project-templates/templates.json
@@ -5,8 +5,8 @@
 			"folder": "equity-parabolic-sar-trailing",
 			"description": "Trades SPY long-only with Parabolic SAR providing dynamic trailing-stop levels and re-entries.",
 			"tags": ["Equity", "indicators", "parabolic-sar", "trailing-stop", "indicator-plotting"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31882878,
+			"projectIdPy": 31882879
 		},
 		{
 			"folder": "equity-aroon-trend",
@@ -15,96 +15,96 @@
 			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. AroonOscillator(25). Long when oscillator crosses above 50; exit when it crosses below -50. Demonstrates: Aroon indicator, threshold crossing pattern, plotting oscillator on subchart. Edge case: do not flip short — long-only.",
 			"tags": ["Equity", "indicators", "aroon", "trend"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31882881,
+			"projectIdPy": 31882880
 		},
 		{
 			"name": "Equity Bollinger Mean Reversion",
 			"folder": "equity-bollinger-mean-reversion",
 			"description": "Trades SPY on a 20-period, 2-standard-deviation Bollinger Bands mean-reversion signal — buys when price closes below the lower band and liquidates on a return to the middle band — with a daily scheduled rebalance.",
 			"tags": ["Equity", "indicators", "bollinger-bands", "mean-reversion", "z-score"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31882886,
+			"projectIdPy": 31882885
 		},
 		{
 			"name": "Equity RSI Overbought/Oversold",
 			"folder": "equity-rsi-overbought-oversold",
 			"description": "Trades QQQ on a 14-period RSI: long when RSI < 30 and exit at RSI > 50; short when RSI > 70 and cover at RSI < 50.",
 			"tags": ["Equity", "indicators", "rsi", "intraday"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31882887,
+			"projectIdPy": 31882884
 		},
 		{
 			"name": "Equity Stochastic Oscillator",
 			"folder": "equity-stochastic-oscillator",
 			"description": "Trades IWM with a 14/3/3 Stochastic oscillator, going long on %K crossing %D from below 20 and exiting on a cross from above 80.",
 			"tags": ["Equity", "indicators", "stochastic", "oscillator", "indicator-history"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31882893,
+			"projectIdPy": 31882894
 		},
 		{
 			"name": "Crypto Static Universe",
 			"folder": "crypto-static",
 			"description": "Trades a fixed list of Cryptocurrencies on Bitfinex at minute resolution with a weekly rebalance.",
 			"tags": ["position-sizing", "scheduled-event", "Crypto"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884313,
+			"projectIdPy": 31882895
 		},
 		{
 			"name": "Index Options Universe",
 			"folder": "index-options-universe",
 			"description": "Filters the SPXW Index Option chain to 0DTE strikes near ATM and buys the call with the lower strike.",
 			"tags": ["option-filter", "0dte", "IndexOption"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884314,
+			"projectIdPy": 31884315
 		},
 		{
 			"name": "CFD",
 			"folder": "cfd",
 			"description": "Trades CFDs across German, Asian, and US index markets with Scheduled Events aligned to each market's hours.",
 			"tags": ["market-hours", "scheduled-event", "Cfd"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884319,
+			"projectIdPy": 31884312
 		},
 		{
 			"name": "Equities Static Universe",
 			"folder": "equities-static-universe",
 			"description": "Simple template with a fixed list of assets, indicators, and a scheduled event.",
 			"tags": ["indicators", "scheduled-event", "Equity"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884320,
+			"projectIdPy": 31884318
 		},
 		{
 			"name": "Equity Options Universe",
 			"folder": "equity-options-universe",
 			"description": "Filters SPY weekly Equity Options to ATM calls and puts and executes a long straddle.",
 			"tags": ["Option", "straddle", "option-strategies"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884323,
+			"projectIdPy": 31884317
 		},
 		{
 			"name": "Crypto Futures",
 			"folder": "crypto-futures",
 			"description": "Trades Crypto Futures (BTC, ETH, LTC) on Binance margin in USDT with weekly rebalancing and margin-interest tracking.",
 			"tags": ["charting", "margin", "CryptoFuture"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884325,
+			"projectIdPy": 31884324
 		},
 		{
 			"name": "Alternative Data Universe for EODHD Upcoming Splits",
 			"folder": "alternative-data-universe-eodhdupcomingsplits",
 			"description": "Selects US Equities with a forward split in the next 3 days and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["splits", "universe", "alternative-data", "Equity", "eod-historical-data", "upcoming-splits"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884329,
+			"projectIdPy": 31884326
 		},
 		{
 			"name": "Equity ADX Trend Filter",
 			"folder": "equity-adx-trend-filter",
 			"description": "Combines a 50/200 EMA crossover signal with an ADX(14) > 25 filter to trade SPY only in trending regimes.",
 			"tags": ["Equity", "indicators", "adx", "trend-filter", "indicator-plotting", "scheduled-event", "indicator-extensions"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884331,
+			"projectIdPy": 31884330
 		},
 		{
 			"folder": "equity-roc-momentum-rank",
@@ -113,16 +113,16 @@
 			"spec": "Assets: XLK,XLF,XLE,XLV,XLI,XLB,XLY,XLP,XLU,XLRE. Minute. 2022-01-01 to 2024-12-31, $200k. ROC(60). Monthly schedule (first trading day) ranks ETFs and equal-weights the top 3. Demonstrates: multi-symbol indicator dictionary, sector rotation, scheduled monthly rebalance. Edge case: liquidate names that drop out of the top 3.",
 			"tags": ["Equity", "indicators", "roc", "sector-rotation"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884336,
+			"projectIdPy": 31884332
 		},
 		{
 			"name": "Alternative Data Universe for US Congress Trading",
 			"folder": "alternative-data-universe-quiverquantcongressuniverse",
 			"description": "Selects US Equities recently bought by US Congress members in trades over $200K and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "Equity", "quiver-quantitative", "us-congress-trading"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884338,
+			"projectIdPy": 31884335
 		},
 		{
 			"folder": "equity-sixty-forty-portfolio",
@@ -131,24 +131,24 @@
 			"spec": "Assets: SPY, TLT. Minute. 2022-01-01 to 2024-12-31, $100k. Set holdings 60/40 on first bar; schedule a quarterly rebalance (first business day of Jan/Apr/Jul/Oct) to retarget. Demonstrates: scheduled events with quarter_start rule, portfolio rebalancing logic, simple set_holdings. Edge case: drift threshold of 5% to skip no-op rebalances.",
 			"tags": ["Equity", "asset-allocation", "scheduled-event", "rebalance"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884340,
+			"projectIdPy": 31884337
 		},
 		{
 			"name": "Alternative Data Universe for EODHD Upcoming IPOs",
 			"folder": "alternative-data-universe-eodhdupcomingipos",
 			"description": "Selects expected/priced non-penny IPOs with a confirmed IPO date and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "ipos", "Equity", "eod-historical-data", "upcoming-ipos"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884342,
+			"projectIdPy": 31884341
 		},
 		{
 			"name": "Alternative Data Universe for Corporate Lobbying",
 			"folder": "alternative-data-universe-quiverlobbyinguniverse",
 			"description": "Selects US Equities whose corporate lobbying spend totals at least $100K and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "Equity", "quiver-quantitative", "corporate-lobbying"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884346,
+			"projectIdPy": 31884343
 		},
 		{
 			"folder": "equity-monthly-roc-rotation",
@@ -157,8 +157,8 @@
 			"spec": "Assets: SPY, EFA, EEM, AGG, GLD. Minute. 2022-01-01 to 2024-12-31, $100k. ROC(60) per ETF. Monthly schedule picks top 3 and equal-weights; liquidates the others. Demonstrates: ROC across asset classes, monthly schedule, set_holdings 1/3 each. Edge case: hold cash if all ROCs negative.",
 			"tags": ["Equity", "asset-rotation", "roc", "scheduled-event"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884348,
+			"projectIdPy": 31884347
 		},
 		{
 			"folder": "equity-fisher-transform-reversal",
@@ -167,56 +167,56 @@
 			"spec": "Asset: QQQ. Minute resolution. 2022-01-01 to 2024-12-31, $100k. FisherTransform(10). Short when value > 2 and turning down; long when < -2 and turning up; exit on cross of 0. Demonstrates: FisherTransform indicator, RollingWindow on indicator value to detect turns. Edge case: only one position at a time.",
 			"tags": ["Equity", "indicators", "fisher-transform", "reversal"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884351,
+			"projectIdPy": 31884349
 		},
 		{
 			"name": "Alternative Data Universe for Brain ML Stock Ranking",
 			"folder": "alternative-data-universe-brainstockrankinguniverse",
 			"description": "Selects US Equities with positive Brain ML rankings across 2-, 3-, and 5-day horizons and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "Equity", "brain", "brain-ml-stock-ranking"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884353,
+			"projectIdPy": 31884352
 		},
 		{
 			"name": "Crypto Universe",
 			"folder": "crypto-universe",
 			"description": "Selects the top 10 Cryptos by USD volume on Coinbase and rebalances daily at noon.",
 			"tags": ["universe", "scheduled-event", "Crypto"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884358,
+			"projectIdPy": 31884355
 		},
 		{
 			"name": "Alternative Data Universe for EODHD Upcoming Earnings",
 			"folder": "alternative-data-universe-eodhdupcomingearnings",
 			"description": "Selects US Equities reporting earnings in the next 3 days with a positive analyst estimate and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "earnings", "Equity", "eod-historical-data", "upcoming-earnings"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884360,
+			"projectIdPy": 31884359
 		},
 		{
 			"name": "Alternative Data Universe for EODHD Upcoming Dividends",
 			"folder": "alternative-data-universe-eodhdupcomingdividends",
 			"description": "Selects US Equities going ex-dividend in the next day with a payout above $0.05 and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "dividends", "Equity", "eod-historical-data", "upcoming-dividends"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884363,
+			"projectIdPy": 31884362
 		},
 		{
 			"name": "Alternative Data Universe for US Government Contracts",
 			"folder": "alternative-data-universe-quivergovernmentcontractuniverse",
 			"description": "Selects US Equities with at least 3 government contracts totalling over $50K and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "Equity", "quiver-quantitative", "us-government-contracts"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884364,
+			"projectIdPy": 31884365
 		},
 		{
 			"name": "Alternative Data Universe for Insider Trading",
 			"folder": "alternative-data-universe-quiverinsidertradinguniverse",
 			"description": "Selects the 10 US Equities with the largest insider-trading dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "Equity", "quiver-quantitative", "insider-trading"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884370,
+			"projectIdPy": 31884366
 		},
 		{
 			"folder": "equity-cmf-money-flow",
@@ -225,56 +225,56 @@
 			"spec": "Asset: XLF. Minute resolution. 2022-01-01 to 2024-12-31, $100k. ChaikinMoneyFlow(20). Long when CMF > 0.10; short when CMF < -0.10; flat in the dead zone. Demonstrates: CMF volume indicator, threshold-based regime, plotting indicator on subchart. Edge case: rebalance only on signal change.",
 			"tags": ["Equity", "indicators", "cmf", "volume"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884372,
+			"projectIdPy": 31884371
 		},
 		{
 			"name": "Alternative Data Universe for Smart Insider Transactions",
 			"folder": "alternative-data-universe-smartinsidertransactionuniverse",
 			"description": "Selects $100M+ market-cap US Equities executing buybacks over 0.5% of shares and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "Equity", "smart-insider", "corporate-buybacks"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884375,
+			"projectIdPy": 31884373
 		},
 		{
 			"name": "Alternative Data Universe for Smart Insider Intentions",
 			"folder": "alternative-data-universe-smartinsiderintentionuniverse",
 			"description": "Selects $100M+ market-cap US Equities announcing buyback intentions over 0.5% of shares and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "Equity", "smart-insider", "corporate-buybacks"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884378,
+			"projectIdPy": 31884376
 		},
 		{
 			"name": "Futures",
 			"folder": "futures",
 			"description": "Trades the continuous E-mini SP 500 Future and rolls between contract months on SymbolChangedEvents.",
 			"tags": ["contract-rolling", "continuous-contracts", "indices", "Future"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884382,
+			"projectIdPy": 31884377
 		},
 		{
 			"name": "Forex",
 			"folder": "forex",
 			"description": "Trades three Forex pairs using a Minimum indicator on the bid-ask spread to enter when spreads are tightest.",
 			"tags": ["bid-ask-spread", "indicators", "quote-bars", "Forex"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884383,
+			"projectIdPy": 31884381
 		},
 		{
 			"name": "Alternative Data",
 			"folder": "alternative-data",
 			"description": "Ranks Equities with the Brain ML Ranking dataset and sizes positions from predicted returns via portfolio targets.",
 			"tags": ["position-sizing", "Equity", "machine-learning", "alternative-data", "ranking", "brain", "brain-ml-stock-ranking"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884390,
+			"projectIdPy": 31884385
 		},
 		{
 			"name": "Alternative Data Universe for Brain Sentiment Indicator",
 			"folder": "alternative-data-universe-brainsentimentindicatoruniverse",
 			"description": "Selects US Equities with positive 7-day media sentiment and active mention coverage and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "Equity", "brain", "brain-sentiment-indicator"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884394,
+			"projectIdPy": 31884392
 		},
 		{
 			"folder": "equity-atr-volatility-stop",
@@ -283,32 +283,32 @@
 			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. ATR(14). Buy on first bar; maintain trailing high; if close < trailing_high - 3*ATR, liquidate and re-enter on next bar. Demonstrates: ATR indicator, manual trailing-stop pattern, plotting stop level. Edge case: reset trailing high after each liquidation.",
 			"tags": ["Equity", "indicators", "atr", "trailing-stop"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884395,
+			"projectIdPy": 31884391
 		},
 		{
 			"name": "Equity Donchian Turtle Breakout",
 			"folder": "equity-donchian-breakout-turtle",
 			"description": "Implements a 20/10 Donchian channel turtle breakout on a basket of liquid US ETFs with ATR-based position sizing.",
 			"tags": ["Equity", "indicators", "donchian", "turtle", "atr", "position-sizing"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884399,
+			"projectIdPy": 31884398
 		},
 		{
 			"name": "Alternative Data Universe for CNBC Trading",
 			"folder": "alternative-data-universe-quivercnbcsuniverse",
 			"description": "Selects US Equities with 3+ BUY recommendations from CNBC personalities and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "Equity", "quiver-quantitative", "cnbc-trading"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884405,
+			"projectIdPy": 31884401
 		},
 		{
 			"name": "Crypto BTC vs PAXG Fed Funds Toggle",
 			"folder": "crypto-fred-rates-toggle",
 			"description": "Rotates between BTCUSD and gold-backed PAXGUSD on Kraken based on the 3-month change in the FRED Fed Funds Rate — long BTC when easing, gold when hiking or flat.",
 			"tags": ["Crypto", "alternative-data", "macro", "regime-switch", "indicators", "history", "fred", "us-federal-reserve"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884408,
+			"projectIdPy": 31884407
 		},
 		{
 			"folder": "equity-turn-of-month-effect",
@@ -317,16 +317,16 @@
 			"spec": "Asset: SPY. Minute. 2022-01-01 to 2024-12-31, $100k. Use trading calendar to identify last 4 and first 3 trading days of each month; hold SPY on those days, otherwise liquidate. Demonstrates: trading calendar API, scheduled events with custom date logic. Edge case: handle month boundary spanning weekends/holidays.",
 			"tags": ["Equity", "calendar-anomaly", "scheduled-event", "trading-calendar"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884410,
+			"projectIdPy": 31884409
 		},
 		{
 			"name": "History and ETF Universe",
 			"folder": "history-and-etf-universe",
 			"description": "Selects QQQ constituents, ranks them by a daily ATR, and rebalances using ETF weights.",
 			"tags": ["universe", "Equity", "etf", "indicators", "history"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884412,
+			"projectIdPy": 31884413
 		},
 		{
 			"folder": "live-notifications-telegram-webhook",
@@ -335,48 +335,48 @@
 			"spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. EMA(50)/EMA(200) cross. On on_order_event(filled) call notify.web('https://api.telegram.org/...', headers={...}, body='...'). Demonstrates: notify.web for arbitrary HTTP webhook (different from email/SMS in live-trading-features). Edge case: stub URL in backtest mode.",
 			"tags": ["Equity", "live-trading", "notifications", "webhook"],
 			"reference_template": "live-trading-features",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884418,
+			"projectIdPy": 31884414
 		},
 		{
 			"name": "Alternative Data Universe for Brain Language Metrics on Company Filings",
 			"folder": "alternative-data-universe-braincompanyfilinglanguagemetricsuniverseall",
 			"description": "Selects US Equities with positive sentiment in both the report and MD&A sections of their latest SEC filings and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "Equity", "brain", "brain-language-metrics-on-company-filings"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884420,
+			"projectIdPy": 31884419
 		},
 		{
 			"name": "Chained Universe",
 			"folder": "chained-universe",
 			"description": "Chains an ETF-constituents universe (QQQ) into a fundamental PE filter to select the most undervalued stocks.",
 			"tags": ["universe", "etf", "Equity", "fundamentals", "chained-universe"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884422,
+			"projectIdPy": 31884421
 		},
 		{
 			"name": "Trade Management",
 			"folder": "trade-management",
 			"description": "Implements a One-Cancels-Other (OCO) pattern with a market order entry and paired stop-loss and take-profit orders, where one of the paired orders cancels when the other fills.",
 			"tags": ["order-tickets", "take-profit", "oco-orders", "stop-loss", "order-management", "Equity"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884425,
+			"projectIdPy": 31884423
 		},
 		{
 			"name": "Equity MACD Histogram Divergence",
 			"folder": "equity-macd-histogram-divergence",
 			"description": "Detects MACD histogram divergence on AAPL and trades crossovers of the signal line, holding until the histogram flips sign.",
 			"tags": ["Equity", "indicators", "macd", "indicator-plotting", "indicator-history"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884429,
+			"projectIdPy": 31884426
 		},
 		{
 			"name": "Equity SuperTrend Trend Following",
 			"folder": "equity-supertrend-trend-following",
 			"description": "Trades SPY with a 10-period 3x ATR SuperTrend, flipping long/short on direction changes of the band.",
 			"tags": ["Equity", "indicators", "supertrend", "indicator-event-handler"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884430,
+			"projectIdPy": 31884428
 		},
 		{
 			"folder": "equity-williams-percent-r",
@@ -385,24 +385,24 @@
 			"spec": "Asset: IWM. Minute resolution. 2022-01-01 to 2024-12-31, $100k. WilliamsPercentR(14). Long when %R < -80; exit when %R > -20. Demonstrates: Williams %R indicator, oversold reversion logic, plotting against -80/-20 reference lines. Edge case: hold cap of 5 trading days.",
 			"tags": ["Equity", "indicators", "williams-r", "oscillator"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884433,
+			"projectIdPy": 31884431
 		},
 		{
 			"name": "Crypto On-Chain Network Activity",
 			"folder": "crypto-onchain-network-activity",
 			"description": "Holds BTCUSD long when both Bitcoin transaction count and hash rate are above their 30-day SMAs (demand and supply expanding); flat otherwise.",
 			"tags": ["Crypto", "alternative-data", "blockchain", "btc", "bitcoin-metadata"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884435,
+			"projectIdPy": 31884434
 		},
 		{
 			"name": "Alternative Data Chained Universe for EODHD Upcoming Dividends",
 			"folder": "alternative-data-chain-universe-eodhdupcomingdividends",
 			"description": "Selects US Equities going ex-dividend in the next day with a payout above $0.05 from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "dividends", "eod-historical-data", "upcoming-dividends"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884437,
+			"projectIdPy": 31884436
 		},
 		{
 			"folder": "equity-cci-overbought",
@@ -411,48 +411,48 @@
 			"spec": "Asset: XLE. Minute resolution. 2022-01-01 to 2024-12-31, $100k. CommodityChannelIndex(20). Long when CCI < -100; short when CCI > 100; both exit at 0. Demonstrates: CCI indicator, mean-reversion with explicit short side, sector ETF. Edge case: skip orders during low-volatility (ATR filter).",
 			"tags": ["Equity", "indicators", "cci", "mean-reversion"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884438,
+			"projectIdPy": 31853617
 		},
 		{
 			"name": "Alternative Data Chained Universe for US Congress Trading",
 			"folder": "alternative-data-chain-universe-quiverquantcongressuniverse",
 			"description": "Selects US Equities recently bought by US Congress members in trades over $200K from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "quiver-quantitative", "us-congress-trading"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884439,
+			"projectIdPy": 31853632
 		},
 		{
 			"name": "Financial Advisors",
 			"folder": "financial-advisors",
 			"description": "Demonstrates Interactive Brokers Financial Advisor group/account allocations via order properties along with live brokerage messages.",
 			"tags": ["interactive-brokers", "order-properties", "financial-advisor", "live-trading", "notifications", "Equity", "brokerage-messages"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31884441,
+			"projectIdPy": 31853653
 		},
 		{
 			"name": "Alternative Data Chained Universe for Brain Sentiment Indicator",
 			"folder": "alternative-data-chain-universe-brainsentimentindicatoruniverse",
 			"description": "Selects US Equities with positive 7-day media sentiment and active mention coverage from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "brain", "brain-sentiment-indicator"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853638,
+			"projectIdPy": 31853662
 		},
 		{
 			"name": "Future Options",
 			"folder": "future-options",
 			"description": "Builds a bull call spread on E-mini SP500 Future Options.",
 			"tags": ["FutureOption", "option-strategies"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853657,
+			"projectIdPy": 31853680
 		},
 		{
 			"name": "Alternative Data Chained Universe for EODHD Upcoming Splits",
 			"folder": "alternative-data-chain-universe-eodhdupcomingsplits",
 			"description": "Selects US Equities with a forward split in the next 3 days from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "splits", "eod-historical-data", "upcoming-splits"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853670,
+			"projectIdPy": 31853697
 		},
 		{
 			"folder": "equity-opening-range-breakout",
@@ -461,32 +461,32 @@
 			"spec": "Asset: SPY. Minute resolution. 2024-09-01 to 2024-12-31, $100k. Build opening range 9:30-10:00; long on first cross above range high; short on first cross below range low. Force liquidate at 15:55. Demonstrates: minute resolution, scheduled events for ORB window, end-of-day flat. Edge case: only one trade per day.",
 			"tags": ["Equity", "opening-range-breakout", "intraday", "scheduled-event"],
 			"reference_template": "intraday-indicator-scans",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853688,
+			"projectIdPy": 31853717
 		},
 		{
 			"name": "Alternative Data Chained Universe for Brain ML Stock Ranking",
 			"folder": "alternative-data-chain-universe-brainstockrankinguniverse",
 			"description": "Selects US Equities with positive Brain ML rankings across 2-, 3-, and 5-day horizons from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "brain", "brain-ml-stock-ranking"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853706,
+			"projectIdPy": 31853738
 		},
 		{
 			"name": "Alternative Data Chained Universe for EODHD Upcoming Earnings",
 			"folder": "alternative-data-chain-universe-eodhdupcomingearnings",
 			"description": "Selects US Equities reporting earnings in the next 3 days with a positive analyst estimate from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "earnings", "eod-historical-data", "upcoming-earnings"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853726,
+			"projectIdPy": 31853761
 		},
 		{
 			"name": "Alternative Data Chained Universe for Smart Insider Transactions",
 			"folder": "alternative-data-chain-universe-smartinsidertransactionuniverse",
 			"description": "Selects $100M+ market-cap US Equities executing buybacks over 0.5% of shares from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "smart-insider", "corporate-buybacks"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853747,
+			"projectIdPy": 31853781
 		},
 		{
 			"folder": "dataset-blockchain-bitcoin-metadata",
@@ -495,96 +495,96 @@
 			"spec": "Asset: BTCUSD on Coinbase + BitcoinMetadata custom data. Minute. 2023-01-01 to 2024-12-31, $100k. add_data(BitcoinMetadata) for block time and difficulty fields. ROC(30) of average block time; long BTCUSD when ROC < 0, flat when > 0. Demonstrates: Blockchain Bitcoin Metadata dataset, on-chain regime switch (distinct from MVRV/hashrate templates). Edge case: handle stale data.",
 			"tags": ["Crypto", "alternative-data", "blockchain", "btc"],
 			"reference_template": "alternative-data-universe-coingeckouniverse",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853768,
+			"projectIdPy": 31853801
 		},
 		{
 			"name": "Alternative Data Chained Universe for Smart Insider Intentions",
 			"folder": "alternative-data-chain-universe-smartinsiderintentionuniverse",
 			"description": "Selects $100M+ market-cap US Equities announcing buyback intentions over 0.5% of shares from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "smart-insider", "corporate-buybacks"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853791,
+			"projectIdPy": 31853824
 		},
 		{
 			"name": "Intraday Indicator Scans",
 			"folder": "intraday-indicator-scans",
 			"description": "Scans QQQ constituents every 15 minutes with a minute-resolution ATR to select the most volatile constituents intraday.",
 			"tags": ["universe", "intraday", "Equity", "etf", "indicators"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853810,
+			"projectIdPy": 31853842
 		},
 		{
 			"name": "Equity Ichimoku Cloud",
 			"folder": "equity-ichimoku-cloud",
 			"description": "Trades QQQ using the Ichimoku Kinko Hyo cloud, entering long on Tenkan/Kijun bullish cross above the cloud.",
 			"tags": ["Equity", "indicators", "ichimoku", "indicator-plotting", "scheduled-event", "indicator-history"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853827,
+			"projectIdPy": 31853875
 		},
 		{
 			"name": "Equity Country GDP Growth Rotation",
 			"folder": "dataset-eodhd-macro-indicators",
 			"description": "Equal-weights the 3 country ETFs with the highest annual GDP growth from a basket of 8 major economies, using the EODHD Macro Indicators dataset.",
 			"tags": ["Equity", "alternative-data", "macro", "etf", "rotation", "eod-historical-data", "macro-indicators"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853847,
+			"projectIdPy": 31853898
 		},
 		{
 			"name": "Alternative Data Chained Universe for CNBC Trading",
 			"folder": "alternative-data-chain-universe-quivercnbcsuniverse",
 			"description": "Selects US Equities with 3+ BUY recommendations from CNBC personalities from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "quiver-quantitative", "cnbc-trading"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853864,
+			"projectIdPy": 31853916
 		},
 		{
 			"name": "Alternative Data Universe for CoinGecko Crypto Market Cap",
 			"folder": "alternative-data-universe-coingeckouniverse",
 			"description": "Selects the top 10 Cryptocurrencies by CoinGecko market cap that are tradable on Coinbase and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["universe", "alternative-data", "Crypto", "coingecko", "crypto-market-cap"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853887,
+			"projectIdPy": 31853933
 		},
 		{
 			"name": "Alternative Data Chained Universe for Corporate Lobbying",
 			"folder": "alternative-data-chain-universe-quiverlobbyinguniverse",
 			"description": "Selects US Equities whose corporate lobbying spend totals at least $100K from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "quiver-quantitative", "corporate-lobbying"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853897,
+			"projectIdPy": 31853944
 		},
 		{
 			"name": "Index Options Static",
 			"folder": "index-options-static",
 			"description": "Trades SPX Index Options, buying the ATM contract with the closest expiration.",
 			"tags": ["option-chain", "IndexOption", "spx"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853908,
+			"projectIdPy": 31853954
 		},
 		{
 			"name": "Alternative Data Chained Universe for US Government Contracts",
 			"folder": "alternative-data-chain-universe-quivergovernmentcontractuniverse",
 			"description": "Selects US Equities with at least 3 government contracts totalling over $50K from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "quiver-quantitative", "us-government-contracts"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853938,
+			"projectIdPy": 31853975
 		},
 		{
 			"name": "Alternative Data Chained Universe for Insider Trading",
 			"folder": "alternative-data-chain-universe-quiverinsidertradinguniverse",
 			"description": "Selects the 10 US Equities with the largest insider-trading dollar volume from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "quiver-quantitative", "insider-trading"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853950,
+			"projectIdPy": 31853987
 		},
 		{
 			"name": "Custom Data with Ticker Mapping",
 			"folder": "custom-data-ticker-mapping",
 			"description": "Loads custom data tied to an Equity whose ticker changed (FB to META) using point-in-time SecurityIdentifier mapping from the Object Store.",
 			"tags": ["ticker-mapping", "custom-data", "object-store", "Equity"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853961,
+			"projectIdPy": 31854000
 		},
 		{
 			"folder": "equity-obv-divergence",
@@ -593,24 +593,24 @@
 			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. OBV indicator and ROC(20) on price. Bullish divergence: price ROC < 0 but OBV ROC > 0 -> long. Bearish opposite -> short. Demonstrates: OBV automatic indicator, IndicatorExtensions to compute ROC of OBV, divergence logic. Edge case: require 5-day confirmation.",
 			"tags": ["Equity", "indicators", "obv", "divergence"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853973,
+			"projectIdPy": 31854009
 		},
 		{
 			"name": "Alternative Data Chained Universe for Brain Language Metrics on Company Filings",
 			"folder": "alternative-data-chain-universe-braincompanyfilinglanguagemetricsuniverseall",
 			"description": "Selects US Equities with positive sentiment in both the report and MD&A sections of their latest SEC filings from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "brain", "brain-language-metrics-on-company-filings"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31853988,
+			"projectIdPy": 31854026
 		},
 		{
 			"name": "Equity Options Static",
 			"folder": "equity-options-static",
 			"description": "Trades a fixed SPY Equity Option chain, constructing and rebalancing a covered call on a weekly schedule.",
 			"tags": ["Option", "scheduled-event", "covered-call"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854001,
+			"projectIdPy": 31854034
 		},
 		{
 			"folder": "equity-momentum-cross-sectional-decile",
@@ -619,16 +619,16 @@
 			"spec": "Universe: S&P 500 (etf-constituents on SPY) capped at 100 by dollar volume. Minute. 2022-01-01 to 2024-12-31, $250k. Compute 252-21 day return (12-1 momentum) via history. Monthly schedule selects top decile (~10 names) and equal-weights. Demonstrates: ETF universe, history-based factor, monthly rebalance, set_holdings on top decile.",
 			"tags": ["Equity", "momentum", "etf-universe", "factor"],
 			"reference_template": "history-and-etf-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854013,
+			"projectIdPy": 31854047
 		},
 		{
 			"name": "Custom Consolidators",
 			"folder": "custom-consolidators",
 			"description": "Builds a calendar-based QuoteBar consolidator anchored to 5 PM ET, applies an EMA on the consolidated Forex bars, and trades crossovers.",
 			"tags": ["indicators", "custom-consolidators", "consolidators", "Forex"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854029,
+			"projectIdPy": 31854063
 		},
 		{
 			"folder": "equity-all-weather-portfolio",
@@ -637,16 +637,16 @@
 			"spec": "Assets: SPY, TLT, IEF, GLD, DBC. Minute. 2022-01-01 to 2024-12-31, $200k. Set target weights on first bar; annual schedule retargets. Demonstrates: multi-asset allocation, scheduled annual rebalance, holdings drift monitoring. Edge case: skip GLD/DBC if missing in early data.",
 			"tags": ["Equity", "all-weather", "asset-allocation", "etf"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854037,
+			"projectIdPy": 31854077
 		},
 		{
 			"name": "Equities Universe",
 			"folder": "equities-universe",
 			"description": "Fundamental universe selecting top undervalued large-caps ranked by an EMA100/EMA300 cross, rebalanced daily.",
 			"tags": ["fundamentals", "indicators", "universe", "Equity"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854054,
+			"projectIdPy": 31854085
 		},
 		{
 			"folder": "live-commands-listener",
@@ -655,16 +655,16 @@
 			"spec": "Asset: SPY. Minute. 2024-09-01 to 2024-12-31, $100k. Override on_command(data): when data.command=='pause', set self._paused = data.paused and persist via object_store. EMA(50)/EMA(200) trades only when not paused. Demonstrates: on_command pattern with direct algorithm-attribute mutation. Edge case: restore pause state across restarts from Object Store.",
 			"tags": ["Equity", "live-trading", "commands", "object-store"],
 			"reference_template": "live-trading-features",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854097,
+			"projectIdPy": 31854291
 		},
 		{
 			"name": "Equity Keltner Squeeze Breakout",
 			"folder": "equity-keltner-squeeze",
 			"description": "Trades a basket of US ETFs on Bollinger-inside-Keltner squeeze releases — long on a close above the upper Bollinger Band, short below the lower, exiting at the midline.",
 			"tags": ["Equity", "indicators", "keltner", "squeeze", "bollinger-bands", "scheduled-event"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854113,
+			"projectIdPy": 31854303
 		},
 		{
 			"folder": "equity-value-pe-pb-quality",
@@ -673,72 +673,72 @@
 			"spec": "Universe: fundamental. Daily. 2022-01-01 to 2024-12-31, $250k. Rank by z-score of (-PE, -PB, +ROE) and combine equally; pick top 20 names. Monthly rebalance. Demonstrates: fundamental data, multi-factor composite, equal-weight. Edge case: skip names with missing fundamentals (use is_finite checks).",
 			"tags": ["Equity", "value-factor", "quality-factor", "fundamentals"],
 			"reference_template": "equities-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854127,
+			"projectIdPy": 31854321
 		},
 		{
 			"name": "Alternative Data Chained Universe for EODHD Upcoming IPOs",
 			"folder": "alternative-data-chain-universe-eodhdupcomingipos",
 			"description": "Selects expected/priced non-penny IPOs with a confirmed IPO date from the top 100 US Equities by dollar volume and equal-weights them with a daily scheduled rebalance.",
 			"tags": ["alternative-data", "universe", "chained-universe", "Equity", "ipos", "eod-historical-data", "upcoming-ipos"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854144,
+			"projectIdPy": 31854349
 		},
 		{
 			"name": "Option SPY Iron Condor",
 			"folder": "option-iron-condor-spy",
 			"description": "Sells weekly SPY iron condors with short strikes ~10 delta and long wings 3 strikes wider.",
 			"tags": ["Option", "iron-condor", "option-strategies", "weekly"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854154,
+			"projectIdPy": 31854368
 		},
 		{
 			"name": "Live Trading Features",
 			"folder": "live-trading-features",
 			"description": "Demonstrates live email and SMS notifications, brokerage disconnect/reconnect handling, and commands.",
 			"tags": ["live-trading", "sms", "notifications", "Equity", "emails", "commands", "brokerage-messages"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854180,
+			"projectIdPy": 31854396
 		},
 		{
 			"name": "Custom Indicator",
 			"folder": "custom-indicator",
 			"description": "Implements a custom Money Flow Index indicator and trades SPY on its signals.",
 			"tags": ["indicators", "custom-indicator", "Equity"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854193,
+			"projectIdPy": 31854409
 		},
 		{
 			"name": "Intraday Greeks-Based Options Selection",
 			"folder": "intraday-greeks-based-options-selection",
 			"description": "Selects RUT Index Options intraday by target delta from EMA-driven signals with paced order submission.",
 			"tags": ["intraday", "IndexOption", "greeks"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854201,
+			"projectIdPy": 31854428
 		},
 		{
 			"name": "Custom Data",
 			"folder": "custom-data",
 			"description": "Defines a custom data source type that ingests Bitstamp data and plots daily Bitcoin prices.",
 			"tags": ["python-data", "custom-data", "Crypto"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854222,
+			"projectIdPy": 31854451
 		},
 		{
 			"name": "Intraday Index Options Selection",
 			"folder": "intraday-index-options-selection",
 			"description": "Loads the SPX weekly chain daily and re-filters ATM calls every 5 minutes to trade as contracts update intraday.",
 			"tags": ["0dte", "IndexOption", "intraday"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854239,
+			"projectIdPy": 31854466
 		},
 		{
 			"name": "AI",
 			"folder": "ai",
 			"description": "Trains a TensorFlow MLP weekly on warmed-up history to predict SPY direction.",
 			"tags": ["machine-learning", "tensorflow", "indicators", "Equity"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854267,
+			"projectIdPy": 31854496
 		},
 		{
 			"folder": "equity-pairs-trading-cointegration",
@@ -747,24 +747,24 @@
 			"spec": "Assets: KO, PEP. Minute resolution. 2022-01-01 to 2024-12-31, $100k. Compute hedge ratio via 60-day rolling OLS on closes; z-score the spread; long-spread when z<-2 (long KO, short PEP); short-spread when z>2; exit when |z|<0.5. Demonstrates: history requests for OLS, RollingWindow, dollar-neutral sizing. Edge case: re-fit hedge ratio weekly.",
 			"tags": ["Equity", "pairs-trading", "statistical-arbitrage", "history"],
 			"reference_template": "history-and-etf-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854280,
+			"projectIdPy": 31854551
 		},
 		{
 			"name": "Alternative Data Universe",
 			"folder": "alternative-data-universe",
 			"description": "Uses EODHD upcoming-earnings data to select Equities and trades straddles around earnings announcements.",
 			"tags": ["Option", "universe", "alternative-data", "earnings", "eod-historical-data", "upcoming-earnings"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854298,
+			"projectIdPy": 31854568
 		},
 		{
 			"name": "Custom Models",
 			"folder": "custom-models",
 			"description": "Replaces the default fee, fill, slippage, and buying-power models through a security initializer.",
 			"tags": ["reality-models", "slippage", "fill-model", "fee-model", "Equity"],
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854310,
+			"projectIdPy": 31854581
 		},
 		{
 			"folder": "equity-permanent-portfolio",
@@ -773,8 +773,8 @@
 			"spec": "Assets: SPY, TLT, GLD, SHY. Minute. 2022-01-01 to 2024-12-31, $100k. Equal-weight 25% on first bar; annual rebalance every January 2nd. Demonstrates: 4-asset allocation, annual scheduled event, scheduled-event rule chaining. Edge case: skip rebalance if drift < 3% from target.",
 			"tags": ["Equity", "permanent-portfolio", "asset-allocation", "scheduled-event"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854324,
+			"projectIdPy": 31854593
 		},
 		{
 			"folder": "equity-dual-momentum-asset-class",
@@ -783,8 +783,8 @@
 			"spec": "Assets: SPY, EFA, AGG. Minute resolution. 2022-01-01 to 2024-12-31, $100k. Monthly: compute 12-month return for each; pick the highest; if highest <= AGG return then hold AGG; else hold winner 100%. Demonstrates: history-based momentum, monthly schedule, conditional hold. Edge case: rebalance only on first trading day of month.",
 			"tags": ["Equity", "dual-momentum", "asset-allocation", "history"],
 			"reference_template": "history-and-etf-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854336,
+			"projectIdPy": 31854609
 		},
 		{
 			"folder": "equity-dollar-cost-averaging",
@@ -793,8 +793,8 @@
 			"spec": "Asset: VOO. Minute. 2022-01-01 to 2024-12-31, $200k starting cash. Schedule: every Monday after market open buy VOO with $5,000 of cash via market_order using calculate_order_quantity. Demonstrates: weekly schedule, fixed-dollar buys, calculate_order_quantity, no liquidation. Edge case: skip if insufficient cash; never sell.",
 			"tags": ["Equity", "dca", "scheduled-event", "buy-and-hold"],
 			"reference_template": "equities-static-universe",
-			"projectIdCs": null,
-			"projectIdPy": null
+			"projectIdCs": 31854362,
+			"projectIdPy": 31854622
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- Populates `projectIdCs` and `projectIdPy` for all 94 entries in `project-templates/templates.json` (188 cloud projects) so subsequent match-check runs reuse them instead of creating new projects.
- Adds a `--no-backtest` flag to `project-templates/run_project_match_check.py` that uploads changed files without running compile/backtest, and lowers `WORKERS_PER_LANG` from 3 to 1.
- Renames the org-id secret reference in `.github/workflows/syntax-tests.yml` from `DOCUMENTATION_ORG_ID` to `QUANTCONNECT_ORG_ID` to match the repo secret name.

## Test plan

- [ ] CI: \`Syntax Tests\` workflow runs and authenticates with the renamed secret.
- [ ] Run \`python project-templates/run_project_match_check.py --no-backtest\` locally and confirm it short-circuits before \`/compile/create\`.
- [ ] Run \`python project-templates/run_project_match_check.py <folder>\` on a single template and confirm it reuses the saved project ID rather than creating a new one.