### PR TITLE
Document disabling Quotes and 2FA for Webull API applications

### DIFF
--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/08 Webull/02 Account Types.html
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/08 Webull/02 Account Types.html
@@ -10,6 +10,7 @@
     <li>From the avatar menu, open <span class='menu-name'>Developer Tools</span> and then click <span class='menu-name'>API Management > My Application</span>.</li>
     <li>Submit your API application and wait for approval, which takes one to two business days. You receive a confirmation email when it's approved.</li>
     <li>After approval, click <span class='menu-name'>API Management > Application Management</span>, enter an application name, accept the Webull OpenAPI Agreement, and register the application.</li>
+    <li>In <span class='menu-name'>Application Management</span>, disable <span class='field-name'>Quotes</span> and <span class='field-name'>two-factor authentication (2FA)</span> for the application. QuantConnect supplies the market data, so you don't need Quotes, and disabling 2FA lets the API authenticate without interactive verification.</li>
     <li>Click <span class='button-name'>Generate Key</span> and then complete the SMS verification code and transaction password verification to generate your <span class='field-name'>App Key</span> and <span class='field-name'>App Secret</span>. You can reset the App Secret later with <span class='button-name'>Reset Key</span>.</li>
     <li>Note the <span class='field-name'>account ID</span> of the Webull account you want to trade.</li>
 </ol>


### PR DESCRIPTION
## Summary

Adds a step to the Webull **Account Types** credential instructions: in Webull's **Application Management**, disable **Quotes** and **two-factor authentication (2FA)** for the API application. QuantConnect supplies the market data (so Quotes aren't needed), and 2FA would block the API from authenticating non-interactively.

## Test plan

- [ ] Render the Webull Account Types page to confirm the new step displays in order within the credential-creation list.