### PR TITLE
Make resolution data-format tables accessible and DRY

### DIFF
--- a/Resources/securities/resolutions/cfd.html
+++ b/Resources/securities/resolutions/cfd.html
@@ -13,51 +13,38 @@
     <tbody>
         <tr>
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-	    <td></td>
-            <td></td>
-            <td></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;" style="font-size: 16px;"></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
 	    <td><br></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
 	    <td><br></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
 	    <td><br></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;" style="font-size: 16px;"></td>
-            <td></td>
-            <td></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
 	    <td><br></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;" style="font-size: 16px;"></td>
-            <td></td>
-            <td></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
     </tbody>
 </table>
-
-<style>
-#resolution-and-data-formats td:nth-child(2), 
-#resolution-and-data-formats th:nth-child(2), 
-#resolution-and-data-formats td:nth-child(3), 
-#resolution-and-data-formats th:nth-child(3), 
-#resolution-and-data-formats td:nth-child(4), 
-#resolution-and-data-formats th:nth-child(4), 
-#resolution-and-data-formats td:last-child, 
-#resolution-and-data-formats th:last-child {
-    text-align: center;
-}
-</style>

--- a/Resources/securities/resolutions/crypto-futures.html
+++ b/Resources/securities/resolutions/crypto-futures.html
@@ -13,51 +13,38 @@
     <tbody>
         <tr>
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-	    <td></td>
-            <td></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
     </tbody>
 </table>
-
-<style>
-#resolution-and-data-formats td:nth-child(2), 
-#resolution-and-data-formats th:nth-child(2), 
-#resolution-and-data-formats td:nth-child(3), 
-#resolution-and-data-formats th:nth-child(3), 
-#resolution-and-data-formats td:nth-child(4), 
-#resolution-and-data-formats th:nth-child(4), 
-#resolution-and-data-formats td:last-child, 
-#resolution-and-data-formats th:last-child {
-    text-align: center;
-}
-</style>

--- a/Resources/securities/resolutions/crypto.html
+++ b/Resources/securities/resolutions/crypto.html
@@ -13,51 +13,38 @@
     <tbody>
         <tr>
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-	    <td></td>
-            <td></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
     </tbody>
 </table>
-
-<style>
-#resolution-and-data-formats td:nth-child(2), 
-#resolution-and-data-formats th:nth-child(2), 
-#resolution-and-data-formats td:nth-child(3), 
-#resolution-and-data-formats th:nth-child(3), 
-#resolution-and-data-formats td:nth-child(4), 
-#resolution-and-data-formats th:nth-child(4), 
-#resolution-and-data-formats td:last-child, 
-#resolution-and-data-formats th:last-child {
-    text-align: center;
-}
-</style>

--- a/Resources/securities/resolutions/equity-options.html
+++ b/Resources/securities/resolutions/equity-options.html
@@ -13,8 +13,8 @@
     <tbody>
         <tr>
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-	    <td></td>
-            <td></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td><br></td>
             <td><br></td>
         </tr>
@@ -22,42 +22,29 @@
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
 	    <td><br></td>
             <td><br></td>
-            <td></td>
-            <td></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
     </tbody>
 </table>
-
-<style>
-#resolution-and-data-formats td:nth-child(2), 
-#resolution-and-data-formats th:nth-child(2), 
-#resolution-and-data-formats td:nth-child(3), 
-#resolution-and-data-formats th:nth-child(3), 
-#resolution-and-data-formats td:nth-child(4), 
-#resolution-and-data-formats th:nth-child(4), 
-#resolution-and-data-formats td:last-child, 
-#resolution-and-data-formats th:last-child {
-    text-align: center;
-}
-</style>

--- a/Resources/securities/resolutions/equity.html
+++ b/Resources/securities/resolutions/equity.html
@@ -13,59 +13,38 @@
     <tbody>
         <tr>
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-            <td><span class="hidden">Not supported</span></td>
-            <td><span class="hidden">Not supported</span></td>
-            <td class="yes"><span class="hidden">Supported</span>✓</td>
-            <td class="yes"><span class="hidden">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-            <td class="yes"><span class="hidden">Supported</span>✓</td>
-            <td class="yes"><span class="hidden">Supported</span>✓</td>
-            <td><span class="hidden">Not supported</span></td>
-            <td><span class="hidden">Not supported</span></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-            <td class="yes"><span class="hidden">Supported</span>✓</td>
-            <td class="yes"><span class="hidden">Supported</span>✓</td>
-            <td><span class="hidden">Not supported</span></td>
-            <td><span class="hidden">Not supported</span></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-            <td class="yes"><span class="hidden">Supported</span>✓</td>
-            <td><span class="hidden">Not supported</span></td>
-            <td><span class="hidden">Not supported</span></td>
-            <td><span class="hidden">Not supported</span></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-            <td class="yes"><span class="hidden">Supported</span>✓</td>
-            <td><span class="hidden">Not supported</span></td>
-            <td><span class="hidden">Not supported</span></td>
-            <td><span class="hidden">Not supported</span></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
     </tbody>
 </table>
-
-<style>
-#resolution-and-data-formats td:nth-child(2),
-#resolution-and-data-formats th:nth-child(2),
-#resolution-and-data-formats td:nth-child(3),
-#resolution-and-data-formats th:nth-child(3),
-#resolution-and-data-formats td:nth-child(4),
-#resolution-and-data-formats th:nth-child(4),
-#resolution-and-data-formats td:last-child,
-#resolution-and-data-formats th:last-child {
-    text-align: center;
-}
-#resolution-and-data-formats .yes { color: #16a34a; }
-#resolution-and-data-formats .hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-}
-</style>

--- a/Resources/securities/resolutions/forex.html
+++ b/Resources/securities/resolutions/forex.html
@@ -13,51 +13,38 @@
     <tbody>
         <tr>
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-	    <td></td>
-            <td></td>
-            <td></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;" style="font-size: 16px;"></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
 	    <td><br></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
 	    <td><br></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
 	    <td><br></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;" style="font-size: 16px;"></td>
-            <td></td>
-            <td></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
 	    <td><br></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;" style="font-size: 16px;"></td>
-            <td></td>
-            <td></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
     </tbody>
 </table>
-
-<style>
-#resolution-and-data-formats td:nth-child(2), 
-#resolution-and-data-formats th:nth-child(2), 
-#resolution-and-data-formats td:nth-child(3), 
-#resolution-and-data-formats th:nth-child(3), 
-#resolution-and-data-formats td:nth-child(4), 
-#resolution-and-data-formats th:nth-child(4), 
-#resolution-and-data-formats td:last-child, 
-#resolution-and-data-formats th:last-child {
-    text-align: center;
-}
-</style>

--- a/Resources/securities/resolutions/future-options.html
+++ b/Resources/securities/resolutions/future-options.html
@@ -13,8 +13,8 @@
     <tbody>
         <tr>
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-	    <td></td>
-            <td></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td><br></td>
             <td><br></td>
         </tr>
@@ -22,42 +22,29 @@
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
 	    <td><br></td>
             <td><br></td>
-            <td></td>
-            <td></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
     </tbody>
 </table>
-
-<style>
-#resolution-and-data-formats td:nth-child(2), 
-#resolution-and-data-formats th:nth-child(2), 
-#resolution-and-data-formats td:nth-child(3), 
-#resolution-and-data-formats th:nth-child(3), 
-#resolution-and-data-formats td:nth-child(4), 
-#resolution-and-data-formats th:nth-child(4), 
-#resolution-and-data-formats td:last-child, 
-#resolution-and-data-formats th:last-child {
-    text-align: center;
-}
-</style>

--- a/Resources/securities/resolutions/futures.html
+++ b/Resources/securities/resolutions/futures.html
@@ -13,51 +13,38 @@
     <tbody>
         <tr>
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-	    <td></td>
-            <td></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
     </tbody>
 </table>
-
-<style>
-#resolution-and-data-formats td:nth-child(2), 
-#resolution-and-data-formats th:nth-child(2), 
-#resolution-and-data-formats td:nth-child(3), 
-#resolution-and-data-formats th:nth-child(3), 
-#resolution-and-data-formats td:nth-child(4), 
-#resolution-and-data-formats th:nth-child(4), 
-#resolution-and-data-formats td:last-child, 
-#resolution-and-data-formats th:last-child {
-    text-align: center;
-}
-</style>

--- a/Resources/securities/resolutions/index-options.html
+++ b/Resources/securities/resolutions/index-options.html
@@ -13,8 +13,8 @@
     <tbody>
         <tr>
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-	    <td></td>
-            <td></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td><br></td>
             <td><br></td>
         </tr>
@@ -22,42 +22,29 @@
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
 	    <td><br></td>
             <td><br></td>
-            <td></td>
-            <td></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
     </tbody>
 </table>
-
-<style>
-#resolution-and-data-formats td:nth-child(2), 
-#resolution-and-data-formats th:nth-child(2), 
-#resolution-and-data-formats td:nth-child(3), 
-#resolution-and-data-formats th:nth-child(3), 
-#resolution-and-data-formats td:nth-child(4), 
-#resolution-and-data-formats th:nth-child(4), 
-#resolution-and-data-formats td:last-child, 
-#resolution-and-data-formats th:last-child {
-    text-align: center;
-}
-</style>

--- a/Resources/securities/resolutions/index.html
+++ b/Resources/securities/resolutions/index.html
@@ -13,51 +13,38 @@
     <tbody>
         <tr>
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-	    <td></td>
-            <td></td>
-            <td></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td><br></td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-	    <td></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td><br></td>
-            <td></td>
-            <td></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
             <td><br></td>
-            <td></td>
-            <td></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
     </tbody>
 </table>
-
-<style>
-#resolution-and-data-formats td:nth-child(2), 
-#resolution-and-data-formats th:nth-child(2), 
-#resolution-and-data-formats td:nth-child(3), 
-#resolution-and-data-formats th:nth-child(3), 
-#resolution-and-data-formats td:nth-child(4), 
-#resolution-and-data-formats th:nth-child(4), 
-#resolution-and-data-formats td:last-child, 
-#resolution-and-data-formats th:last-child {
-    text-align: center;
-}
-</style>

--- a/Resources/securities/resolutions/india-equity.html
+++ b/Resources/securities/resolutions/india-equity.html
@@ -13,8 +13,8 @@
     <tbody>
         <tr>
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
-	    <td></td>
-            <td></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td><br></td>
             <td><br></td>
         </tr>
@@ -22,42 +22,29 @@
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
 	    <td><br></td>
             <td><br></td>
-            <td></td>
-            <td></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
             <td><br></td>
-            <td></td>
-            <td></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-	    <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-            <td></td>
-            <td></td>
-            <td></td>
+	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
     </tbody>
 </table>
-
-<style>
-#resolution-and-data-formats td:nth-child(2), 
-#resolution-and-data-formats th:nth-child(2), 
-#resolution-and-data-formats td:nth-child(3), 
-#resolution-and-data-formats th:nth-child(3), 
-#resolution-and-data-formats td:nth-child(4), 
-#resolution-and-data-formats th:nth-child(4), 
-#resolution-and-data-formats td:last-child, 
-#resolution-and-data-formats th:last-child {
-    text-align: center;
-}
-</style>


### PR DESCRIPTION
## Summary

Generalizes the accessibility work from #2553 / #2554 across all 11 `Resources/securities/resolutions/*.html` data-format tables, and moves the styling out of per-file `<style>` blocks into the shared `qc-table` stylesheet.

Each support cell is now plain semantic markup:

```html
<td class="supported"><span class="sr-only">Supported</span>✓</td>
<td class="unsupported"><span class="sr-only">Not supported</span></td>
```

- **Text instead of images** — the `cdn.quantconnect.com/i/tu/check.png` green-check images are replaced by a text ✓ glyph, so the support state is real DOM text for AI agents and screen readers (and one less CDN request).
- **`sr-only`, not `hidden`** — uses Bootstrap's visually-hidden utility. The earlier `class="hidden"` resolves to `display:none` under Bootstrap, which hides the label from screen readers; `sr-only` keeps it announced.
- **No per-file CSS** — the inline `<style>` blocks are removed; centering and the green color come from the shared `qc-table` rules (see dependency below).
- Each table keeps its own support matrix; only the cell markup changed.

## ⚠️ Depends on a global CSS change (merge order matters)

This relies on these rules being added to `public/css/src/qc.defaults.scss` in `QuantConnect/www.view.quantconnect.com`:

```scss
.table.qc-table td.supported,
.table.qc-table td.unsupported { text-align: center; }
.table.qc-table td.supported   { color: #16a34a; }
```

**That CSS should land first.** Until it does, these tables render with the ✓/blank markers but without centering or green color (functional, just unstyled). A companion PR will add the SCSS.

## Test plan

- After the CSS is deployed, open each resolution page and confirm: supported cells show a centered green ✓, unsupported cells are blank, and the resolution column stays left-aligned.
- Inspect the DOM / run a screen reader and confirm every cell exposes "Supported" / "Not supported".