### PR TITLE
Skip Project Match Check on fork pull requests

### DIFF
--- a/.github/workflows/syntax-tests.yml
+++ b/.github/workflows/syntax-tests.yml
@@ -52,6 +52,11 @@ jobs:
           runInContainer python -u project-templates/python/run_syntax_check.py
 
       - name: Run Project Match Check
+        # Repository secrets (QuantConnect credentials) are not exposed to
+        # pull_request runs from forks, so skip this step for fork PRs to avoid
+        # failing on missing credentials. It still runs on push and on PRs from
+        # branches in this repo. The syntax check above runs for every trigger.
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           runInContainer python -u project-templates/run_project_match_check.py
 


### PR DESCRIPTION
## Problem

The `Run Project Match Check` step in the `Syntax Tests` workflow fails on pull requests opened from forks, e.g. [run 27697580595](https://github.com/QuantConnect/Documentation/actions/runs/27697580595/job/81924878149):

```
RuntimeError: Set DOCS_TEMPLATE_USER_ID and DOCS_TEMPLATE_USER_TOKEN, or create /root/.lean/credentials via `lean login`.
```

GitHub does not expose repository secrets (`QUANTCONNECT_USER_ID`, `QUANTCONNECT_API_TOKEN`, `QUANTCONNECT_ORG_ID`) to `pull_request` runs triggered from forks, so the credentials passed into the container are empty and `run_project_match_check.py` raises at credential load before checking any template.

## Fix

Gate the `Run Project Match Check` step so it only runs when secrets are available:

```yaml
if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
```

- `push` (incl. to `master`) → runs, as today.
- PR from a branch in this repo → runs.
- PR from a fork → skipped (neutral skip, not a failure).

The `Run Syntax Test` step is unchanged and keeps running for every trigger, including fork PRs, so template syntax/type errors are still caught at PR time. The cloud match check (which creates/updates cloud projects and writes back project IDs) runs on the `push` to `master` after merge, consistent with the existing `Open PR for templates.json changes` step that is already gated to `push` + `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)