### PR TITLE
Omit Samco and Zerodha brokerage repos from the link checker

### DIFF
--- a/.github/workflows/external_url_check_workflow.yml
+++ b/.github/workflows/external_url_check_workflow.yml
@@ -26,10 +26,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # All public Lean.Brokerages.* / Lean.DataSource.* repos, except the
-          # Lean.DataSource.Quiver* family (keep only Lean.DataSource.QuiverQuant).
+          # Lean.DataSource.Quiver* family (keep only Lean.DataSource.QuiverQuant)
+          # and the Samco/Zerodha brokerages.
           repos=$(gh repo list QuantConnect --limit 1000 --no-archived --visibility public \
             --json name \
-            --jq '[.[].name | select((startswith("Lean.Brokerages.") or startswith("Lean.DataSource.")) and (. == "Lean.DataSource.QuiverQuant" or (startswith("Lean.DataSource.Quiver") | not)))] | sort')
+            --jq '[.[].name | select((startswith("Lean.Brokerages.") or startswith("Lean.DataSource.")) and (. == "Lean.DataSource.QuiverQuant" or (startswith("Lean.DataSource.Quiver") | not)) and (. != "Lean.Brokerages.Samco") and (. != "Lean.Brokerages.Zerodha"))] | sort')
           echo "Discovered $(echo "$repos" | jq length) repos:"
           echo "$repos" | jq -r '.[]'
           echo "repos=$(echo "$repos" | jq -c .)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Exclude Lean.Brokerages.Samco and Lean.Brokerages.Zerodha from the repo discovery so the external link checker no longer scans them.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1575

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
They are no longer in the docs, so we have no links to update the repos with.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
