### PR TITLE
Restrict own LLM provider to paid Assistant Nodes

### DIFF
--- a/09 AI Assistance/02 Assistants/05 LLM Providers.html
+++ b/09 AI Assistance/02 Assistants/05 LLM Providers.html
@@ -3,7 +3,7 @@
   It requires no setup and is the right choice when you want the assistant working without bringing your own LLM API key.
 </p>
 <p>
-  Organizations on a <a href='/docs/v2/cloud-platform/organizations/tier-features'>paid tier</a> can supply an API key from an LLM provider of their choice.
+  Organizations with a paid <a href='/docs/v2/cloud-platform/organizations/resources#05-Assistant-Nodes'>Assistant Node</a> can supply an API key from an LLM provider of their choice.
   With your own provider, you can select a specific model, configure the reasoning effort, the maximum number of turns the assistant takes per deployment, and the tool selection policy.
   Use this option when you want to swap in a specific model, tune those parameters, or route costs through your own account.
 </p>
@@ -33,7 +33,3 @@
   <li>Grok: <a href='https://accounts.x.ai/sign-in' rel='nofollow' target='_blank'>Log in or create an account</a> on the xAI Console. Then, on the <a href='https://console.x.ai' rel='nofollow' target='_blank'>API Keys</a> page, click <span class='button-name'>Create API key</span>.</li>
   <li>OpenAI: <a href='https://platform.openai.com/login' rel='nofollow' target='_blank'>Log in or create an account</a> on the OpenAI Platform. Then, on the <a href='https://platform.openai.com/api-keys' rel='nofollow' target='_blank'>API Keys</a> page, click <span class='button-name'>Create new secret key</span>.</li>
 </ul>
-
-<p>
-  The free A-MICRO <a href='/docs/v2/cloud-platform/organizations/resources#05-Assistant-Nodes'>Assistant Node</a> keeps its 100,000 tokens per month cap even when you use your own provider.
-</p>


### PR DESCRIPTION
## Summary

- Change the bring-your-own LLM provider requirement from a paid organization tier to a paid Assistant Node, linking to the Assistant Nodes section of the Resources docs.
- Remove the note about the free A-MICRO Assistant Node token cap, since the paid-node requirement makes it redundant.

## Test Plan

- Verified the `organizations/resources#05-Assistant-Nodes` link target exists.
- Checked the diff only touches `09 AI Assistance/02 Assistants/05 LLM Providers.html`.