### PR TITLE
Remove "sources" URL guard from the link checker

### DIFF
--- a/url_check.py
+++ b/url_check.py
@@ -170,9 +170,6 @@ def _get_all_urls(doc_files: list[str]) -> dict[str, list[str]]:
                     new_lines[i] = converted_line
                     has_relative_link = True
 
-                if "sources" in url:
-                    continue
-
                 url_files.setdefault(url, []).append(filepath)
 
                 if lean_io_url:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fix the link checker so it doesn't silently skip over 16 links

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

`if "sources" in url: continue` in _get_all_urls matched the substring "sources" inside "resources"/"Resources", so it silently dropped 16 legitimate links from both HTTP and section-anchor validation - including a genuinely dead tradingtechnologies.com/resources/pricing 404.
<img width="1174" height="294" alt="image" src="https://github.com/user-attachments/assets/2d42ed6f-96f3-4300-80b3-3d0387e61e4d" />


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
