### PR TITLE
Document EMSX locate properties on TerminalLinkOrderProperties

### DIFF
--- a/Resources/brokerages/terminal-link/orders.php
+++ b/Resources/brokerages/terminal-link/orders.php
@@ -132,6 +132,22 @@
             <td></td>
         </tr>
         <tr>
+            <td><code class="csharp">LocateBroker</code><code class="python">locate_broker</code></td>
+            <td><code class='csharp'>string</code><code class='python'>str</code></td>
+            <td>
+                The EMSX locate broker code that identifies the counterparty the shares are borrowed from for a short equity sale (for example, <code>"BMTB"</code>).
+                Maps to the <code>LocBrkr</code> field on the EMSX trading ticket.
+                Setting this property (or <code class="csharp">LocateId</code><code class="python">locate_id</code>) on a short equity sale causes the brokerage to emit <code>EMSX_LOCATE_REQ = "Y"</code> alongside.
+            </td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><code class="csharp">LocateId</code><code class="python">locate_id</code></td>
+            <td><code class='csharp'>string</code><code class='python'>str</code></td>
+            <td>The EMSX locate confirmation/ticket Id that the lending broker returns. Maps to the <code>LocId</code> field on the EMSX trading ticket.</td>
+            <td></td>
+        </tr>
+        <tr>
             <td><code class="csharp">Strategy</code><code class="python">strategy</code></td>
             <td><code>StrategyParameters</code></td>
             <td>


### PR DESCRIPTION
## Summary
- Add `LocateBroker` / `locate_broker` and `LocateId` / `locate_id` rows to the TerminalLink order-properties table in [Resources/brokerages/terminal-link/orders.php](Resources/brokerages/terminal-link/orders.php).
- Covers the two new properties added to `TerminalLinkOrderProperties` in QuantConnect/Lean#9502 for attaching Reg SHO locate information to short equity sales routed through Bloomberg EMSX.

## Test plan
- [ ] Render `Resources/brokerages/terminal-link/orders.php` and confirm both new rows appear between `Broker` and `Strategy`, with C#/Python toggles, types, and default values matching the surrounding rows.