### PR TITLE
Fix Public troubleshooting table layout

### DIFF
--- a/Resources/brokerages/public/troubleshooting.html
+++ b/Resources/brokerages/public/troubleshooting.html
@@ -9,7 +9,7 @@
     </thead>
     <tbody>
         <tr>
-            <td nowrap>
+            <td>
                 <div class="error-messages">A deposit of $&lt;amount&gt; is required to place this order</div>
             </td>
             <td>
@@ -17,7 +17,7 @@
             </td>
         </tr>
         <tr>
-            <td nowrap>
+            <td>
                 <div class="error-messages">You can have up to 10 pending orders opening new positions on the same underlying</div>
             </td>
             <td>
@@ -25,7 +25,7 @@
             </td>
         </tr>
         <tr>
-            <td nowrap>
+            <td>
                 <div class="error-messages">Short selling require margin</div>
             </td>
             <td>


### PR DESCRIPTION
## Summary

Removes `nowrap` from the error-message cells in the Public brokerage Troubleshooting table. Public's error messages are full sentences, so `nowrap` forced the first column to its full unwrapped width and crushed the "Possible Cause and Fix" column into a sliver. Without it, both columns wrap naturally, matching the Charles Schwab troubleshooting table, which also has sentence-length messages.

## Test Plan

- Table now follows the same markup as `Resources/brokerages/charles-schwab/troubleshooting.html` (long messages, no `nowrap`), which renders with balanced columns on the live site.