### PR TITLE
Add Webull API credential steps to Account Types

### DIFF
--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/08 Webull/02 Account Types.html
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/08 Webull/02 Account Types.html
@@ -4,11 +4,14 @@
 <p>Follow the <a rel="nofollow" target="_blank" href="https://www.webull.com/">account creation wizard</a> on the Webull website to create a Webull account.</p>
 
 <h4>Create API Credentials</h4>
-<p>To trade with the Webull API, you need an App Key, App Secret, and account ID. Follow these steps to create them:</p>
+<p>To trade with the Webull API, you need an App Key, App Secret, and the account ID of the Webull account you want to trade. The following steps summarize how to create them. For the full process with screenshots, see <a rel="nofollow" target="_blank" href="https://developer.webull.com/apis/docs/authentication/IndividualApplicationAPI">Individual Application API</a> in the Webull developer documentation.</p>
 <ol>
-    <li>Log in to the <a rel="nofollow" target="_blank" href="https://developer.webull.com/api-doc/prepare/api_apply/">Webull Developer Portal</a> with your Webull account.</li>
-    <li>Create an application to generate an <span class='field-name'>App Key</span> and <span class='field-name'>App Secret</span>.</li>
-    <li>Enable the application for trading and note the <span class='field-name'>account ID</span> of the Webull account you want to trade.</li>
+    <li>Log in to <a rel="nofollow" target="_blank" href="https://www.webull.com/">Webull.com</a> and open the account center.</li>
+    <li>From the avatar menu, open <span class='menu-name'>Developer Tools</span> and then click <span class='menu-name'>API Management > My Application</span>.</li>
+    <li>Submit your API application and wait for approval, which takes one to two business days. You receive a confirmation email when it's approved.</li>
+    <li>After approval, click <span class='menu-name'>API Management > Application Management</span>, enter an application name, accept the Webull OpenAPI Agreement, and register the application.</li>
+    <li>Click <span class='button-name'>Generate Key</span> and then complete the SMS verification code and transaction password verification to generate your <span class='field-name'>App Key</span> and <span class='field-name'>App Secret</span>. You can reset the App Secret later with <span class='button-name'>Reset Key</span>.</li>
+    <li>Note the <span class='field-name'>account ID</span> of the Webull account you want to trade.</li>
 </ol>
 
 <h4>Paper Trading</h4>


### PR DESCRIPTION
## Summary

Follow-up to #2462. Replaces the generic "Create API Credentials" steps on the Webull **Account Types** page with the actual Individual Application API process from the Webull developer documentation (apply for API access, register the application, generate the App Key / App Secret via SMS + transaction-password verification), and links to the source page so users can see the accompanying screenshots.

## Test plan

- [x] Steps match the [Individual Application API](https://developer.webull.com/apis/docs/authentication/IndividualApplicationAPI) documentation.
- [ ] Render the Account Types page to confirm the ordered list and link display correctly.