### PR TITLE
Add custom indicator warm-up Python template

### DIFF
--- a/project-templates/python/templates.json
+++ b/project-templates/python/templates.json
@@ -1,6 +1,13 @@
 {
 	"templates": [
 		{
+			"name": "Warm-Up: Custom Indicator",
+			"folder": "warmup-template-custom-indicator",
+			"description": "Warms and registers a custom annualized volatility PythonIndicator before trading SPY when volatility rises.",
+			"spec": "Asset: SPY. Daily resolution. 2024-09-01 to 2024-12-31, $100k. CustomVolatility(3*21, trading_days_per_year=252) custom PythonIndicator built from LogReturn(1) and StandardDeviation(3*21). Attach the indicator to the Equity, warm it with typed TradeBar history, register it for future updates, and enter only when volatility is ready, rising versus its previous value, and the Equity is not already invested. Demonstrates: custom indicator warm-up, built-in indicator composition, typed history updates, custom indicator registration.",
+			"tags": ["Equity", "warm-up", "history", "indicators", "custom-indicator"],
+			"reference_template": "custom-indicator"
+		},		{
 			"name": "Equity Parabolic SAR Trailing Stop",
 			"folder": "equity-parabolic-sar-trailing",
 			"description": "Trades SPY long-only with Parabolic SAR providing dynamic trailing-stop levels and re-entries.",
@@ -10,14 +17,14 @@
 			"folder": "equity-aroon-trend",
 			"name": "Equity Aroon Trend",
 			"description": "Trades SPY using AroonOscillator(25); enters long on cross above +50 and exits on cross below -50.",
-			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. AroonOscillator(25). Long when oscillator crosses above 50; exit when it crosses below -50. Demonstrates: Aroon indicator, threshold crossing pattern, plotting oscillator on subchart. Edge case: do not flip short â€” long-only.",
+			"spec": "Asset: SPY. Minute resolution. 2022-01-01 to 2024-12-31, $100k. AroonOscillator(25). Long when oscillator crosses above 50; exit when it crosses below -50. Demonstrates: Aroon indicator, threshold crossing pattern, plotting oscillator on subchart. Edge case: do not flip short — long-only.",
 			"tags": ["Equity", "indicators", "aroon", "trend"],
 			"reference_template": "equities-static-universe"
 		},
 		{
 			"name": "Equity Bollinger Mean Reversion",
 			"folder": "equity-bollinger-mean-reversion",
-			"description": "Trades SPY on a 20-period, 2-standard-deviation Bollinger Bands mean-reversion signal â€” buys when price closes below the lower band and liquidates on a return to the middle band â€” with a daily scheduled rebalance.",
+			"description": "Trades SPY on a 20-period, 2-standard-deviation Bollinger Bands mean-reversion signal — buys when price closes below the lower band and liquidates on a return to the middle band — with a daily scheduled rebalance.",
 			"tags": ["Equity", "indicators", "bollinger-bands", "mean-reversion", "z-score"]
 		},
 		{
@@ -169,7 +176,7 @@
 		{
 			"folder": "equity-cmf-money-flow",
 			"name": "Equity Chaikin Money Flow",
-			"description": "Trades XLF using ChaikinMoneyFlow(20) â€” long when CMF > 0.1 and short when CMF < -0.1, flat in between.",
+			"description": "Trades XLF using ChaikinMoneyFlow(20) — long when CMF > 0.1 and short when CMF < -0.1, flat in between.",
 			"spec": "Asset: XLF. Minute resolution. 2022-01-01 to 2024-12-31, $100k. ChaikinMoneyFlow(20). Long when CMF > 0.10; short when CMF < -0.10; flat in the dead zone. Demonstrates: CMF volume indicator, threshold-based regime, plotting indicator on subchart. Edge case: rebalance only on signal change.",
 			"tags": ["Equity", "indicators", "cmf", "volume"],
 			"reference_template": "equities-static-universe"
@@ -233,7 +240,7 @@
 		{
 			"name": "Crypto BTC vs PAXG Fed Funds Toggle",
 			"folder": "crypto-fred-rates-toggle",
-			"description": "Rotates between BTCUSD and gold-backed PAXGUSD on Kraken based on the 3-month change in the FRED Fed Funds Rate â€” long BTC when easing, gold when hiking or flat.",
+			"description": "Rotates between BTCUSD and gold-backed PAXGUSD on Kraken based on the 3-month change in the FRED Fed Funds Rate — long BTC when easing, gold when hiking or flat.",
 			"tags": ["Crypto", "alternative-data", "macro", "regime-switch", "indicators", "history", "fred", "us-federal-reserve"]
 		},
 		{
@@ -311,7 +318,7 @@
 		{
 			"folder": "equity-cci-overbought",
 			"name": "Equity Commodity Channel Index",
-			"description": "Trades XLE on CCI(20) â€” long when CCI < -100 and exit at 0; short when CCI > 100 and cover at 0.",
+			"description": "Trades XLE on CCI(20) — long when CCI < -100 and exit at 0; short when CCI > 100 and cover at 0.",
 			"spec": "Asset: XLE. Minute resolution. 2022-01-01 to 2024-12-31, $100k. CommodityChannelIndex(20). Long when CCI < -100; short when CCI > 100; both exit at 0. Demonstrates: CCI indicator, mean-reversion with explicit short side, sector ETF. Edge case: skip orders during low-volatility (ATR filter).",
 			"tags": ["Equity", "indicators", "cci", "mean-reversion"],
 			"reference_template": "equities-static-universe"
@@ -505,7 +512,7 @@
 		{
 			"name": "Equity Keltner Squeeze Breakout",
 			"folder": "equity-keltner-squeeze",
-			"description": "Trades a basket of US ETFs on Bollinger-inside-Keltner squeeze releases â€” long on a close above the upper Bollinger Band, short below the lower, exiting at the midline.",
+			"description": "Trades a basket of US ETFs on Bollinger-inside-Keltner squeeze releases — long on a close above the upper Bollinger Band, short below the lower, exiting at the midline.",
 			"tags": ["Equity", "indicators", "keltner", "squeeze", "bollinger-bands", "scheduled-event"]
 		},
 		{
@@ -587,7 +594,7 @@
 		{
 			"folder": "equity-permanent-portfolio",
 			"name": "Equity Permanent Portfolio",
-			"description": "Holds 25% each of SPY, TLT, GLD, and SHY with annual rebalance — Browne's Permanent Portfolio.",
+			"description": "Holds 25% each of SPY, TLT, GLD, and SHY with annual rebalance � Browne's Permanent Portfolio.",
 			"spec": "Assets: SPY, TLT, GLD, SHY. Minute. 2022-01-01 to 2024-12-31, $100k. Equal-weight 25% on first bar; annual rebalance every January 2nd. Demonstrates: 4-asset allocation, annual scheduled event, scheduled-event rule chaining. Edge case: skip rebalance if drift < 3% from target.",
 			"tags": ["Equity", "permanent-portfolio", "asset-allocation", "scheduled-event"],
 			"reference_template": "equities-static-universe"

--- a/project-templates/python/warmup-template-custom-indicator/main.py
+++ b/project-templates/python/warmup-template-custom-indicator/main.py
@@ -32,7 +32,7 @@ class CustomVolatility(PythonIndicator):
 
     def __init__(self, period, trading_days_per_year=252):
         super().__init__()
-        self.warm_up_period = period
+        self.warm_up_period = period + 1
         self._trading_days_per_year = trading_days_per_year
         self.value = 0
         self._log_return = LogReturn(1)

--- a/project-templates/python/warmup-template-custom-indicator/main.py
+++ b/project-templates/python/warmup-template-custom-indicator/main.py
@@ -1,0 +1,53 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+
+class WarmUpCustomIndicatorAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 9, 1)
+        self.set_end_date(2024, 12, 31)
+        self.set_cash(100_000)
+        self.settings.seed_initial_prices = True
+        self._equity = self.add_equity("SPY", Resolution.DAILY)
+        self._equity.volatility = CustomVolatility(3*21)
+        # Warm the custom indicator with daily trade bars.
+        for bar in self.history[TradeBar](self._equity, self._equity.volatility.warm_up_period, Resolution.DAILY):
+            self._equity.volatility.update(bar)
+        self.register_indicator(self._equity, self._equity.volatility)
+
+    def on_data(self, data: Slice) -> None:
+        if not self._equity.volatility.is_ready:
+            return
+        # Buy if volatility is increasing.
+        if not self._equity.invested and self._equity.volatility.value > self._equity.volatility.previous.value:
+            self.set_holdings(self._equity, 1)
+        # Exit if volatility is decreasing.
+        elif self._equity.invested and self._equity.volatility.value < self._equity.volatility.previous.value:
+            self.liquidate()
+
+
+class CustomVolatility(PythonIndicator):
+
+    def __init__(self, period, trading_days_per_year=252):
+        super().__init__()
+        self.warm_up_period = period
+        self._trading_days_per_year = trading_days_per_year
+        self.value = 0
+        self._log_return = LogReturn(1)
+        self._standard_deviation = IndicatorExtensions.of(StandardDeviation(period), self._log_return)
+
+    def update(self, input_: BaseData):
+        # Annualized log-return volatility.
+        price = input_.value
+        if price <= 0:
+            return
+        self._log_return.update(input_.end_time, price)
+        if self.is_ready:
+            self.value = self._standard_deviation.current.value * math.sqrt(self._trading_days_per_year) * 100.0
+        return self.is_ready
+
+    @property
+    def is_ready(self) -> bool:
+        return self._standard_deviation.is_ready

--- a/project-templates/python/warmup-template-custom-indicator/research.ipynb
+++ b/project-templates/python/warmup-template-custom-indicator/research.ipynb
@@ -43,7 +43,7 @@
    "source": [
     "### Define Indicator\n",
     "\n",
-    "Implement annualized volatility by chaining LogReturn into StandardDeviation."
+    "Implement annualized volatility by using [IndicatorExtensions](https://www.quantconnect.com/docs/v2/writing-algorithms/indicators/combining-indicators#08-Custom-Chains) to chain [LogReturn](https://www.quantconnect.com/docs/v2/writing-algorithms/indicators/supported-indicators/log-return) into [StandardDeviation](https://www.quantconnect.com/docs/v2/writing-algorithms/indicators/supported-indicators/standard-deviation)."
    ]
   },
   {
@@ -57,7 +57,7 @@
     "\n",
     "    def __init__(self, period, trading_days_per_year=252):\n",
     "        super().__init__()\n",
-    "        self.warm_up_period = period\n",
+    "        self.warm_up_period = period + 1\n",
     "        self._trading_days_per_year = trading_days_per_year\n",
     "        self.value = 0\n",
     "        self._log_return = LogReturn(1)\n",
@@ -80,61 +80,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "custom-warmup-heading",
-   "metadata": {},
-   "source": [
-    "### Warm Custom Indicator\n",
-    "\n",
-    "Attach the volatility indicator to the Equity, warm it, and register it for future updates."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "custom-warmup",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "equity.volatility = CustomVolatility(3*21)\n",
-    "# Warm the custom indicator with typed daily trade bars.\n",
-    "history = qb.history[TradeBar](equity, equity.volatility.warm_up_period, Resolution.DAILY)\n",
-    "for bar in history:\n",
-    "    equity.volatility.update(bar)\n",
-    "qb.register_indicator(equity, equity.volatility)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "custom-readiness-heading",
-   "metadata": {},
-   "source": [
-    "### Verify Readiness\n",
-    "\n",
-    "Confirm the custom indicator is ready and has a positive volatility value."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "custom-readiness",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(f\"Volatility ready: {equity.volatility.is_ready}\")\n",
-    "print(f\"Volatility value: {equity.volatility.value:.2f}\")\n",
-    "print(f\"Previous value: {equity.volatility.previous.value:.2f}\")\n",
-    "assert equity.volatility.is_ready\n",
-    "assert equity.volatility.value > 0"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "custom-series-heading",
    "metadata": {},
    "source": [
     "### Build Time Series\n",
     "\n",
-    "Replay a longer history window and store raw volatility values."
+    "Replay daily history and store annualized volatility values."
    ]
   },
   {
@@ -144,21 +95,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "series_volatility = CustomVolatility(3*21)\n",
-    "value_rows = []\n",
-    "signal_rows = []\n",
-    "for bar in qb.history[TradeBar](equity, 180, Resolution.DAILY):\n",
-    "    series_volatility.update(bar)\n",
-    "    if not series_volatility.is_ready:\n",
-    "        continue\n",
-    "    value_rows.append({\"time\": bar.end_time, \"volatility\": series_volatility.value})\n",
-    "    signal_rows.append({\n",
-    "        \"time\": bar.end_time,\n",
-    "        \"signal\": 1 if series_volatility.value > series_volatility.previous.value else 0\n",
-    "    })\n",
+    "trading_days_per_month = 21\n",
+    "volatility = CustomVolatility(3 * trading_days_per_month)\n",
+    "volatility_by_date = {\n",
+    "    bar.end_time: volatility.value\n",
+    "    for bar in qb.history[TradeBar](equity, volatility.warm_up_period + 10, Resolution.DAILY)\n",
+    "    if volatility.update(bar)\n",
+    "}\n",
     "\n",
-    "indicator_values = pd.DataFrame(value_rows).set_index(\"time\")\n",
-    "indicator_values.tail()"
+    "indicator_values = pd.Series(volatility_by_date, name=\"volatility\")\n",
+    "indicator_values"
    ]
   },
   {
@@ -178,8 +124,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "signals = pd.DataFrame(signal_rows).set_index(\"time\")\n",
-    "signals.tail()"
+    "# Check if volatility increased from the previous day.\n",
+    "signal = (indicator_values.diff() > 0).astype(int)\n",
+    "signal"
    ]
   }
  ],

--- a/project-templates/python/warmup-template-custom-indicator/research.ipynb
+++ b/project-templates/python/warmup-template-custom-indicator/research.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "custom-logo",
+   "metadata": {},
+   "source": [
+    "![QuantConnect Logo](https://cdn.quantconnect.com/web/i/icon.png)\n",
+    "<hr>\n",
+    "\n",
+    "## Custom Indicator Warm-Up Research\n",
+    "\n",
+    "Define a custom indicator and warm it from typed daily TradeBar history."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "custom-setup-heading",
+   "metadata": {},
+   "source": [
+    "### Set Up QuantBook\n",
+    "\n",
+    "Create a daily SPY subscription for the custom indicator updates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "custom-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qb = QuantBook()\n",
+    "qb.set_start_date(2024, 9, 1)\n",
+    "qb.settings.seed_initial_prices = True\n",
+    "equity = qb.add_equity(\"SPY\", Resolution.DAILY)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "custom-class-heading",
+   "metadata": {},
+   "source": [
+    "### Define Indicator\n",
+    "\n",
+    "Implement annualized volatility by chaining LogReturn into StandardDeviation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "custom-class",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class CustomVolatility(PythonIndicator):\n",
+    "\n",
+    "    def __init__(self, period, trading_days_per_year=252):\n",
+    "        super().__init__()\n",
+    "        self.warm_up_period = period\n",
+    "        self._trading_days_per_year = trading_days_per_year\n",
+    "        self.value = 0\n",
+    "        self._log_return = LogReturn(1)\n",
+    "        self._standard_deviation = IndicatorExtensions.of(StandardDeviation(period), self._log_return)\n",
+    "\n",
+    "    def update(self, input_: BaseData):\n",
+    "        # Annualized log-return volatility.\n",
+    "        price = input_.value\n",
+    "        if price <= 0:\n",
+    "            return\n",
+    "        self._log_return.update(input_.end_time, price)\n",
+    "        if self.is_ready:\n",
+    "            self.value = self._standard_deviation.current.value * math.sqrt(self._trading_days_per_year) * 100.0\n",
+    "        return self.is_ready\n",
+    "\n",
+    "    @property\n",
+    "    def is_ready(self) -> bool:\n",
+    "        return self._standard_deviation.is_ready"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "custom-warmup-heading",
+   "metadata": {},
+   "source": [
+    "### Warm Custom Indicator\n",
+    "\n",
+    "Attach the volatility indicator to the Equity, warm it, and register it for future updates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "custom-warmup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "equity.volatility = CustomVolatility(3*21)\n",
+    "# Warm the custom indicator with typed daily trade bars.\n",
+    "history = qb.history[TradeBar](equity, equity.volatility.warm_up_period, Resolution.DAILY)\n",
+    "for bar in history:\n",
+    "    equity.volatility.update(bar)\n",
+    "qb.register_indicator(equity, equity.volatility)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "custom-readiness-heading",
+   "metadata": {},
+   "source": [
+    "### Verify Readiness\n",
+    "\n",
+    "Confirm the custom indicator is ready and has a positive volatility value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "custom-readiness",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Volatility ready: {equity.volatility.is_ready}\")\n",
+    "print(f\"Volatility value: {equity.volatility.value:.2f}\")\n",
+    "print(f\"Previous value: {equity.volatility.previous.value:.2f}\")\n",
+    "assert equity.volatility.is_ready\n",
+    "assert equity.volatility.value > 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "custom-series-heading",
+   "metadata": {},
+   "source": [
+    "### Build Time Series\n",
+    "\n",
+    "Replay a longer history window and store raw volatility values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "custom-values",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "series_volatility = CustomVolatility(3*21)\n",
+    "value_rows = []\n",
+    "signal_rows = []\n",
+    "for bar in qb.history[TradeBar](equity, 180, Resolution.DAILY):\n",
+    "    series_volatility.update(bar)\n",
+    "    if not series_volatility.is_ready:\n",
+    "        continue\n",
+    "    value_rows.append({\"time\": bar.end_time, \"volatility\": series_volatility.value})\n",
+    "    signal_rows.append({\n",
+    "        \"time\": bar.end_time,\n",
+    "        \"signal\": 1 if series_volatility.value > series_volatility.previous.value else 0\n",
+    "    })\n",
+    "\n",
+    "indicator_values = pd.DataFrame(value_rows).set_index(\"time\")\n",
+    "indicator_values.tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "custom-signal-heading",
+   "metadata": {},
+   "source": [
+    "### Signal Series\n",
+    "\n",
+    "Display the 1/0 signal generated when volatility is increasing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "custom-signals",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "signals = pd.DataFrame(signal_rows).set_index(\"time\")\n",
+    "signals.tail()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Foundation-Py-Default",
+   "language": "python",
+   "name": "Foundation-Py-Default"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a Python project template that warms and registers a CustomVolatility PythonIndicator from history, verifies readiness in research, and trades when volatility rises.

backtest URL https://www.quantconnect.cloud/backtest/e3169f5bc8268ff7f99e5678663e0610/?theme=darkly