### PR TITLE
Add Secrets section to Bring Your Own Key docs

### DIFF
--- a/09 AI Assistance/02 Assistants/10 Add Assistants.html
+++ b/09 AI Assistance/02 Assistants/10 Add Assistants.html
@@ -2,7 +2,7 @@
   We provide several built-in assistants for common community goals. 
   You can customize these to your project goals by creating a custom assistant. 
   By default, Assistants run on the free QuantConnect Meta Agent. 
-  To use a different LLM, set your own API key when you create the assistant and configure the reasoning effort, max turns, and tool choice.
+  To use a different LLM, set your own <a href="/docs/v2/ai-assistance/bring-your-own-key#02-Secrets">API key</a> when you create the assistant and configure the reasoning effort, max turns, and tool choice.
 </p>
 <p>Follow these steps to add Assistants to your organization:</p>
 <ol>

--- a/09 AI Assistance/07 Bring Your Own Key/01 Introduction.html
+++ b/09 AI Assistance/07 Bring Your Own Key/01 Introduction.html
@@ -5,8 +5,9 @@
 </p>
 
 <p>
+  The provider, API key, and model are stored in a <a href='/docs/v2/ai-assistance/bring-your-own-key#02-Secrets'>secret</a>.
   To configure your own provider, either <a href='/docs/v2/ai-assistance/assistants#10-Add-Assistants'>add an assistant</a> or <a href='/docs/v2/ai-assistance/assistants#11-Update-Assistants'>update an existing one</a>.
-  In the <span class='page-section-name'>Provider</span> section of the Assistant Configuration, click the <span class='box-name'>Use Your Own Provider</span> option.
+  In the <span class='page-section-name'>Provider</span> section of the Assistant Configuration, click the <span class='box-name'>Use Your Own Provider</span> option and select a secret from the <span class='field-name'>Provider Token</span> dropdown.
   The following settings become available:
 </p>
 
@@ -18,18 +19,6 @@
         </tr>
     </thead>
     <tbody>
-        <tr>
-            <td><span class='column-name'>Provider</span></td>
-            <td>The LLM provider to use.</td>
-        </tr>
-        <tr>
-            <td><span class='column-name'>API Token</span></td>
-            <td>The API key from your provider account.</td>
-        </tr>
-        <tr>
-            <td><span class='column-name'>Model</span></td>
-            <td>The model to run. The list shows the models that the selected provider offers.</td>
-        </tr>
         <tr>
             <td><span class='column-name'>Reasoning Effort</span></td>
             <td>The amount of reasoning the model applies before it responds. The default is <code>high</code>.</td>

--- a/09 AI Assistance/07 Bring Your Own Key/02 Secrets.html
+++ b/09 AI Assistance/07 Bring Your Own Key/02 Secrets.html
@@ -9,8 +9,7 @@
 <p>Follow these steps to add a secret to your organization:</p>
 <ol>
   <li>On the <span class="page-section-name">Secrets</span> page, click <span class="button-name">New Secret</span>.</li>
-  <li>Fill out the following fields:</li>
-</ol>
+  <li>Fill out the following fields:
 <table class='qc-table table'>
     <thead>
         <tr>
@@ -41,7 +40,7 @@
         </tr>
     </tbody>
 </table>
-<ol start='3'>
+  </li>
   <li>Click <span class="button-name">Save</span>.</li>
 </ol>
 
@@ -57,7 +56,7 @@
 <p>To run an Assistant on a secret, associate the secret with the Assistant in one of the following ways:</p>
 <ul>
   <li>
-    When you <a href='/docs/v2/ai-assistance/assistants#10-Add-Assistants'>add</a> or <a href='/docs/v2/ai-assistance/assistants#11-Update-Assistants'>update</a> an Assistant, in the <span class='page-section-name'>Provider</span> section click <span class='box-name'>Use Your Own Provider</span> and select the secret from the <span class='field-name'>Provider Token</span> dropdown.
+    When you <a href='/docs/v2/ai-assistance/assistants#10-Add-Assistants'>add</a> or <a href='/docs/v2/ai-assistance/assistants#11-Update-Assistants'>update</a> an Assistant, in the <span class='page-section-name'>Provider</span> section, click <span class='box-name'>Use Your Own Provider</span> and select the secret from the <span class='field-name'>Provider Token</span> dropdown.
   </li>
   <li>
     When you deploy an Assistant, click <span class='button-name'>Configure</span>, select <span class='box-name'>Bring your own token</span>, and select the secret from the <span class='field-name'>Secret</span> dropdown.

--- a/09 AI Assistance/07 Bring Your Own Key/02 Secrets.html
+++ b/09 AI Assistance/07 Bring Your Own Key/02 Secrets.html
@@ -1,0 +1,71 @@
+<p>
+  A secret securely stores an LLM provider token and the model configuration that goes with it, so you can reuse the same credentials across your Assistants without pasting the token each time.
+  To manage your secrets, log in to the <a href="/terminal">Algorithm Lab</a> and, in the left navigation bar, click <span class="page-section-name">Organization &gt; Secrets</span>.
+  The <span class="page-section-name">Secrets</span> page lists every secret in your organization with its name, key, configuration, and a masked preview of its token.
+  The token is write-only, while the secret configuration stays visible and editable.
+</p>
+
+<h4>Add a Secret</h4>
+<p>Follow these steps to add a secret to your organization:</p>
+<ol>
+  <li>On the <span class="page-section-name">Secrets</span> page, click <span class="button-name">New Secret</span>.</li>
+  <li>Fill out the following fields:</li>
+</ol>
+<table class='qc-table table'>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><span class='field-name'>Name</span></td>
+            <td>A label to identify the secret.</td>
+        </tr>
+        <tr>
+            <td><span class='field-name'>Key</span></td>
+            <td>The type of secret. Select <span class='field-name'>Llm Provider Token</span> to store LLM provider credentials.</td>
+        </tr>
+        <tr>
+            <td><span class='field-name'>Provider</span></td>
+            <td>The LLM provider that issued the token.</td>
+        </tr>
+        <tr>
+            <td><span class='field-name'>Token</span></td>
+            <td>The API key from your provider account.</td>
+        </tr>
+        <tr>
+            <td><span class='field-name'>Model</span></td>
+            <td>The model to run. The list shows the models that the selected provider offers.</td>
+        </tr>
+    </tbody>
+</table>
+<ol start='3'>
+  <li>Click <span class="button-name">Save</span>.</li>
+</ol>
+
+<h4>Update or Delete a Secret</h4>
+<p>
+  On the <span class="page-section-name">Secrets</span> page, each secret has <span class="button-name">Update</span> and <span class="button-name">Delete</span> actions.
+  Click <span class="button-name">Update</span> to edit the secret configuration.
+  Because the token and its configuration are saved together, leave the <span class="field-name">Token</span> field blank to keep the current value, or re-enter the token to change any configuration below it.
+  Click <span class="button-name">Delete</span> to remove the secret.
+</p>
+
+<h4>Use a Secret</h4>
+<p>To run an Assistant on a secret, associate the secret with the Assistant in one of the following ways:</p>
+<ul>
+  <li>
+    When you <a href='/docs/v2/ai-assistance/assistants#10-Add-Assistants'>add</a> or <a href='/docs/v2/ai-assistance/assistants#11-Update-Assistants'>update</a> an Assistant, in the <span class='page-section-name'>Provider</span> section click <span class='box-name'>Use Your Own Provider</span> and select the secret from the <span class='field-name'>Provider Token</span> dropdown.
+  </li>
+  <li>
+    When you deploy an Assistant, click <span class='button-name'>Configure</span>, select <span class='box-name'>Bring your own token</span>, and select the secret from the <span class='field-name'>Secret</span> dropdown.
+  </li>
+</ul>
+<p>In either dropdown, select <span class='button-name'>Create new secret</span> to add a secret without leaving the Assistant.</p>
+<p>Keep the following in mind when you use a secret:</p>
+<ul>
+  <li>When you run an <a href='/docs/v2/ai-assistance/assistant-teams'>Assistant Team</a>, the orchestrator's secret is used for the whole team.</li>
+  <li>You cannot change the secret after you deploy a task. To use a different secret, start a new task.</li>
+</ul>

--- a/09 AI Assistance/07 Bring Your Own Key/03 Claude.html
+++ b/09 AI Assistance/07 Bring Your Own Key/03 Claude.html
@@ -2,5 +2,5 @@
 <ol>
   <li><a href="https://platform.claude.com/login" rel="nofollow" target="_blank">Log in or create an account</a> on the Claude Console.</li>
   <li>On the <a href="https://platform.claude.com/settings/keys" rel="nofollow" target="_blank">API Keys</a> page, click <span class="button-name">Create Key</span>.</li>
-  <li>Copy the key and paste it into the <span class="field-name">API Token</span> field in the assistant's <span class="page-section-name">Settings</span>.</li>
+  <li>Copy the key and paste it into the <span class="field-name">Token</span> field in the Organization's <span class="page-section-name">Secrets</span>.</li>
 </ol>

--- a/09 AI Assistance/07 Bring Your Own Key/04 OpenAI.html
+++ b/09 AI Assistance/07 Bring Your Own Key/04 OpenAI.html
@@ -2,5 +2,5 @@
 <ol>
   <li><a href="https://platform.openai.com/login" rel="nofollow" target="_blank">Log in or create an account</a> on the OpenAI Platform.</li>
   <li>On the <a href="https://platform.openai.com/api-keys" rel="nofollow" target="_blank">API keys</a> page, click <span class="button-name">Create new secret key</span>.</li>
-  <li>Copy the key and paste it into the <span class="field-name">API Token</span> field in the assistant's <span class="page-section-name">Settings</span>.</li>
+  <li>Copy the key and paste it into the <span class="field-name">Token</span> field in the Organization's <span class="page-section-name">Secrets</span>.</li>
 </ol>

--- a/09 AI Assistance/07 Bring Your Own Key/05 OpenRouter.html
+++ b/09 AI Assistance/07 Bring Your Own Key/05 OpenRouter.html
@@ -2,5 +2,5 @@
 <ol>
   <li><a href="https://openrouter.ai" rel="nofollow" target="_blank">Log in or create an account</a> on OpenRouter.</li>
   <li>On the <a href="https://openrouter.ai/keys" rel="nofollow" target="_blank">Keys</a> page, click <span class="button-name">Create Key</span>.</li>
-  <li>Copy the key and paste it into the <span class="field-name">API Token</span> field in the assistant's <span class="page-section-name">Settings</span>.</li>
+  <li>Copy the key and paste it into the <span class="field-name">Token</span> field in the Organization's <span class="page-section-name">Secrets</span>.</li>
 </ol>

--- a/09 AI Assistance/07 Bring Your Own Key/metadata.json
+++ b/09 AI Assistance/07 Bring Your Own Key/metadata.json
@@ -2,7 +2,7 @@
     "type": "metadata",
     "values": {
         "description": "Bring your own LLM API key to run QuantConnect Assistants on Claude, OpenAI, or OpenRouter.",
-        "keywords": "bring your own key, byok, llm api key, claude api key, openai api key, openrouter api key, quantconnect assistants",
+        "keywords": "bring your own key, byok, llm api key, claude api key, openai api key, openrouter api key, quantconnect assistants, secrets, llm provider token",
         "og:description": "Bring your own LLM API key to run QuantConnect Assistants on Claude, OpenAI, or OpenRouter.",
         "og:title": "Bring Your Own Key - Documentation QuantConnect.com",
         "og:type": "website",


### PR DESCRIPTION
## Summary

Documents the new organization **Secrets** page under **AI Assistance > Bring Your Own Key** and reconciles the surrounding pages with the secrets-based flow.

- **New** `02 Secrets.html` — how to view, add, update, and delete organization secrets, and how to use a secret in an Assistant (Provider Token dropdown and the Configure → Bring your own token flow when deploying). Also notes that an Assistant Team uses the orchestrator's secret and that a secret cannot be changed after a task is deployed.
- **Renamed** the provider pages so Secrets slots in at `02`: Claude → `03`, OpenAI → `04`, OpenRouter → `05`, and updated each to point to the Secrets **Token** field instead of an assistant **API Token** field.
- **Updated** `01 Introduction.html` — the provider, API key, and model now live in a secret; the settings table keeps only Reasoning Effort, Max Turns, and Tool Choice.
- **Updated** `02 Assistants/10 Add Assistants.html` — "API key" now links to the Secrets section.
- **Updated** `metadata.json` keywords.

## Test plan

- Verify the new **02 Secrets** section renders and the intra-page anchor links (`#02-Secrets`, assistants add/update, assistant-teams) resolve.
- Confirm the provider pages appear in order 03/04/05 with the updated Token/Secrets wording.
- Confirm the Introduction table lists only Reasoning Effort, Max Turns, Tool Choice.