### PR TITLE
Use pandas converter in RollingWindow research template

### DIFF
--- a/project-templates/python/warmup-template-rolling-window/research.ipynb
+++ b/project-templates/python/warmup-template-rolling-window/research.ipynb
@@ -90,7 +90,7 @@
    "source": [
     "### Build Time Series\n",
     "\n",
-    "Convert the window to a Series and populate with daily close values."
+    "Convert the window to a DataFrame, then select the daily close values."
    ]
   },
   {
@@ -101,7 +101,7 @@
    "outputs": [],
    "source": [
     "window_bars = list(window)[::-1]\n",
-    "prices = pd.Series([bar.close for bar in window_bars], index=[bar.end_time for bar in window_bars])\n",
+    "prices = qb.pandas_converter.get_data_frame[TradeBar](window_bars)[\"close\"]\n",
     "prices"
    ]
   },


### PR DESCRIPTION
- replace manual close Series construction with pandas_converter in the RollingWindow warm-up research notebook
URL: https://www.quantconnect.cloud/backtest/afa7cfbbff68705fd5d207847bf1c2fe/?theme=darkly