### PR TITLE
Document Bybit Demo Trading paper trading support

### DIFF
--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/10 ByBit/02 Account Types.html
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/10 ByBit/02 Account Types.html
@@ -20,9 +20,17 @@
 </ul>
 
 <h4>Paper Trading</h4>
-<p>Our integration doesn't support paper trading through the Bybit Demo Trading environment, but you can follow these steps to simulate it with QuantConnect:</p>
+<p>Bybit supports paper trading through two environments: <a rel="nofollow" target="_blank" href="https://www.bybit.com/en/help-center/article/FAQ-Demo-Trading">Bybit Demo Trading</a> and the <a rel="nofollow" target="_blank" href="https://testnet.bybit.com/">Bybit Testnet</a>. Each environment uses a separate set of API credentials, so you can't reuse your live account keys.</p>
 
+<p>Follow these steps to set up paper trading with Bybit Demo Trading:</p>
 <ol>
-    <li>In the <code class="csharp">Initialize</code><code class="python">initialize</code> method of your algorithm, set the Bybit brokerage model.</li>
-    <li><a href="/docs/v2/cloud-platform/live-trading/brokerages/quantconnect-paper-trading#15-Deploy-Live-Algorithms">Deploy your algorithm with the QuantConnect Paper Trading brokerage</a>.</li>
+    <li>Log in to your <a rel="nofollow" target="_blank" href="https://www.bybit.com/">Bybit account</a>.</li>
+    <li>From your account menu, switch to <span class="box-name">Demo Trading</span>.</li>
+    <li><a rel="nofollow" target="_blank" href="https://www.bybit.com/en/help-center/article/How-to-create-your-API-key">Create API credentials</a> in the Demo Trading environment and store them somewhere safe.</li>
+</ol>
+
+<p>Follow these steps to set up paper trading with the Bybit Testnet:</p>
+<ol>
+    <li>Log in to the <a rel="nofollow" target="_blank" href="https://testnet.bybit.com/">Bybit Testnet</a>.</li>
+    <li><a rel="nofollow" target="_blank" href="https://www.bybit.com/en/help-center/article/How-to-create-your-API-key">Create API credentials</a> on the Testnet and store them somewhere safe.</li>
 </ol>

--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/10 ByBit/16 Deploy Live Algorithms.php
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/10 ByBit/16 Deploy Live Algorithms.php
@@ -5,7 +5,32 @@ $holdingsState = true;
 $secondBullet = "";
 $authentication = "<li>Enter your API key and secret.</li>" . file_get_contents(DOCS_RESOURCES."/brokerages/create-credentials/bitfinex.html") . "
 <li>Click the <span class='field-name'>VIP Level</span> field and then click your level from the drop-down menu.</li>
-<p>For more information about VIP levels, see <a href='https://www.bybit.com/en/help-center/article/FAQ-VIP-Program' target='_blank' rel='nofollow'>FAQ — Bybit VIP Program</a> on the Bybit website.</p>";
+<p>For more information about VIP levels, see <a href='https://www.bybit.com/en/help-center/article/FAQ-VIP-Program' target='_blank' rel='nofollow'>FAQ — Bybit VIP Program</a> on the Bybit website.</p>
+<li>Click on the <span class='field-name'>Environment</span> field and then click one of the environments.</li>
+<p>The following table shows the supported environments:</p>
+
+<table class='table qc-table'>
+    <thead>
+        <tr>
+            <th>Environment</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Live</td>
+            <td>Trade with real money</td>
+        </tr>
+        <tr>
+            <td>Demo</td>
+            <td>Trade with paper money through the <a href='https://www.bybit.com/en/help-center/article/FAQ-Demo-Trading' target='_blank' rel='nofollow'>Bybit Demo Trading</a> environment</td>
+        </tr>
+        <tr>
+            <td>Testnet</td>
+            <td>Trade with paper money through the <a href='https://testnet.bybit.com/' target='_blank' rel='nofollow'>Bybit Testnet</a></td>
+        </tr>
+    </tbody>
+</table>";
 $postDeploy = "";
 include(DOCS_RESOURCES."/live-trading/deploy-live-algorithm.php");
 ?>

--- a/05 Lean CLI/09 Live Trading/01 Brokerages/10 Bybit/03 Deploy Local Algorithms.php
+++ b/05 Lean CLI/09 Live Trading/01 Brokerages/10 Bybit/03 Deploy Local Algorithms.php
@@ -23,9 +23,9 @@ VIP Level (VIP0, VIP1, VIP2, VIP3, VIP4, VIP5, SupremeVIP, Pro1, Pro2, Pro3, Pro
 <li>Enter the environment to use.
 <div class='cli section-example-container'>
 <pre>$ lean live \"My Project\"
-Use testnet? (live, paper): live</pre>
+Use testnet? (live, paper, demo): live</pre>
 </div>
-<p>The paper environment is <a href='https://learn.bybit.com/bybit-guide/what-is-bybit-demo-trading/' rel='nofollow' target='_blank'>Bybit Demo Trading</a>.</p>
+<p>The <span class='box-name'>paper</span> environment is the <a href='https://testnet.bybit.com/' rel='nofollow' target='_blank'>Bybit Testnet</a> and the <span class='box-name'>demo</span> environment is <a href='https://www.bybit.com/en/help-center/article/FAQ-Demo-Trading' rel='nofollow' target='_blank'>Bybit Demo Trading</a>. Both environments require API credentials that you create in that environment; your live account keys won't work.</p>
 </li>
 ";
 


### PR DESCRIPTION
## Summary

Bybit now supports paper trading through the Bybit Demo Trading environment (see [Lean.Brokerages.ByBit#41](https://github.com/QuantConnect/Lean.Brokerages.ByBit/pull/41)). This updates the docs accordingly:

- **Cloud Platform → Account Types**: Replace the "paper trading not supported" note with steps to set up paper trading through **Bybit Demo Trading** and the **Bybit Testnet**, each using its own environment-specific API credentials.
- **Cloud Platform → Deploy Live Algorithms**: Add an **Environment** field table with Live / Demo / Testnet, matching the deployment dropdown.
- **Lean CLI → Deploy Local Algorithms**: Update the environment prompt to `Use testnet? (live, paper, demo)` and clarify that `paper` is the Testnet and `demo` is Bybit Demo Trading.

## Test plan

- Verified the Environment options (Live / Demo / Testnet) match the Cloud deployment UI dropdown.
- Verified the Lean CLI prompt wording matches the `(live, paper, demo)` options.
- Confirmed only the three intended Bybit files are included; no unrelated files.