### PR TITLE
Use OAuth for Webull cloud deployment

### DIFF
--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/08 Webull/02 Account Types.html
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/08 Webull/02 Account Types.html
@@ -4,7 +4,7 @@
 <p>Follow the <a rel="nofollow" target="_blank" href="https://www.webull.com/">account creation wizard</a> on the Webull website to create a Webull account.</p>
 
 <h4>Create API Credentials</h4>
-<p>To trade with the Webull API, you need an App Key, App Secret, and the account ID of the Webull account you want to trade. The following steps summarize how to create them. For the full process with screenshots, see <a rel="nofollow" target="_blank" href="https://developer.webull.com/apis/docs/authentication/IndividualApplicationAPI">Individual Application API</a> in the Webull developer documentation.</p>
+<p>In QuantConnect Cloud and when you use the <a href="/docs/v2/lean-cli">Lean CLI</a> to deploy to the cloud, you authenticate through the deployment wizard, so you don't need to create API credentials. To use Webull locally with the Lean CLI&mdash;to download data, backtest, research, or trade live&mdash;you need an App Key, App Secret, and the account ID of the Webull account you want to trade. The following steps summarize how to create these credentials. For the full process with screenshots, see <a rel="nofollow" target="_blank" href="https://developer.webull.com/apis/docs/authentication/IndividualApplicationAPI">Individual Application API</a> in the Webull developer documentation.</p>
 <ol>
     <li>Log in to <a rel="nofollow" target="_blank" href="https://www.webull.com/">Webull.com</a> and open the account center.</li>
     <li>From the avatar menu, open <span class='menu-name'>Developer Tools</span> and then click <span class='menu-name'>API Management > My Application</span>.</li>

--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/08 Webull/16 Deploy Live Algorithms.php
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/08 Webull/16 Deploy Live Algorithms.php
@@ -3,7 +3,9 @@ $brokerageName = "Webull";
 $cashState = false;
 $holdingsState = false;
 $secondBullet = "";
-$authentication = "<li>Enter your Webull App Key, App Secret, and account ID.</li>" . file_get_contents(DOCS_RESOURCES."/brokerages/create-credentials/webull.html");
+$authentication = "<li>Click the <span class=\"button-name\">Authenticate</span> button.</li>
+<li>On the Webull website, log in to your account to grant QuantConnect access to your account information and authorization.</li>
+<li>Click the <span class='field-name'>Select Account Id</span> field and then click one of your accounts.</li>";
 $postDeploy = "";
 $dataProviderDetails = "<p>Webull doesn't provide a live data feed, so use the <a href='/docs/v2/cloud-platform/datasets'>QuantConnect data provider</a> or another data provider for the securities you trade.</p>";
 include(DOCS_RESOURCES."/live-trading/deploy-live-algorithm.php");

--- a/05 Lean CLI/09 Live Trading/01 Brokerages/08 Webull/02 Deploy Cloud Algorithms.php
+++ b/05 Lean CLI/09 Live Trading/01 Brokerages/08 Webull/02 Deploy Cloud Algorithms.php
@@ -1,13 +1,20 @@
 <?
 $brokerageDetails = "
-<li>Enter your Webull App Key, App Secret, and account ID.
+<li>In the browser window that automatically opens, log in to your Webull account.
 <div class='cli section-example-container'>
 <pre>$ lean cloud live \"My Project\" --push --open
-App key: 0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
-App secret: *******************************
-Account id: 12345678</pre>
+Please open the following URL in your browser to authorize the LEAN CLI.
+https://www.quantconnect.com/api/v2/live/auth0/authorize?brokerage=webull
+Will sleep 5 seconds and retry fetching authorization...
+</pre>
 </div>
-" . file_get_contents(DOCS_RESOURCES."/brokerages/create-credentials/webull.html") . "
+</li>
+
+<li>Enter the Webull account ID.
+<div class='cli section-example-container'>
+<pre>$ lean cloud live \"My Project\" --push --open
+The Webull account Id: 12345678</pre>
+</div>
 </li>";
 $dataProviderDetails = "";
 $brokerageName="Webull";


### PR DESCRIPTION
## Summary

Corrects how Webull authentication is documented. Webull authenticates differently depending on where you run:

- **QuantConnect Cloud** and **Lean CLI deploying to the cloud** use OAuth — an **Authenticate** button (cloud) / auth0 browser authorization flow (CLI) — so users don't enter API keys.
- **Local Lean CLI** (download, backtest, research, and live trading) continues to use the App Key, App Secret, and account ID.

Changes:
- `08 Webull/16 Deploy Live Algorithms.php` (cloud) — replaces App Key/Secret/Account ID entry with the Authenticate button → log in on Webull → select Account Id (mirrors TradeStation).
- `Lean CLI .../08 Webull/02 Deploy Cloud Algorithms.php` — replaces key entry with the auth0 browser authorization flow plus account-ID entry.
- `08 Webull/02 Account Types.html` — clarifies that cloud and CLI-to-cloud deployments authenticate through the wizard, while local Lean CLI use (download, backtest, research, live) requires API credentials.

The local Lean CLI deploy page (`03 Deploy Local Algorithms.php`) is unchanged — it correctly keeps the App Key/Secret/Account ID entry and the credential-creation link.

Follow-up to #2462 and #2465.

## Test plan

- [ ] Render the cloud and CLI deploy pages to confirm the Authenticate/auth0 steps and the Account Types wording display correctly.