### PR TITLE
Fix wide table columns on Charles Schwab troubleshooting page

### DIFF
--- a/Resources/brokerages/charles-schwab/troubleshooting.html
+++ b/Resources/brokerages/charles-schwab/troubleshooting.html
@@ -9,7 +9,7 @@
     </thead>
     <tbody>
         <tr>
-            <td nowrap>
+            <td>
                 <div class="error-messages">Name = Account_Sys_0005,</br>Description = No trades are currently allowed</div>
             </td>
             <td>
@@ -17,7 +17,7 @@
             </td>
         </tr>
         <tr>
-            <td nowrap>
+            <td>
                 <div class="error-messages">Name = Order_Sys_0002,</br>Description = The stop price must be above the current ask for buy stop orders and below the bid for sell stop orders.</div>
             </td>
             <td>
@@ -35,7 +35,7 @@ StopMarketOrder(symbol, quantity, stopPrice);</pre>
             </td>
         </tr>
         <tr>
-            <td nowrap>
+            <td>
                 <div class="error-messages">Name = Position_Sys_0001,</br>Description = This order may result in an oversold/overbought position in your account. Please check your position quantity and/or open orders.</div>
             </td>
             <td>
@@ -64,7 +64,7 @@ Liquidate();</pre>
     </thead>
     <tbody>
         <tr>
-            <td nowrap>
+            <td>
                 <div class="error-messages">Name = Easy_To_Borrow_GTC,</br>Description = This security is currently easy to borrow, good until canceled orders may be subjected to changes in status to hard to borrow resulting in your order being canceled.</div>
             </td>
             <td>
@@ -72,7 +72,7 @@ Liquidate();</pre>
             </td>
         </tr>
         <tr>
-            <td nowrap>
+            <td>
                 <div class="error-messages">Name = ETB_WARNING,</br>Description = Please note: although this security is considered easy to borrow at this time, conditions may change including share availability and possible fees associated with hard to borrow securities.</div>
             </td>
             <td>
@@ -80,7 +80,7 @@ Liquidate();</pre>
             </td>
         </tr>
         <tr>
-            <td nowrap>
+            <td>
                 <div class="error-messages">Name = PRICES_CAN_CHANGE_QUICKLY,</br>Description = With market orders, prices can change quickly in fast market conditions resulting in execution prices that can be different from the quotes displayed at order entry.</div>
             </td>
             <td>
@@ -88,7 +88,7 @@ Liquidate();</pre>
             </td>
         </tr>
         <tr>
-            <td nowrap>
+            <td>
                 <div class="error-messages">Name = SCHW_DO0989,</br>Description = Please note that when a Stop order triggers it becomes a Market order. Because of this and depending on market conditions, this order may execute at a price significantly different than the Stop price.</div>
             </td>
             <td>
@@ -96,7 +96,7 @@ Liquidate();</pre>
             </td>
         </tr>
         <tr>
-            <td nowrap>
+            <td>
                 <div class="error-messages">Name = STOP_ORDERS_NO_GUARANTEE,</br>Description = With stop orders, there is no guarantee that the execution price will be equal to or near the activation price.</div>
             </td>
             <td>


### PR DESCRIPTION
## Summary

The error and warning troubleshooting tables rendered with an excessively wide first column: the message cells used `<td nowrap>`, which forced the long `Name`/`Description` text onto a single line and unbalanced the layout. This drops `nowrap` from those cells so the message text wraps naturally and the columns balance.

## Test plan

- Rendered the `troubleshooting.html` fragment and confirmed the message column now wraps and both tables display with balanced column widths.