### PR TITLE
Make Equity resolution table text-based and accessible

### DIFF
--- a/Resources/securities/resolutions/equity.html
+++ b/Resources/securities/resolutions/equity.html
@@ -1,6 +1,7 @@
 <p>The following table shows the available resolutions and data formats for Equity subscriptions:</p>
 
 <table class="qc-table table" id="resolution-and-data-formats">
+    <caption>Available resolutions and data formats for Equity subscriptions</caption>
     <thead>
         <tr>
             <th>Resolution</th>
@@ -12,52 +13,65 @@
     </thead>
     <tbody>
         <tr>
-            <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-	    <td></td>
-            <td></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+            <th scope="row"><code class="csharp">Tick</code><code class="python">TICK</code></th>
+	    <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td class="yes"><span class="hidden">Supported</span>✓</td>
         </tr>
         <tr>
-            <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+            <th scope="row"><code class="csharp">Second</code><code class="python">SECOND</code></th>
+	    <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td class="no"><span class="hidden">Not supported</span>✗</td>
         </tr>
         <tr>
-            <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+            <th scope="row"><code class="csharp">Minute</code><code class="python">MINUTE</code></th>
+	    <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td class="no"><span class="hidden">Not supported</span>✗</td>
         </tr>
         <tr>
-            <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <th scope="row"><code class="csharp">Hour</code><code class="python">HOUR</code></th>
+	    <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td class="no"><span class="hidden">Not supported</span>✗</td>
         </tr>
         <tr>
-            <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <th scope="row"><code class="csharp">Daily</code><code class="python">DAILY</code></th>
+	    <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td class="no"><span class="hidden">Not supported</span>✗</td>
         </tr>
     </tbody>
 </table>
 
 <style>
-#resolution-and-data-formats td:nth-child(2), 
-#resolution-and-data-formats th:nth-child(2), 
-#resolution-and-data-formats td:nth-child(3), 
-#resolution-and-data-formats th:nth-child(3), 
-#resolution-and-data-formats td:nth-child(4), 
-#resolution-and-data-formats th:nth-child(4), 
-#resolution-and-data-formats td:last-child, 
+#resolution-and-data-formats td:nth-child(2),
+#resolution-and-data-formats th:nth-child(2),
+#resolution-and-data-formats td:nth-child(3),
+#resolution-and-data-formats th:nth-child(3),
+#resolution-and-data-formats td:nth-child(4),
+#resolution-and-data-formats th:nth-child(4),
+#resolution-and-data-formats td:last-child,
 #resolution-and-data-formats th:last-child {
     text-align: center;
+}
+#resolution-and-data-formats tbody th[scope="row"] {
+    text-align: left;
+    font-weight: normal;
+}
+#resolution-and-data-formats .yes { color: #16a34a; }
+#resolution-and-data-formats .no  { color: #dc2626; }
+#resolution-and-data-formats .hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
 }
 </style>


### PR DESCRIPTION
## Summary

Improves the Equity resolution/data-format table in `Resources/securities/resolutions/equity.html` so its content is legible to AI agents and assistive technology, not just sighted users.

- Replace the green-check `<img>` cells with text glyphs — green ✓ for supported, red ✗ for not supported — removing the CDN image dependency.
- Fill the previously-blank cells so "not supported" is explicit rather than inferred from an empty cell.
- Add hidden `Supported` / `Not supported` text labels so screen readers and DOM scrapers read the meaning, not just the symbol.
- Add a `<caption>` binding the description to the table.
- Mark the resolution column with `scope="row"` so each marker is programmatically tied to its row.

No content/meaning changes — the supported combinations are identical to before.

## Test plan

- Open the page locally and confirm the table renders with green ✓ / red ✗, the resolution column stays left-aligned, and columns 2–5 stay centered.
- Inspect the DOM / run a screen reader and confirm each cell reads "Supported" or "Not supported".