### PR TITLE
Add manual indicator alternative for equity-monthly-roc-rotation

### DIFF
--- a/project-templates/csharp/equity-monthly-roc-rotation/Main.cs
+++ b/project-templates/csharp/equity-monthly-roc-rotation/Main.cs
@@ -77,6 +77,10 @@ public class MonthlyRotationAlgorithm : QCAlgorithm
         {
             dynamic equity = AddEquity(ticker, Resolution.Minute);
             equity.Roc = ROC(equity, _rocPeriod, Resolution.Daily);
+            // Alternatively, use a manual indicator.
+            // equity.Roc = new RateOfChange(_rocPeriod);
+            // WarmUpIndicator(equity.Symbol, equity.Roc, Resolution.Daily);
+            // RegisterIndicator(equity.Symbol, equity.Roc, Resolution.Daily);
         }
 
         Schedule.On(

--- a/project-templates/csharp/equity-monthly-roc-rotation/Main.cs
+++ b/project-templates/csharp/equity-monthly-roc-rotation/Main.cs
@@ -71,6 +71,7 @@ public class MonthlyRotationAlgorithm : QCAlgorithm
         SetStartDate(2022, 1, 1);
         SetEndDate(2024, 12, 31);
         SetCash(100000);
+        // AutomaticIndicatorWarmUp only supports automatic indicators, not manual indicators.
         Settings.AutomaticIndicatorWarmUp = true;
 
         foreach (var ticker in new[] { "SPY", "EFA", "EEM", "AGG", "GLD" })
@@ -79,7 +80,7 @@ public class MonthlyRotationAlgorithm : QCAlgorithm
             equity.Roc = ROC(equity, _rocPeriod, Resolution.Daily);
             // Alternatively, use a manual indicator.
             // equity.Roc = new RateOfChange(_rocPeriod);
-            // WarmUpIndicator(equity.Symbol, equity.Roc, Resolution.Daily);
+            // WarmUpIndicator<IndicatorDataPoint>(equity.Symbol, equity.Roc, Resolution.Daily);
             // RegisterIndicator(equity.Symbol, equity.Roc, Resolution.Daily);
         }
 

--- a/project-templates/python/equity-monthly-roc-rotation/main.py
+++ b/project-templates/python/equity-monthly-roc-rotation/main.py
@@ -10,6 +10,7 @@ class MonthlyRotationAlgorithm(QCAlgorithm):
         self.set_start_date(2022, 1, 1)
         self.set_end_date(2024, 12, 31)
         self.set_cash(100000)
+        # automatic_indicator_warm_up only supports automatic indicators, not manual indicators.
         self.settings.automatic_indicator_warm_up = True
 
         for ticker in ["SPY", "EFA", "EEM", "AGG", "GLD"]:

--- a/project-templates/python/equity-monthly-roc-rotation/main.py
+++ b/project-templates/python/equity-monthly-roc-rotation/main.py
@@ -17,8 +17,8 @@ class MonthlyRotationAlgorithm(QCAlgorithm):
             equity.roc = self.roc(equity, self._roc_period, Resolution.DAILY)
             # Alternatively, use a manual indicator.
             # equity.roc = RateOfChange(self._roc_period)
-            # self.warm_up_indicator(equity.symbol, equity.roc, Resolution.DAILY)
-            # self.register_indicator(equity.symbol, equity.roc, Resolution.DAILY)
+            # self.warm_up_indicator(equity, equity.roc, Resolution.DAILY)
+            # self.register_indicator(equity, equity.roc, Resolution.DAILY)
 
         self.schedule.on(
             self.date_rules.month_start("SPY"),

--- a/project-templates/python/equity-monthly-roc-rotation/main.py
+++ b/project-templates/python/equity-monthly-roc-rotation/main.py
@@ -15,6 +15,10 @@ class MonthlyRotationAlgorithm(QCAlgorithm):
         for ticker in ["SPY", "EFA", "EEM", "AGG", "GLD"]:
             equity = self.add_equity(ticker, Resolution.MINUTE)
             equity.roc = self.roc(equity, self._roc_period, Resolution.DAILY)
+            # Alternatively, use a manual indicator.
+            # equity.roc = RateOfChange(self._roc_period)
+            # self.warm_up_indicator(equity.symbol, equity.roc, Resolution.DAILY)
+            # self.register_indicator(equity.symbol, equity.roc, Resolution.DAILY)
 
         self.schedule.on(
             self.date_rules.month_start("SPY"),


### PR DESCRIPTION
- Added a commented manual indicator alternative to the Python equity-monthly-roc-rotation template.