### PR TITLE
Update mypy to 2.1.0 in syntax tests workflow

### DIFF
--- a/.github/workflows/syntax-tests.yml
+++ b/.github/workflows/syntax-tests.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run Syntax Test
         run: |
-          runInContainer bash -c "pip install --no-cache-dir quantconnect-stubs requests types-requests==2.32.* types-pytz==2025.2.0.* mypy==1.20.2"
+          runInContainer bash -c "pip install --no-cache-dir quantconnect-stubs requests types-requests==2.32.* types-pytz==2025.2.0.* mypy==2.1.0"
           runInContainer python -u project-templates/python/run_syntax_check.py
 
       - name: Run Project Match Check


### PR DESCRIPTION
## Summary
Bumps the pinned mypy version in the Syntax Tests workflow from `1.20.2` to `2.1.0`, matching the same bump made in [QuantConnect/Lean#9566](https://github.com/QuantConnect/Lean/pull/9566).

## Test plan
- Ran `python project-templates/python/run_syntax_check.py` locally with mypy 2.1.0 installed: all 100 templates pass (100% success rate).