### PR TITLE
Simplify bulk download and update instructions (#2448)

### DIFF
--- a/05 Lean CLI/05 Datasets/05 QuantConnect/02 US Equity/03 Download in Bulk.php
+++ b/05 Lean CLI/05 Datasets/05 QuantConnect/02 US Equity/03 Download in Bulk.php
@@ -1,11 +1,11 @@
 <p>After you subscribe to local access (see <a href="/docs/v2/lean-cli/datasets/quantconnect/us-equity#02-Prerequisites">Prerequisites</a>), open a terminal in your <a href="https://www.quantconnect.com/docs/v2/lean-cli/initialization/organization-workspaces">organization workspace</a> and run the following commands to bulk download the data and its prerequisites.</p>
 
-<p>To download the US Equity Security Master, run:</p>
+<p>To download or update your local copy of the US Equity Security Master, run:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Equity Security Master"</pre> 
 </div>
 
-<p>To download the US Equities data for a resolution, run the following command, replacing <code>&lt;resolution&gt;</code> with daily, hour, minute, second, or tick and adjusting the date range:</p>
+<p>To download or update your local copy of the US Equities data for a resolution, run the following command, replacing <code>&lt;resolution&gt;</code> with daily, hour, minute, second, or tick and adjusting the date range:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Equities" --data-type "Bulk" --resolution "&lt;resolution&gt;" --start "20230101" --end "20230105"</pre> 
 </div>
@@ -25,8 +25,3 @@ include(DOCS_RESOURCES."/datasets/download_bulk_data_script.php");
 ?>
 
 <p>The preceding script checks the date of the most recent SPY data you have for all resolutions. If there is new data available for any of these resolutions, it downloads the new data files and overwrites your hourly and daily files. If you don't intend to download all resolutions, adjust this script to your needs.</p>
-
-<p>To update your local copy of the US Equity Security Master, run:</p>
-<div class="cli section-example-container">
-     <pre>$ lean data download --dataset "US Equity Security Master"</pre> 
-</div>

--- a/05 Lean CLI/05 Datasets/05 QuantConnect/03 Equity Options/03 Download in Bulk.php
+++ b/05 Lean CLI/05 Datasets/05 QuantConnect/03 Equity Options/03 Download in Bulk.php
@@ -1,16 +1,16 @@
 <p>After you subscribe to local access (see <a href="/docs/v2/lean-cli/datasets/quantconnect/equity-options#02-Prerequisites">Prerequisites</a>), open a terminal in your <a href="https://www.quantconnect.com/docs/v2/lean-cli/initialization/organization-workspaces">organization workspace</a> and run the following commands to bulk download the data and its prerequisites.</p>
 
-<p>To download the US Equity Security Master, run:</p>
+<p>To download or update your local copy of the US Equity Security Master, run:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Equity Security Master"</pre> 
 </div>
 
-<p>To download the US Equity Option Universe data, run:</p>
+<p>To download or update your local copy of the US Equity Option Universe data, run:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Equity Option Universe" --data-type "Bulk" --start "20250403" --end "20250403"</pre> 
 </div>
 
-<p>To download the US Equity Options data for a resolution, run the following command, replacing <code>&lt;resolution&gt;</code> with daily, hour, or minute and adjusting the date range:</p>
+<p>To download or update your local copy of the US Equity Options data for a resolution, run the following command, replacing <code>&lt;resolution&gt;</code> with daily, hour, or minute and adjusting the date range:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Equity Options" --data-type "Bulk" --resolution "&lt;resolution&gt;" --start "20230101" --end "20230105"</pre> 
 </div>
@@ -30,13 +30,3 @@ include(DOCS_RESOURCES."/datasets/download_bulk_data_script.php");
 ?>
 
 <p>The preceding script checks the date of the most recent minute resolution data you have for AAPL. If there is new minute data available, it downloads the new data files and overwrites your hourly and daily files. If you don't intend to download all resolutions, adjust this script to your needs.</p>
-
-<p>To update your local copy of the US Equity Security Master, run:</p>
-<div class="cli section-example-container">
-     <pre>$ lean data download --dataset "US Equity Security Master"</pre> 
-</div>
-
-<p>To update your local copy of the US Equity Option Universe data, run:</p>
-<div class="cli section-example-container">
-     <pre>$ lean data download --dataset "US Equity Option Universe" --data-type "Bulk" --start "20250403" --end "20250403"</pre> 
-</div>

--- a/05 Lean CLI/05 Datasets/05 QuantConnect/04 Forex/02 Download in Bulk.php
+++ b/05 Lean CLI/05 Datasets/05 QuantConnect/04 Forex/02 Download in Bulk.php
@@ -1,4 +1,4 @@
-<p>After you subscribe to the FOREX dataset on the <a href="https://www.quantconnect.com/pricing">Pricing</a> page of your organization, open a terminal in your <a href="https://www.quantconnect.com/docs/v2/lean-cli/initialization/organization-workspaces">organization workspace</a> and run the following command to bulk download the data, replacing <code>&lt;resolution&gt;</code> with daily, hour, minute, or second and adjusting the date range:</p>
+<p>After you subscribe to the FOREX dataset on the <a href="https://www.quantconnect.com/pricing">Pricing</a> page of your organization, open a terminal in your <a href="https://www.quantconnect.com/docs/v2/lean-cli/initialization/organization-workspaces">organization workspace</a> and run the following command to bulk download or update the data, replacing <code>&lt;resolution&gt;</code> with daily, hour, minute, or second and adjusting the date range:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "FOREX Data" --data-type "Bulk" --resolution "&lt;resolution&gt;" --start "20230101" --end "20230105"</pre> 
 </div>

--- a/05 Lean CLI/05 Datasets/05 QuantConnect/05 Futures/03 Download in Bulk.php
+++ b/05 Lean CLI/05 Datasets/05 QuantConnect/05 Futures/03 Download in Bulk.php
@@ -1,16 +1,16 @@
 <p>After you subscribe to local access (see <a href="/docs/v2/lean-cli/datasets/quantconnect/futures#02-Prerequisites">Prerequisites</a>), open a terminal in your <a href="https://www.quantconnect.com/docs/v2/lean-cli/initialization/organization-workspaces">organization workspace</a> and run the following commands to bulk download the data and its prerequisites.</p>
 
-<p>To download the US Futures Security Master, run:</p>
+<p>To download or update your local copy of the US Futures Security Master, run:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Futures Security Master"</pre> 
 </div>
 
-<p>To download the US Future Universe data, run:</p>
+<p>To download or update your local copy of the US Future Universe data, run:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Future Universe" --data-type "Bulk" --start "20250403" --end "20250403"</pre> 
 </div>
 
-<p>To download the US Futures data for a resolution, run the following command, replacing <code>&lt;resolution&gt;</code> with daily, hour, minute, second, or tick and adjusting the date range:</p>
+<p>To download or update your local copy of the US Futures data for a resolution, run the following command, replacing <code>&lt;resolution&gt;</code> with daily, hour, minute, second, or tick and adjusting the date range:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Futures" --data-type "Bulk" --resolution "&lt;resolution&gt;" --start "20230101" --end "20230105"</pre> 
 </div>
@@ -30,13 +30,3 @@ include(DOCS_RESOURCES."/datasets/download_bulk_data_script.php");
 ?>
 
 <p>The preceding script checks the date of the most recent ZC data you have from the CBOT market for tick, second, and minute resolutions. If there is new data available for any of these resolutions, it downloads the new data files and overwrites your hourly and daily files. If you don't intend to download all resolutions and markets, adjust this script to your needs.</p>
-
-<p>To update your local copy of the US Futures Security Master, run:</p>
-<div class="cli section-example-container">
-     <pre>$ lean data download --dataset "US Futures Security Master"</pre> 
-</div>
-
-<p>To update your local copy of the US Future Universe data, run:</p>
-<div class="cli section-example-container">
-     <pre>$ lean data download --dataset "US Future Universe" --data-type "Bulk" --start "20250403" --end "20250403"</pre> 
-</div>

--- a/05 Lean CLI/05 Datasets/05 QuantConnect/06 Future Options/03 Download in Bulk.php
+++ b/05 Lean CLI/05 Datasets/05 QuantConnect/06 Future Options/03 Download in Bulk.php
@@ -1,21 +1,21 @@
 <p>After you unlock local access (see <a href="/docs/v2/lean-cli/datasets/quantconnect/future-options#02-Prerequisites">Prerequisites</a>), open a terminal in your <a href="https://www.quantconnect.com/docs/v2/lean-cli/initialization/organization-workspaces">organization workspace</a> and run the following commands to bulk download the prerequisite datasets.</p>
 
-<p>To download the US Futures Security Master, run:</p>
+<p>To download or update your local copy of the US Futures Security Master, run:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Futures Security Master"</pre> 
 </div>
 
-<p>To download the US Future Universe data, run:</p>
+<p>To download or update your local copy of the US Future Universe data, run:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Future Universe" --data-type "Bulk" --start "20250403" --end "20250403"</pre> 
 </div>
 
-<p>To download the US Future Option Universe data, run:</p>
+<p>To download or update your local copy of the US Future Option Universe data, run:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Future Option Universe" --data-type "Bulk" --start "20250403" --end "20250403"</pre> 
 </div>
 
-<p>To download the US Future Options data, use the <a href="https://www.quantconnect.com/datasets/algoseek-us-future-options/cli">CLI Command Generator</a> on the dataset listing to generate your download command, then run it in your organization workspace. For more information, see <a href="/docs/v2/lean-cli/datasets/quantconnect/key-concepts#03-Using-the-CLI">Using the CLI</a>. You also need the underlying US Futures data; see <a href="/docs/v2/lean-cli/datasets/quantconnect/futures#03-Download-in-Bulk">US Futures</a>.</p>
+<p>To download or update your local copy of the US Future Options data, use the <a href="https://www.quantconnect.com/datasets/algoseek-us-future-options/cli">CLI Command Generator</a> on the dataset listing to generate your download command, then run it in your organization workspace. For more information, see <a href="/docs/v2/lean-cli/datasets/quantconnect/key-concepts#03-Using-the-CLI">Using the CLI</a>. You also need the underlying US Futures data; see <a href="/docs/v2/lean-cli/datasets/quantconnect/futures#03-Download-in-Bulk">US Futures</a>.</p>
 
 <p>After you bulk download the US Future Options dataset, new daily updates are available at 7 AM Eastern Time (ET) after each trading day. Instead of directly calling the <code>lean data download</code> command, you can place a Python script in the <span class="public-directory-name">data</span> directory of your organization workspace and run it to update your data files. The following example script updates all data resolutions and markets:</p>
 
@@ -30,8 +30,3 @@ include(DOCS_RESOURCES."/datasets/download_bulk_data_script.php");
 ?>
 
 <p>The preceding script checks the date of the most recent ES data you have from the CME market for minute resolution. If there is new data available, it downloads the new data files and overwrites your hourly and daily files. If you don't intend to download all resolutions and markets, adjust this script to your needs.</p>
-
-<p>To update your local copy of the US Futures Security Master, run:</p>
-<div class="cli section-example-container">
-     <pre>$ lean data download --dataset "US Futures Security Master"</pre> 
-</div>

--- a/05 Lean CLI/05 Datasets/05 QuantConnect/07 Index Options/03 Download in Bulk.php
+++ b/05 Lean CLI/05 Datasets/05 QuantConnect/07 Index Options/03 Download in Bulk.php
@@ -1,11 +1,11 @@
 <p>After you subscribe to local access (see <a href="/docs/v2/lean-cli/datasets/quantconnect/index-options#02-Prerequisites">Prerequisites</a>), open a terminal in your <a href="https://www.quantconnect.com/docs/v2/lean-cli/initialization/organization-workspaces">organization workspace</a> and run the following commands to bulk download the data and its prerequisites.</p>
 
-<p>To download the US Index Option Universe data, run:</p>
+<p>To download or update your local copy of the US Index Option Universe data, run:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Index Option Universe" --data-type "Bulk" --start "20250403" --end "20250403"</pre> 
 </div>
 
-<p>To download the US Index Options data for a resolution, run the following command, replacing <code>&lt;resolution&gt;</code> with daily, hour, or minute and adjusting the date range:</p>
+<p>To download or update your local copy of the US Index Options data for a resolution, run the following command, replacing <code>&lt;resolution&gt;</code> with daily, hour, or minute and adjusting the date range:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Index Options" --data-type "Bulk" --resolution "&lt;resolution&gt;" --start "20230101" --end "20230105"</pre> 
 </div>
@@ -25,14 +25,3 @@ include(DOCS_RESOURCES."/datasets/download_bulk_data_script.php");
 ?>
 
 <p>The preceding script checks the date of the most recent minute resolution data you have for SPX. If there is new minute data available, it downloads the new data files and overwrites your hourly and daily files. If you don't intend to download all resolutions, adjust this script to your needs.</p>
-
-<p>To update your local copy of the US Index Option Universe data, run the following command, or use the universe auto-update script below:</p>
-<div class="cli section-example-container">
-     <pre>$ lean data download --dataset "US Index Option Universe" --data-type "Bulk" --start "20250403" --end "20250403"</pre> 
-</div>
-
-<?
-$dataset = "US Index Option Universe";
-$dirName = "indexoption/usa/universes";
-include(DOCS_RESOURCES."/datasets/download_bulk_data_script_universe.php");
-?>

--- a/05 Lean CLI/05 Datasets/05 QuantConnect/08 CFD/02 Download in Bulk.php
+++ b/05 Lean CLI/05 Datasets/05 QuantConnect/08 CFD/02 Download in Bulk.php
@@ -1,4 +1,4 @@
-<p>After you subscribe to the CFD dataset on the <a href="https://www.quantconnect.com/pricing">Pricing</a> page of your organization, open a terminal in your <a href="https://www.quantconnect.com/docs/v2/lean-cli/initialization/organization-workspaces">organization workspace</a> and run the following command to bulk download the data, replacing <code>&lt;resolution&gt;</code> with daily, hour, minute, or second and adjusting the date range:</p>
+<p>After you subscribe to the CFD dataset on the <a href="https://www.quantconnect.com/pricing">Pricing</a> page of your organization, open a terminal in your <a href="https://www.quantconnect.com/docs/v2/lean-cli/initialization/organization-workspaces">organization workspace</a> and run the following command to bulk download or update the data, replacing <code>&lt;resolution&gt;</code> with daily, hour, minute, or second and adjusting the date range:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "CFD Data" --data-type "Bulk" --resolution "&lt;resolution&gt;" --start "20230101" --end "20230105"</pre> 
 </div>

--- a/05 Lean CLI/05 Datasets/05 QuantConnect/09 US Equity Coarse Fundamental/03 Download in Bulk.php
+++ b/05 Lean CLI/05 Datasets/05 QuantConnect/09 US Equity Coarse Fundamental/03 Download in Bulk.php
@@ -1,26 +1,11 @@
 <p>After you subscribe to local access (see <a href="/docs/v2/lean-cli/datasets/quantconnect/us-equity-coarse-fundamental#02-Prerequisites">Prerequisites</a>), open a terminal in your <a href="https://www.quantconnect.com/docs/v2/lean-cli/initialization/organization-workspaces">organization workspace</a> and run the following commands to bulk download the data and its prerequisites.</p>
 
-<p>To download the US Equity Coarse Universe data, run:</p>
+<p>To download or update the US Equity Coarse Universe data, run:</p>
 <div class="cli section-example-container">
-     <pre>$ lean data download --dataset "US Equity Coarse Universe" --data-type "Bulk"</pre> 
+     <pre>$ lean data download --dataset "US Equity Coarse Universe" --data-type "Bulk" --overwrite</pre> 
 </div>
 
-<p>To download the US Equity Security Master, run:</p>
-<div class="cli section-example-container">
-     <pre>$ lean data download --dataset "US Equity Security Master"</pre> 
-</div>
-
-<p>After you bulk download the US Equity Coarse Universe dataset, new daily updates are available at 7 AM Eastern Time (ET) after each trading day. Instead of directly calling the <code>lean data download</code> command, you can place the following Python script in the <span class="public-directory-name">data</span> directory of your organization workspace and run it to update your data files:</p>
-
-<?
-$dataset = "US Equity Coarse Universe";
-$dirName = "equity/usa/fundamental/coarse";
-include(DOCS_RESOURCES."/datasets/download_bulk_data_script_universe.php");
-?>
-
-<p>The preceding script checks the date of the most recent US Equity Coarse Universe data you have. If there is new data available, it downloads the new data files.</p>
-
-<p>To update your local copy of the US Equity Security Master, run:</p>
+<p>To download or update your local copy of the US Equity Security Master, run:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Equity Security Master"</pre> 
 </div>

--- a/05 Lean CLI/05 Datasets/05 QuantConnect/10 US ETF Constituents/03 Download in Bulk.php
+++ b/05 Lean CLI/05 Datasets/05 QuantConnect/10 US ETF Constituents/03 Download in Bulk.php
@@ -1,26 +1,11 @@
 <p>After you subscribe to local access (see <a href="/docs/v2/lean-cli/datasets/quantconnect/us-etf-constituents#02-Prerequisites">Prerequisites</a>), open a terminal in your <a href="https://www.quantconnect.com/docs/v2/lean-cli/initialization/organization-workspaces">organization workspace</a> and run the following commands to bulk download the data and its prerequisites.</p>
 
-<p>To download the US ETF Constituents data, run:</p>
+<p>To download or update the US ETF Constituents data, run:</p>
 <div class="cli section-example-container">
-     <pre>$ lean data download --dataset "US ETF Constituents" --data-type "Bulk" --start "20250701" --end "20260701"</pre> 
+     <pre>$ lean data download --dataset "US ETF Constituents" --data-type "Bulk" --overwrite</pre> 
 </div>
 
-<p>To download the US Equity Security Master, run:</p>
-<div class="cli section-example-container">
-     <pre>$ lean data download --dataset "US Equity Security Master"</pre> 
-</div>
-
-<p>After you bulk download the US ETF Constituents dataset, new daily updates are available at 7 AM Eastern Time (ET) after each trading day. Instead of directly calling the <code>lean data download</code> command, you can place the following Python script in the <span class="public-directory-name">data</span> directory of your organization workspace and run it to update your data files:</p>
-
-<?
-$dataset = "US ETF Constituents";
-$dirName = "equity/usa/universes/etf/spy";
-include(DOCS_RESOURCES."/datasets/download_bulk_data_script_universe.php");
-?>
-
-<p>The preceding script checks the date of the most recent SPY data you have. If there is new data available for SPY, it downloads the new data files for all of the ETFs. You may need to adjust this script to fit your needs.</p>
-
-<p>To update your local copy of the US Equity Security Master, run:</p>
+<p>To download or update your local copy of the US Equity Security Master, run:</p>
 <div class="cli section-example-container">
      <pre>$ lean data download --dataset "US Equity Security Master"</pre> 
 </div>


### PR DESCRIPTION
## Summary

Follow-up to the QuantConnect CLI datasets pricing work, refining the **Download in Bulk** sections:

- Every bulk download command now reads **"To download or update your local copy of …"**, since re-running the command updates the local data.
- Removed the redundant trailing **"To update your local copy of …"** command blocks (they just repeated the download commands).
- **US Equity Coarse Universe** and **US ETF Constituents** (single-file universe datasets) now use one command with the **`--overwrite`** parameter instead of the Python auto-update script.
- The resolution-based datasets (US Equity, Equity Options, Forex, Futures, Future Options, Index Options, CFD) keep the Python auto-update script.

## Test plan

- [ ] Verify each Download in Bulk page renders correctly on quantconnect.com/docs
- [ ] Confirm the remaining `download_bulk_data_script.php` includes still resolve
- [ ] Check the download/update commands are correct