### PR TITLE
Document the Recycle Bin in the Delete Projects page

### DIFF
--- a/01 Cloud Platform/06 Projects/01 Getting Started/11 Delete Projects.html
+++ b/01 Cloud Platform/06 Projects/01 Getting Started/11 Delete Projects.html
@@ -1,4 +1,4 @@
-<p>You can delete a project when it is open or closed.</p>
+<p>You can delete a project when it is open or closed. Deleted projects are moved to the <span class="page-section-name">Recycle Bin</span> directory on the <a href="/docs/v2/cloud-platform/projects/getting-started#02-View-All-Projects">My Projects</a> page, where you can recover them if you delete one by mistake. Projects in the <span class="page-section-name">Recycle Bin</span> are permanently deleted after 30 days.</p>
 
 <h4>Delete Open Projects</h4>
 <p>In the Project panel, click <span class="button-name">Delete</span>, and then click <span class="button-name">Yes</span> to delete the project.<br></p>
@@ -12,4 +12,14 @@
     <li>Hover over the project file and then click the <span class="icon-name">trash can</span> icon that appears.</li>
     <img class="docs-image" src="https://cdn.quantconnect.com/i/tu/delete-projects-when-closed.png" alt="Delete a project in all projects view">
     <p>"Project deleted" displays.</p>
+</ol>
+
+<h4>Recover Deleted Projects</h4>
+<p>When you delete a project, it moves to the <span class="page-section-name">Recycle Bin</span> directory instead of being permanently removed. Projects in the <span class="page-section-name">Recycle Bin</span> are permanently deleted after 30 days, so recover them within that window. Follow these steps to recover a project you deleted by mistake:</p>
+
+<ol>
+    <li>Open the <a href="/docs/v2/cloud-platform/projects/getting-started#02-View-All-Projects">My Projects</a> page.</li>
+    <li>Click the <span class="page-section-name">Recycle Bin</span> directory.</li>
+    <li>Click the project to open it.</li>
+    <li><a href="/docs/v2/cloud-platform/projects/getting-started#07-Rename-Projects">Rename the project</a> to remove the <span class="public-directory-name">Recycle Bin/</span> prefix from its path (for example, rename <span class="public-directory-name">Recycle Bin/My Legacy Project</span> to <span class="public-directory-name">My Legacy Project</span>).</li>
 </ol>


### PR DESCRIPTION
## Summary
- Note that deleted cloud projects are moved to the **Recycle Bin** directory and are purged after 30 days.
- Add a **Recover Deleted Projects** section explaining how to restore a project by opening it from the Recycle Bin and renaming it to strip the `Recycle Bin/` prefix.

## Test plan
- [x] Render `/docs/v2/cloud-platform/projects/getting-started#11-Delete-Projects` and verify the new paragraph and section display correctly.
- [ ] Confirm the in-page links to `#02-View-All-Projects` and `#07-Rename-Projects` work.