### PR TITLE
Fix broken algorithm parameters link in Bulk Downloads examples (#2563)

### DIFF
--- a/03 Writing Algorithms/16 Importing Data/03 Bulk Downloads/99 Examples.html
+++ b/03 Writing Algorithms/16 Importing Data/03 Bulk Downloads/99 Examples.html
@@ -19,7 +19,7 @@
   Signature Version 4
  </a>
  authentication headers. The following algorithm signs the request and downloads a CSV file. To keep your secret keys out of source control, read the credentials from
- <a href="/docs/v2/writing-algorithms/key-concepts/algorithm-parameters">
+ <a href="/docs/v2/writing-algorithms/optimization/parameters">
   algorithm parameters
  </a>
  instead of hardcoding them.


### PR DESCRIPTION
## Summary
- The Bulk Downloads examples page linked "algorithm parameters" to `/docs/v2/writing-algorithms/key-concepts/algorithm-parameters`, which is a soft 404.
- Updated the link to the canonical parameters page `/docs/v2/writing-algorithms/optimization/parameters` (folder `30 Optimization/01 Parameters`), matching how other pages reference it.

Resolves #2563

## Test plan
- [ ] Verify the page renders correctly on quantconnect.com/docs
- [ ] Confirm the "algorithm parameters" link resolves to the Optimization > Parameters page
- [ ] Run `python url_check.py` to confirm the broken link is resolved