### PR TITLE
Add note about Object Store usage update delay

### DIFF
--- a/Resources/object-store/view-cloud-storage.php
+++ b/Resources/object-store/view-cloud-storage.php
@@ -1,6 +1,8 @@
 <p>The Object Store page shows all the data your organization has in the Object Store. To view the page, log in to the Algorithm Lab and then, in the left navigation bar, click <a href="/organization/object-store" class='menu-name'>Organization &gt; Object Store</a>.</p>
 
-<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/view-cloud-platform-object-store.png' alt='Table of files and their sizes'> 
+<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/view-cloud-platform-object-store.png' alt='Table of files and their sizes'>
+
+<p>The displayed usage takes some time (about one hour) to reflect the actual value after you add or remove files.</p>
 
 <p>To view the metadata of a file (including it's path, size, and a content preview), click one of the files in the table.</p>
 


### PR DESCRIPTION
## Summary
Adds a paragraph to the Object Store cloud storage page clarifying that the displayed usage takes about an hour to reflect the actual value after files are added or removed.

## Test plan
- Verify the new paragraph renders after the first image on the Object Store view page.