### PR TITLE
Update Terminal Link docs for the new TerminalLinkBrokerageModel

### DIFF
--- a/03 Writing Algorithms/24 Reality Modeling/05 Brokerages/02 Supported Models/16 Terminal Link/01 Introduction.html
+++ b/03 Writing Algorithms/24 Reality Modeling/05 Brokerages/02 Supported Models/16 Terminal Link/01 Introduction.html
@@ -1,1 +1,9 @@
-<p>This page explains the Terminal Link brokerage, including the asset classes it supports, its default <a href='/docs/v2/writing-algorithms/reality-modeling/key-concepts#02-Security-Level-Models'>security-level models</a>, and its default markets.</p>
+<p>This page explains the <code>TerminalLinkBrokerageModel</code>, including the asset classes it supports, its default <a href='/docs/v2/writing-algorithms/reality-modeling/key-concepts#02-Security-Level-Models'>security-level models</a>, and its default markets.</p>
+
+<div class="section-example-container">
+    <pre class="csharp">SetBrokerageModel(BrokerageName.TerminalLink, AccountType.Margin);</pre>
+    <pre class="python">self.set_brokerage_model(BrokerageName.TERMINAL_LINK, AccountType.MARGIN)</pre>
+</div>
+
+<p class='csharp'>For more information about this model, see the <a target="_blank" rel="nofollow" href="https://www.lean.io/docs/v2/lean-engine/class-reference/cs/classQuantConnect_1_1Brokerages_1_1TerminalLinkBrokerageModel.html">class reference</a> and <a target="_blank" rel="nofollow" href="https://github.com/QuantConnect/Lean/blob/master/Common/Brokerages/TerminalLinkBrokerageModel.cs">implementation</a>.</p>
+<p class='python'>For more information about this model, see the <a target="_blank" rel="nofollow" href="https://www.lean.io/docs/v2/lean-engine/class-reference/py/QuantConnect/Brokerages/TerminalLinkBrokerageModel/">class reference</a> and <a target="_blank" rel="nofollow" href="https://github.com/QuantConnect/Lean/blob/master/Common/Brokerages/TerminalLinkBrokerageModel.cs">implementation</a>.</p>

--- a/05 Lean CLI/09 Live Trading/01 Brokerages/16 Bloomberg EMSX/02 Asset Classes.php
+++ b/05 Lean CLI/09 Live Trading/01 Brokerages/16 Bloomberg EMSX/02 Asset Classes.php
@@ -4,5 +4,4 @@
     <li><a href='https://www.quantconnect.com/docs/v2/writing-algorithms/securities/asset-classes/us-equity'>Equities</a></li>
     <li><a href='https://www.quantconnect.com/docs/v2/writing-algorithms/securities/asset-classes/equity-options'>Equity Options</a></li>
     <li><a href='https://www.quantconnect.com/docs/v2/writing-algorithms/securities/asset-classes/futures'>Futures</a></li>
-    <li><a href='https://www.quantconnect.com/docs/v2/writing-algorithms/securities/asset-classes/index-options'>Index Options</a></li>
 </ul>

--- a/05 Lean CLI/09 Live Trading/01 Brokerages/16 Bloomberg EMSX/04 Orders.php
+++ b/05 Lean CLI/09 Live Trading/01 Brokerages/16 Bloomberg EMSX/04 Orders.php
@@ -10,7 +10,6 @@
         <th>Equity</th>
         <th>Equity Options</th>
         <th>Futures</th>
-        <th>Index Options</th>
       </tr>
    </thead>
    <tbody>
@@ -19,11 +18,15 @@
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-types/market-on-open-orders">MarketOnOpenOrder</a></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+        <td></td>
+        <td></td>
       </tr>
       <tr>
         <td><a href="https://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-types/limit-orders">LimitOrder</a></td>
-        <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
@@ -33,11 +36,9 @@
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-        <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
       </tr>
       <tr>
         <td><a href="https://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-types/stop-limit-orders">StopLimitOrder</a></td>
-        <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>

--- a/Resources/brokerages/terminal-link/asset-classes.html
+++ b/Resources/brokerages/terminal-link/asset-classes.html
@@ -4,5 +4,4 @@
     <li><a href='/docs/v2/writing-algorithms/securities/asset-classes/us-equity'>Equities</a></li>
     <li><a href='/docs/v2/writing-algorithms/securities/asset-classes/equity-options'>Equity Options</a></li>
     <li><a href='/docs/v2/writing-algorithms/securities/asset-classes/futures'>Futures</a></li>
-    <li><a href='/docs/v2/writing-algorithms/securities/asset-classes/index-options'>Index Options</a>
 </ul>

--- a/Resources/brokerages/terminal-link/orders.php
+++ b/Resources/brokerages/terminal-link/orders.php
@@ -10,7 +10,6 @@
         <th>Equity</th>
         <th>Equity Options</th>
         <th>Futures</th>
-        <th>Index Options</th>
       </tr>
    </thead>
    <tbody>
@@ -19,11 +18,15 @@
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+      </tr>
+      <tr>
+        <td><a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/market-on-open-orders">Market on open</a></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+        <td></td>
+        <td></td>
       </tr>
       <tr>
         <td><a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/limit-orders">Limit</a></td>
-        <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
@@ -33,11 +36,9 @@
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
-        <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
       </tr>
       <tr>
         <td><a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/stop-limit-orders">Stop limit</a></td>
-        <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>

--- a/Resources/brokerages/terminal-link/terminallink.json
+++ b/Resources/brokerages/terminal-link/terminallink.json
@@ -10,7 +10,7 @@
 			"Live Trading":	[1,1,1]
 		}
 	],
-	"order-types": ["Market", "Limit", "Stop Market",  "Stop Limit"],
+	"order-types": ["Market", "Market On Open", "Limit", "Stop Market",  "Stop Limit"],
 	"assets": ["Equity", "Equity Options", "Futures", "Forex"], 
 	"brokerage-url": "https://www.lean.io/terminal-link",
 	"documentation": "/docs/v2/cloud-platform/live-trading/brokerages/bloomberg-emsx",


### PR DESCRIPTION
## Summary

Updates the Terminal Link (Bloomberg EMSX) documentation to reflect the new `TerminalLinkBrokerageModel` added in [QuantConnect/Lean#9546](https://github.com/QuantConnect/Lean/pull/9546). Previously Terminal Link used the permissive `DefaultBrokerageModel`, so orders were validated against a generic model.

- **Supported-models intro**: document `TerminalLinkBrokerageModel` with a `SetBrokerageModel` example and class-reference/implementation links (matching the other brokerage pages).
- **Asset classes**: remove **Index Options** — the model only accepts Equity, Equity Options, and Futures.
- **Order types**: add **Market on open** (Equity only) to the order-types tables.
- Updated both the shared `Resources/brokerages/terminal-link/*` includes and the standalone LEAN CLI Bloomberg EMSX pages, plus `terminallink.json`.

Order updates remain documented as unsupported.

## Test plan

- [ ] Verify the Terminal Link supported-models page renders the new intro snippet and class-reference links.
- [ ] Verify the order-types tables (Writing Algorithms, Cloud Platform, LEAN CLI) show Market on open as Equity-only and no longer list Index Options.
- [ ] Confirm the asset-classes list no longer includes Index Options.