### PR TITLE
Add manual indicator alternative for equity-aroon-trend

### DIFF
--- a/project-templates/csharp/equity-aroon-trend/Main.cs
+++ b/project-templates/csharp/equity-aroon-trend/Main.cs
@@ -71,6 +71,8 @@ public class AroonOscillatorAlgorithm : QCAlgorithm
         SetEndDate(2024, 12, 31);
         SetCash(100000);
 
+        // AutomaticIndicatorWarmUp only supports automatic indicators, not manual indicators.
+
         Settings.AutomaticIndicatorWarmUp = true;
 
         _spy = AddEquity("SPY", Resolution.Minute).Symbol;
@@ -78,7 +80,7 @@ public class AroonOscillatorAlgorithm : QCAlgorithm
         _aroon = AROON(_spy, 25, Resolution.Minute);
         // Alternatively, use a manual indicator.
         // _aroon = new AroonOscillator(25, 25);
-        // WarmUpIndicator(_spy, _aroon);
+        // WarmUpIndicator<IndicatorDataPoint>(_spy, _aroon);
         // RegisterIndicator(_spy, _aroon);
 
         PlotIndicator("Aroon Oscillator", _aroon);

--- a/project-templates/csharp/equity-aroon-trend/Main.cs
+++ b/project-templates/csharp/equity-aroon-trend/Main.cs
@@ -71,15 +71,15 @@ public class AroonOscillatorAlgorithm : QCAlgorithm
         SetEndDate(2024, 12, 31);
         SetCash(100000);
 
-        // AutomaticIndicatoraarmUp only supports automatic indicators, not manual indicators.
-        Settings.AutomaticIndicatoraarmUp = true;
+        // AutomaticIndicatorWarmUp only supports automatic indicators, not manual indicators.
+        Settings.AutomaticIndicatorWarmUp = true;
 
         _spy = AddEquity("SPY", Resolution.Minute).Symbol;
 
         _aroon = AROON(_spy, 25, Resolution.Minute);
         // Alternatively, use a manual indicator.
         // _aroon = new AroonOscillator(25, 25);
-        // aarmUpIndicator<IndicatorDataPoint>(_spy, _aroon);
+        // WarmUpIndicator(_spy, _aroon);
         // RegisterIndicator(_spy, _aroon);
 
         PlotIndicator("Aroon Oscillator", _aroon);

--- a/project-templates/csharp/equity-aroon-trend/Main.cs
+++ b/project-templates/csharp/equity-aroon-trend/Main.cs
@@ -71,15 +71,15 @@ public class AroonOscillatorAlgorithm : QCAlgorithm
         SetEndDate(2024, 12, 31);
         SetCash(100000);
 
-        // AutomaticIndicatorWarmUp only supports automatic indicators, not manual indicators.
-        Settings.AutomaticIndicatorWarmUp = true;
+        // AutomaticIndicatoraarmUp only supports automatic indicators, not manual indicators.
+        Settings.AutomaticIndicatoraarmUp = true;
 
         _spy = AddEquity("SPY", Resolution.Minute).Symbol;
 
         _aroon = AROON(_spy, 25, Resolution.Minute);
         // Alternatively, use a manual indicator.
         // _aroon = new AroonOscillator(25, 25);
-        // WarmUpIndicator<IndicatorDataPoint>(_spy, _aroon);
+        // aarmUpIndicator<IndicatorDataPoint>(_spy, _aroon);
         // RegisterIndicator(_spy, _aroon);
 
         PlotIndicator("Aroon Oscillator", _aroon);

--- a/project-templates/csharp/equity-aroon-trend/Main.cs
+++ b/project-templates/csharp/equity-aroon-trend/Main.cs
@@ -72,7 +72,6 @@ public class AroonOscillatorAlgorithm : QCAlgorithm
         SetCash(100000);
 
         // AutomaticIndicatorWarmUp only supports automatic indicators, not manual indicators.
-
         Settings.AutomaticIndicatorWarmUp = true;
 
         _spy = AddEquity("SPY", Resolution.Minute).Symbol;

--- a/project-templates/csharp/equity-aroon-trend/Main.cs
+++ b/project-templates/csharp/equity-aroon-trend/Main.cs
@@ -76,6 +76,10 @@ public class AroonOscillatorAlgorithm : QCAlgorithm
         _spy = AddEquity("SPY", Resolution.Minute).Symbol;
 
         _aroon = AROON(_spy, 25, Resolution.Minute);
+        // Alternatively, use a manual indicator.
+        // _aroon = new AroonOscillator(25, 25);
+        // WarmUpIndicator(_spy, _aroon);
+        // RegisterIndicator(_spy, _aroon);
 
         PlotIndicator("Aroon Oscillator", _aroon);
     }

--- a/project-templates/python/equity-aroon-trend/main.py
+++ b/project-templates/python/equity-aroon-trend/main.py
@@ -8,6 +8,8 @@ class AroonOscillatorAlgorithm(QCAlgorithm):
         self.set_end_date(2024, 12, 31)
         self.set_cash(100000)
 
+        # automatic_indicator_warm_up only supports automatic indicators, not manual indicators.
+
         self.settings.automatic_indicator_warm_up = True
 
         self._spy = self.add_equity("SPY", Resolution.MINUTE).symbol

--- a/project-templates/python/equity-aroon-trend/main.py
+++ b/project-templates/python/equity-aroon-trend/main.py
@@ -13,6 +13,10 @@ class AroonOscillatorAlgorithm(QCAlgorithm):
         self._spy = self.add_equity("SPY", Resolution.MINUTE).symbol
 
         self._aroon = self.aroon(self._spy, 25, Resolution.MINUTE)
+        # Alternatively, use a manual indicator.
+        # self._aroon = AroonOscillator(25, 25)
+        # self.warm_up_indicator(self._spy, self._aroon)
+        # self.register_indicator(self._spy, self._aroon)
 
         self.plot_indicator("Aroon Oscillator", self._aroon)
 

--- a/project-templates/python/equity-aroon-trend/main.py
+++ b/project-templates/python/equity-aroon-trend/main.py
@@ -9,7 +9,6 @@ class AroonOscillatorAlgorithm(QCAlgorithm):
         self.set_cash(100000)
 
         # automatic_indicator_warm_up only supports automatic indicators, not manual indicators.
-
         self.settings.automatic_indicator_warm_up = True
 
         self._spy = self.add_equity("SPY", Resolution.MINUTE).symbol


### PR DESCRIPTION
- Added a commented manual indicator alternative to the Python equity-aroon-trend template.