### PR TITLE
Add manual indicator alternative for equity-cci-overbought

### DIFF
--- a/project-templates/csharp/equity-cci-overbought/Main.cs
+++ b/project-templates/csharp/equity-cci-overbought/Main.cs
@@ -81,12 +81,12 @@ public class XleCciMeanReversionAlgorithm : QCAlgorithm
         _cci = CCI(_xle.Symbol, 20, MovingAverageType.Simple, Resolution.Daily);
         // Alternatively, use a manual indicator.
         // _cci = new CommodityChannelIndex(20, MovingAverageType.Simple);
-        // WarmUpIndicator<IndicatorDataPoint>(_xle.Symbol, _cci, Resolution.Daily);
+        // WarmUpIndicator(_xle.Symbol, _cci, Resolution.Daily);
         // RegisterIndicator(_xle.Symbol, _cci, Resolution.Daily);
         _atr = ATR(_xle.Symbol, 14, MovingAverageType.Simple, Resolution.Daily);
         // Alternatively, use a manual indicator.
         // _atr = new AverageTrueRange(14, MovingAverageType.Simple);
-        // WarmUpIndicator<IndicatorDataPoint>(_xle.Symbol, _atr, Resolution.Daily);
+        // WarmUpIndicator(_xle.Symbol, _atr, Resolution.Daily);
         // RegisterIndicator(_xle.Symbol, _atr, Resolution.Daily);
 
         PlotIndicator("CCI", _cci);

--- a/project-templates/csharp/equity-cci-overbought/Main.cs
+++ b/project-templates/csharp/equity-cci-overbought/Main.cs
@@ -73,6 +73,7 @@ public class XleCciMeanReversionAlgorithm : QCAlgorithm
         SetStartDate(2022, 1, 1);
         SetEndDate(2024, 12, 31);
         SetCash(100000);
+        // AutomaticIndicatorWarmUp only supports automatic indicators, not manual indicators.
         Settings.AutomaticIndicatorWarmUp = true;
 
         _xle = AddEquity("XLE", Resolution.Minute);
@@ -80,12 +81,12 @@ public class XleCciMeanReversionAlgorithm : QCAlgorithm
         _cci = CCI(_xle.Symbol, 20, MovingAverageType.Simple, Resolution.Daily);
         // Alternatively, use a manual indicator.
         // _cci = new CommodityChannelIndex(20, MovingAverageType.Simple);
-        // WarmUpIndicator(_xle.Symbol, _cci, Resolution.Daily);
+        // WarmUpIndicator<IndicatorDataPoint>(_xle.Symbol, _cci, Resolution.Daily);
         // RegisterIndicator(_xle.Symbol, _cci, Resolution.Daily);
         _atr = ATR(_xle.Symbol, 14, MovingAverageType.Simple, Resolution.Daily);
         // Alternatively, use a manual indicator.
         // _atr = new AverageTrueRange(14, MovingAverageType.Simple);
-        // WarmUpIndicator(_xle.Symbol, _atr, Resolution.Daily);
+        // WarmUpIndicator<IndicatorDataPoint>(_xle.Symbol, _atr, Resolution.Daily);
         // RegisterIndicator(_xle.Symbol, _atr, Resolution.Daily);
 
         PlotIndicator("CCI", _cci);

--- a/project-templates/csharp/equity-cci-overbought/Main.cs
+++ b/project-templates/csharp/equity-cci-overbought/Main.cs
@@ -78,7 +78,15 @@ public class XleCciMeanReversionAlgorithm : QCAlgorithm
         _xle = AddEquity("XLE", Resolution.Minute);
 
         _cci = CCI(_xle.Symbol, 20, MovingAverageType.Simple, Resolution.Daily);
+        // Alternatively, use a manual indicator.
+        // _cci = new CommodityChannelIndex(20, MovingAverageType.Simple);
+        // WarmUpIndicator(_xle.Symbol, _cci, Resolution.Daily);
+        // RegisterIndicator(_xle.Symbol, _cci, Resolution.Daily);
         _atr = ATR(_xle.Symbol, 14, MovingAverageType.Simple, Resolution.Daily);
+        // Alternatively, use a manual indicator.
+        // _atr = new AverageTrueRange(14, MovingAverageType.Simple);
+        // WarmUpIndicator(_xle.Symbol, _atr, Resolution.Daily);
+        // RegisterIndicator(_xle.Symbol, _atr, Resolution.Daily);
 
         PlotIndicator("CCI", _cci);
 

--- a/project-templates/python/equity-cci-overbought/main.py
+++ b/project-templates/python/equity-cci-overbought/main.py
@@ -14,7 +14,15 @@ class XleCciMeanReversionAlgorithm(QCAlgorithm):
         self._xle = self.add_equity("XLE", Resolution.MINUTE).symbol
 
         self._cci = self.cci(self._xle, 20, MovingAverageType.SIMPLE, Resolution.DAILY)
+        # Alternatively, use a manual indicator.
+        # self._cci = CommodityChannelIndex(20, MovingAverageType.SIMPLE)
+        # self.warm_up_indicator(self._xle, self._cci, Resolution.DAILY)
+        # self.register_indicator(self._xle, self._cci, Resolution.DAILY)
         self._atr = self.atr(self._xle, 14, MovingAverageType.SIMPLE, Resolution.DAILY)
+        # Alternatively, use a manual indicator.
+        # self._atr = AverageTrueRange(14, MovingAverageType.SIMPLE)
+        # self.warm_up_indicator(self._xle, self._atr, Resolution.DAILY)
+        # self.register_indicator(self._xle, self._atr, Resolution.DAILY)
 
         self.plot_indicator("CCI", self._cci)
 

--- a/project-templates/python/equity-cci-overbought/main.py
+++ b/project-templates/python/equity-cci-overbought/main.py
@@ -9,6 +9,7 @@ class XleCciMeanReversionAlgorithm(QCAlgorithm):
         self.set_start_date(2022, 1, 1)
         self.set_end_date(2024, 12, 31)
         self.set_cash(100000)
+        # automatic_indicator_warm_up only supports automatic indicators, not manual indicators.
         self.settings.automatic_indicator_warm_up = True
 
         self._xle = self.add_equity("XLE", Resolution.MINUTE).symbol


### PR DESCRIPTION
- Added a commented manual indicator alternative to the Python equity-cci-overbought template.