### PR TITLE
Simplify Equity resolution table and align with sibling pages

### DIFF
--- a/Resources/securities/resolutions/equity.html
+++ b/Resources/securities/resolutions/equity.html
@@ -12,39 +12,39 @@
     </thead>
     <tbody>
         <tr>
-            <th scope="row"><code class="csharp">Tick</code><code class="python">TICK</code></th>
-	    <td class="no"><span class="hidden">Not supported</span>✗</td>
-            <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
+            <td><span class="hidden">Not supported</span></td>
+            <td><span class="hidden">Not supported</span></td>
             <td class="yes"><span class="hidden">Supported</span>✓</td>
             <td class="yes"><span class="hidden">Supported</span>✓</td>
         </tr>
         <tr>
-            <th scope="row"><code class="csharp">Second</code><code class="python">SECOND</code></th>
-	    <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
             <td class="yes"><span class="hidden">Supported</span>✓</td>
-            <td class="no"><span class="hidden">Not supported</span>✗</td>
-            <td class="no"><span class="hidden">Not supported</span>✗</td>
-        </tr>
-        <tr>
-            <th scope="row"><code class="csharp">Minute</code><code class="python">MINUTE</code></th>
-	    <td class="yes"><span class="hidden">Supported</span>✓</td>
             <td class="yes"><span class="hidden">Supported</span>✓</td>
-            <td class="no"><span class="hidden">Not supported</span>✗</td>
-            <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td><span class="hidden">Not supported</span></td>
+            <td><span class="hidden">Not supported</span></td>
         </tr>
         <tr>
-            <th scope="row"><code class="csharp">Hour</code><code class="python">HOUR</code></th>
-	    <td class="yes"><span class="hidden">Supported</span>✓</td>
-            <td class="no"><span class="hidden">Not supported</span>✗</td>
-            <td class="no"><span class="hidden">Not supported</span>✗</td>
-            <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
+            <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td><span class="hidden">Not supported</span></td>
+            <td><span class="hidden">Not supported</span></td>
         </tr>
         <tr>
-            <th scope="row"><code class="csharp">Daily</code><code class="python">DAILY</code></th>
-	    <td class="yes"><span class="hidden">Supported</span>✓</td>
-            <td class="no"><span class="hidden">Not supported</span>✗</td>
-            <td class="no"><span class="hidden">Not supported</span>✗</td>
-            <td class="no"><span class="hidden">Not supported</span>✗</td>
+            <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
+            <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td><span class="hidden">Not supported</span></td>
+            <td><span class="hidden">Not supported</span></td>
+            <td><span class="hidden">Not supported</span></td>
+        </tr>
+        <tr>
+            <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
+            <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td><span class="hidden">Not supported</span></td>
+            <td><span class="hidden">Not supported</span></td>
+            <td><span class="hidden">Not supported</span></td>
         </tr>
     </tbody>
 </table>
@@ -60,12 +60,7 @@
 #resolution-and-data-formats th:last-child {
     text-align: center;
 }
-#resolution-and-data-formats tbody th[scope="row"] {
-    text-align: left;
-    font-weight: normal;
-}
 #resolution-and-data-formats .yes { color: #16a34a; }
-#resolution-and-data-formats .no  { color: #dc2626; }
 #resolution-and-data-formats .hidden {
     position: absolute;
     width: 1px;

--- a/Resources/securities/resolutions/equity.html
+++ b/Resources/securities/resolutions/equity.html
@@ -1,7 +1,6 @@
 <p>The following table shows the available resolutions and data formats for Equity subscriptions:</p>
 
 <table class="qc-table table" id="resolution-and-data-formats">
-    <caption>Available resolutions and data formats for Equity subscriptions</caption>
     <thead>
         <tr>
             <th>Resolution</th>


### PR DESCRIPTION
## Summary

Follow-up to #2553, simplifying the Equity resolution/data-format table so it stays consistent with the other `Resources/securities/resolutions/*.html` pages while keeping the AI/screen-reader legibility wins.

- Remove the redundant `<caption>` (it duplicated the intro sentence directly above the table).
- Remove the visible red ✗ marker from unsupported cells (other pages leave these blank); keep an invisible `Not supported` label so the meaning is still in the DOM.
- Remove `scope="row"` and revert the first column from `<th>` back to `<td>`, matching the sibling pages.
- Drop the now-unused `.no` color rule and the `tbody th[scope="row"]` override rule.

Kept from #2553: the text ✓ glyph (replacing the CDN check image) and the invisible `Supported` / `Not supported` labels.

## Test plan

- Open the page locally and confirm: supported cells show a green ✓, unsupported cells are blank, the resolution column is left-aligned and normal weight, and columns 2–5 stay centered.
- Inspect the DOM and confirm each cell still exposes "Supported" / "Not supported" text.