### PR TITLE
Correct IB FIX integration to use QuantConnect user Id

### DIFF
--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/03 FIX Integration.html
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/03 FIX Integration.html
@@ -19,11 +19,11 @@
 	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-03.png'>
 	<li>On the <span class='page-section-name'>Service Account Configuration</span> screen, click the <span class='button-name'>Configure</span> gear next to QuantConnect.</li>
 	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-04.png'>
-	<li>In the <span class='page-section-name'>Service Account Configuration for QuantConnect</span> dialog, select the IB account(s) you want to link, enter your QuantConnect user name in the <span class='field-name'>Quantconnect Username</span> field, and then click <span class='button-name'>Save</span>.</li>
+	<li>In the <span class='page-section-name'>Service Account Configuration for QuantConnect</span> dialog, select the IB account(s) you want to link, enter your QuantConnect user Id in the <span class='field-name'>Quantconnect Username</span> field, and then click <span class='button-name'>Save</span>.</li>
 	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-05.png'>
 	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-06.png'>
-	<p>The user name you enter is the default subscriber for the QuantConnect service. You can select multiple accounts here. When you later connect from QuantConnect to IB, you enter this same user name to authenticate.</p>
-	<p>Your QuantConnect username is the last part of your <a href='https://www.quantconnect.com/docs/v2/cloud-platform/community/profile#02-Personal-Information'>profile page</a> URL. For example, if your profile page is <span class='public-file-name'>https://www.quantconnect.com/u/james_bond</span>, your username is <span class='public-file-name'>james_bond</span>.</p>
+	<p>The user Id you enter is the default subscriber for the QuantConnect service. You can select multiple accounts here. When you later connect from QuantConnect to IB, you enter this same user Id to authenticate.</p>
+	<p>To get your QuantConnect user Id, <a href='https://www.quantconnect.com/docs/v2/cloud-platform/community/profile#09-Request-API-Token'>request an API token</a>. We email you your user Id and API token.</p>
 	<li>Back on the <span class='page-section-name'>Service Account Configuration</span> screen, click <span class='button-name'>Continue</span>.</li>
 	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-07.png'>
 	<li>Acknowledge and confirm the OMS Riders and Addendum.</li>

--- a/01 Cloud Platform/14 Community/04 Profile/02 Personal Information.html
+++ b/01 Cloud Platform/14 Community/04 Profile/02 Personal Information.html
@@ -24,7 +24,6 @@
 </ol>
 
 <h4>Username</h4>
-<p>Your username is the last part of your profile page URL. For example, if your profile page is <span class='public-file-name'>https://www.quantconnect.com/u/james_bond</span>, your username is <span class='public-file-name'>james_bond</span>.</p>
 <p>Follow these steps to update your username:</p>
 <ol>
     <li>Log in to your account.</li>


### PR DESCRIPTION
## Summary

The IB FIX Integration page tells users to enter their QuantConnect username, but the value the broker expects is the QuantConnect **user Id**. This corrects the wording and points to where the user Id can be obtained.

- Changed "user name" to "user Id" in the entry step and the explanatory paragraph.
- Replaced the username/profile-URL note with one that points to the [Request API Token](https://www.quantconnect.com/docs/v2/cloud-platform/community/profile#09-Request-API-Token) flow, which emails the user Id.
- Removed the username/profile-URL line previously added to the Personal Information page, since it is no longer relevant.

## Test plan

- Verify both pages render and the cross-link to the Request API Token section resolves.