### PR TITLE
Add browser re-check to the documentation link checker

### DIFF
--- a/.github/workflows/url_check_workflow.yml
+++ b/.github/workflows/url_check_workflow.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install dependencies
-        run: pip install aiohttp==3.11.14
+        run: pip install aiohttp==3.11.14 curl_cffi==0.13.0
 
       - name: Run URL checker
         env:

--- a/browser_recheck.py
+++ b/browser_recheck.py
@@ -1,0 +1,49 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared browser-impersonating re-check, used by both url_check.py (this repo's
+# own pages) and external_url_check.py (the Lean.Brokerages.*/Lean.DataSource.*
+# repos). Many sites serve 401/403 to plain HTTP clients based on TLS/header
+# fingerprinting even though the link is valid; curl_cffi mimics a real browser
+# (Chrome TLS fingerprint) and gets through, so a 401/403 can be re-checked before
+# it's reported.
+
+import asyncio
+
+from curl_cffi.requests import AsyncSession
+
+
+async def browser_recheck(url: str) -> str:
+    """Re-check a 401/403 with a browser-impersonating client (Chrome TLS fingerprint).
+
+    Returns:
+      - "ok"      : a real 2xx (or 429 - server is live, just rate-limiting)
+      - "broken"  : a definitive 404/410 the block was hiding (a genuinely dead link)
+      - "blocked" : still can't verify (e.g. a hard WAF) - report but don't fail
+    """
+    for attempt in range(3):
+        try:
+            async with AsyncSession() as s:
+                r = await s.get(url, impersonate="chrome", timeout=30, allow_redirects=True)
+            code = r.status_code
+            if 200 <= code < 300:
+                return "broken" if str(r.url).rstrip("/").endswith("/404") else "ok"
+            if code in (404, 410):
+                return "broken"        # the block was hiding a genuinely dead link
+            if code == 429:
+                return "ok"            # rate-limited => server is live, link exists
+            # 401/403/5xx: transient block or rate-limit - back off and retry
+        except Exception:
+            pass
+        await asyncio.sleep(2 * (attempt + 1))   # 2s, 4s
+    return "blocked"

--- a/external_url_check.py
+++ b/external_url_check.py
@@ -58,8 +58,7 @@ from collections import defaultdict, namedtuple
 from pathlib import Path
 
 import aiohttp
-from curl_cffi.requests import AsyncSession
-
+from browser_recheck import browser_recheck
 from doc_anchors import build_file_index, check_deprecated_path, check_section_anchor
 
 # -- Constants ----------------------------------------------------------------
@@ -168,34 +167,6 @@ def _is_external(url: str) -> bool:
     return url.startswith("http://") or url.startswith("https://")
 
 
-async def _browser_recheck(url: str) -> str:
-    """Re-check a 401/403 with a browser-impersonating client (Chrome TLS fingerprint).
-
-    Many sites (FINRA, Coinbase, Bitfinex, CoinAPI, ...) serve 401/403 to plain
-    HTTP clients based on TLS/header fingerprinting even though the link is valid;
-    curl_cffi mimics a real browser and gets through. Returns:
-      - "ok"      : a real 2xx (or 429 - server is live, just rate-limiting)
-      - "broken"  : a definitive 404/410 the block was hiding (a genuinely dead link)
-      - "blocked" : still can't verify (e.g. a hard WAF) - report but don't fail
-    """
-    for attempt in range(3):
-        try:
-            async with AsyncSession() as s:
-                r = await s.get(url, impersonate="chrome", timeout=30, allow_redirects=True)
-            code = r.status_code
-            if 200 <= code < 300:
-                return "broken" if str(r.url).rstrip("/").endswith("/404") else "ok"
-            if code in (404, 410):
-                return "broken"        # the block was hiding a genuinely dead link
-            if code == 429:
-                return "ok"            # rate-limited => server is live, link exists
-            # 401/403/5xx: transient block or rate-limit - back off and retry
-        except Exception:
-            pass
-        await asyncio.sleep(2 * (attempt + 1))   # 2s, 4s
-    return "blocked"
-
-
 async def check_url(session: aiohttp.ClientSession, semaphore: asyncio.Semaphore,
                     url: str, files: list[Path], repo_dir: Path,
                     findings: list[Finding], broken_pages: set[str]):
@@ -215,7 +186,7 @@ async def check_url(session: aiohttp.ClientSession, semaphore: asyncio.Semaphore
                         findings.append(_finding("400", "400 Bad Request", url, files, repo_dir))
                     case 401 | 403:
                         # Likely bot/WAF blocking - re-check with a browser-like client.
-                        verdict = await _browser_recheck(url)
+                        verdict = await browser_recheck(url)
                         if verdict == "broken":
                             # The block was hiding a genuinely dead link - fail on it.
                             findings.append(_finding(

--- a/url_check.py
+++ b/url_check.py
@@ -16,6 +16,10 @@
 # Scans all .html/.php doc files and documentation-map.json for <a href="..."> links,
 # then validates them:
 #   - HTTP checks: GET each external URL, flag 4xx responses and soft-404 pages.
+#     A 401/403 is re-checked with a browser-impersonating client (curl_cffi),
+#     since many sites bot-block plain HTTP clients on otherwise-valid links: a
+#     confirmed 404 is escalated to a failing error, a still-blocked link stays a
+#     warning, and a reachable one is dropped.
 #   - Section anchors: verify that #fragment links map to real files on disk.
 #   - Resource includes: verify <? include(DOCS_RESOURCES."...") targets exist.
 #   - GitHub issues: confirm referenced Lean issues are still open.
@@ -45,6 +49,7 @@ from pathlib import Path
 
 import aiohttp
 
+from browser_recheck import browser_recheck
 from doc_anchors import build_file_index, check_section_anchor
 
 # -- Constants ----------------------------------------------------------------
@@ -329,10 +334,19 @@ async def _check_url(
                 match resp.status:
                     case 400:
                         results["400"].append(_fmt("400 Bad Request", url, files))
-                    case 401:
-                        results["401"].append(_fmt("401 Unauthorized", url, files))
-                    case 403:
-                        results["403"].append(_fmt("403 Forbidden", url, files))
+                    case 401 | 403:
+                        # Likely bot/WAF blocking - re-check with a browser-like
+                        # client. A confirmed 404 is escalated to a failing error
+                        # so a dead link can't hide behind a 403; if still blocked
+                        # it stays a non-failing warning, and a 2xx is dropped.
+                        match await browser_recheck(url):
+                            case "broken":
+                                results["404"].append(_fmt(
+                                    "404 Not found (confirmed via browser re-check)", url, files))
+                            case "blocked":
+                                cat = str(resp.status)
+                                msg = "401 Unauthorized" if resp.status == 401 else "403 Forbidden"
+                                results[cat].append(_fmt(msg, url, files))
                     case 404:
                         results["404"].append(_fmt("404 Not found", url, files))
                     case 200:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

url_check.py treated every 403 as a non-failing warning, so a bot-blocked link could be a genuinely dead page nobody noticed. Re-check 401/403 responses with a browser-impersonating client (curl_cffi, Chrome TLS fingerprint), the same way external_url_check.py already does: a confirmed 404 escalates to a failing error, a still-blocked link stays a warning, and a reachable-but-blocked one is dropped.

- browser_recheck.py: the re-check, factored out of external_url_check.py so both checkers share one implementation.
- url_check.py: imports it and wires it into the 401/403 handling.
- external_url_check.py: imports the shared helper instead of its own copy.
- url_check_workflow.yml: installs curl_cffi.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#2563

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

403s from bot-blocking sites were both noisy (false warnings) and dangerous (masking genuinely-dead links); the browser re-check fixes both, and this PR brings the docs checker in line with the brokerage/dataset repos checker.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
