### PR TITLE
Add screenshots to IB FIX Integration tutorial

### DIFF
--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/03 FIX Integration.html
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/03 FIX Integration.html
@@ -6,12 +6,21 @@
 
 <ol>
 	<li>Log in to the <a rel='nofollow' target='_blank' href='https://qnt.co/interactivebrokers'>IB Client Portal</a>, open <span class='page-section-name'>Settings</span>, click <span class='page-section-name'>Research Subscriptions</span>, open <span class='page-section-name'>News &amp; Research Subscriptions</span>, and then click <span class='button-name'>Manage Subscriptions</span>.</li>
+	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-01.png'>
 	<li>Select <span class='button-name'>QuantConnect</span> from the list of subscriptions to create the FIX session, and then click <span class='button-name'>Continue</span>.</li>
+	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-02.png'>
 	<li>On the <span class='page-section-name'>Review Your Research Subscriptions</span> screen, review the market-data agreements and disclosures, and then confirm to proceed.</li>
+	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-03.png'>
 	<li>On the <span class='page-section-name'>Service Account Configuration</span> screen, click the <span class='button-name'>Configure</span> gear next to QuantConnect.</li>
+	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-04.png'>
 	<li>In the <span class='page-section-name'>Service Account Configuration for QuantConnect</span> dialog, select the IB account(s) you want to link, enter your QuantConnect user name in the <span class='field-name'>Quantconnect Username</span> field, and then click <span class='button-name'>Save</span>.</li>
+	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-05.png'>
+	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-06.png'>
 	<p>The user name you enter is the default subscriber for the QuantConnect service. You can select multiple accounts here. When you later connect from QuantConnect to IB, you enter this same user name to authenticate.</p>
 	<li>Back on the <span class='page-section-name'>Service Account Configuration</span> screen, click <span class='button-name'>Continue</span>.</li>
+	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-07.png'>
 	<li>Acknowledge and confirm the OMS Riders and Addendum.</li>
+	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-08.png'>
+	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-09.png'>
 	<p>After you confirm, your subscription is complete and the selected information is added to the FIX connection for order validation.</p>
 </ol>


### PR DESCRIPTION
## Summary
- Add nine screenshots (`ib-fix-01.png` through `ib-fix-09.png`) to the IB FIX Integration tutorial, one per step (Steps 5 and 7 receive two images each for the before/after dialog and OMS rider/addendum views).

## Test plan
- [ ] Render the page and verify each image displays under the matching step
- [ ] Confirm CDN URLs resolve (`https://cdn.quantconnect.com/i/tu/ib-fix-01.png` .. `ib-fix-09.png`)