### PR TITLE
Fix custom-indicator skill

### DIFF
--- a/skill-templates/indicators/custom-indicator/SKILL.md
+++ b/skill-templates/indicators/custom-indicator/SKILL.md
@@ -15,7 +15,7 @@ Ask the user: (1) indicator name; (2) formula/logic; (3) input type -- `Indicato
 ## Step 2 -- Generate the Code
 
 Python: `from AlgorithmImports import *` only. Inherit `PythonIndicator`. File: `snake_case.py` in its own file.
-C#: inherit `Indicator` (or `BarIndicator` for OHLCV). Set `WarmUpPeriod` in constructor. File: `PascalCase.cs`.
+C#: inherit `Indicator` (or `BarIndicator` for OHLCV). Declare a `WarmUpPeriod` property (implement `IIndicatorWarmUpPeriodProvider`). File: `PascalCase.cs`.
 Manual warm-up (default): loop py`self.history[TradeBar](symbol, period + 1)`cs`History<TradeBar>(symbol, period + 1, Resolution.Daily)`, call py`indicator.update(bar)`cs`indicator.Update(bar)` before py`self.register_indicator`cs`RegisterIndicator`.
 Automatic warm-up: py`self.settings.automatic_indicator_warm_up = True`cs`Settings.AutomaticIndicatorWarmUp = true` in py`initialize`cs`Initialize`.
 
@@ -37,13 +37,13 @@ class CustomVolatility(PythonIndicator):
         return self._window.is_ready
 ```
 ```csharp
-public class CustomVolatility : Indicator
+public class CustomVolatility : Indicator, IIndicatorWarmUpPeriodProvider
 {
     private readonly RollingWindow<decimal> _window;
+    public int WarmUpPeriod => _window.Size;
     public CustomVolatility(int period) : base("CustomVolatility")
     {
         _window = new RollingWindow<decimal>(period);
-        WarmUpPeriod = period;
     }
     public override bool IsReady => _window.IsReady;
     protected override decimal ComputeNextValue(IndicatorDataPoint input)

--- a/skill-templates/indicators/custom-indicator/SKILL.md
+++ b/skill-templates/indicators/custom-indicator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: custom-indicator
 description: >
-  Creates a custom indicator class in QuantConnect/LEAN. Invoke for "create a custom indicator", "implement [name] indicator", "I need an indicator LEAN doesn't have", "PythonIndicator", "custom indicator class". Skip for LEAN built-ins (SMA, EMA, RSI).
+  Creates a custom indicator class in QuantConnect/LEAN. Invoke for "create a custom indicator", "implement [name] indicator", "I need an indicator LEAN doesn't have", py`PythonIndicator`cs`ComputeNextValue`, "custom indicator class". Skip for LEAN built-ins (SMA, EMA, RSI).
 ---
 
 # /custom-indicator -- QuantConnect Custom Indicator
@@ -14,8 +14,12 @@ Ask the user: (1) indicator name; (2) formula/logic; (3) input type -- `Indicato
 
 ## Step 2 -- Generate the Code
 
+<!-- python-only -->
 Python: `from AlgorithmImports import *` only. Inherit `PythonIndicator`. File: `snake_case.py` in its own file.
+<!-- /python-only -->
+<!-- csharp-only -->
 C#: inherit `Indicator` (or `BarIndicator` for OHLCV). Declare a `WarmUpPeriod` property (implement `IIndicatorWarmUpPeriodProvider`). File: `PascalCase.cs`.
+<!-- /csharp-only -->
 Manual warm-up (default): loop py`self.history[TradeBar](symbol, period + 1)`cs`History<TradeBar>(symbol, period + 1, Resolution.Daily)`, call py`indicator.update(bar)`cs`indicator.Update(bar)` before py`self.register_indicator`cs`RegisterIndicator`.
 Automatic warm-up: py`self.settings.automatic_indicator_warm_up = True`cs`Settings.AutomaticIndicatorWarmUp = true` in py`initialize`cs`Initialize`.
 
@@ -55,7 +59,9 @@ public class CustomVolatility : Indicator, IIndicatorWarmUpPeriodProvider
     }
 }
 ```
+<!-- csharp-only -->
 For OHLCV in C#, inherit `BarIndicator` and use `IBaseDataBar` in `ComputeNextValue`.
+<!-- /csharp-only -->
 
 ### Single-symbol integration
 ```python
@@ -86,13 +92,17 @@ def on_securities_changed(self, changes):
         self.deregister_indicator(security.indicator)
         self.liquidate(security)
 ```
-C# mirrors Python: use `OnSecuritiesChanged`, `RegisterIndicator`, `DeregisterIndicator`, `Liquidate`. Gate reads on `_indicators[symbol].IsReady`.
+<!-- csharp-only -->
+In `OnSecuritiesChanged`, create and warm the indicator for each added security, then `RegisterIndicator`; on removal, `DeregisterIndicator` and `Liquidate`. Track them in a `Dictionary<Symbol, CustomVolatility>` and gate reads on `_indicators[symbol].IsReady`.
+<!-- /csharp-only -->
 
 ## Step 3 -- Write Files via MCP
 
 1. `quantconnect:create_file` with the indicator class.
-2. `quantconnect:update_file_contents` for `main.py` / `Main.cs`.
+2. `quantconnect:update_file_contents` for py`main.py`cs`Main.cs`.
+<!-- python-only -->
 3. Python only: add `from custom_volatility import CustomVolatility` after `from AlgorithmImports import *`.
+<!-- /python-only -->
 
 ## Step 4 -- Compile
 

--- a/skills/csharp/indicators/custom-indicator/SKILL.md
+++ b/skills/csharp/indicators/custom-indicator/SKILL.md
@@ -15,19 +15,19 @@ Ask the user: (1) indicator name; (2) formula/logic; (3) input type -- `Indicato
 ## Step 2 -- Generate the Code
 
 Python: `from AlgorithmImports import *` only. Inherit `PythonIndicator`. File: `snake_case.py` in its own file.
-C#: inherit `Indicator` (or `BarIndicator` for OHLCV). Set `WarmUpPeriod` in constructor. File: `PascalCase.cs`.
+C#: inherit `Indicator` (or `BarIndicator` for OHLCV). Declare a `WarmUpPeriod` property (implement `IIndicatorWarmUpPeriodProvider`). File: `PascalCase.cs`.
 Manual warm-up (default): loop `History<TradeBar>(symbol, period + 1, Resolution.Daily)`, call `indicator.Update(bar)` before `RegisterIndicator`.
 Automatic warm-up: `Settings.AutomaticIndicatorWarmUp = true` in `Initialize`.
 
 ### Indicator class
 ```csharp
-public class CustomVolatility : Indicator
+public class CustomVolatility : Indicator, IIndicatorWarmUpPeriodProvider
 {
     private readonly RollingWindow<decimal> _window;
+    public int WarmUpPeriod => _window.Size;
     public CustomVolatility(int period) : base("CustomVolatility")
     {
         _window = new RollingWindow<decimal>(period);
-        WarmUpPeriod = period;
     }
     public override bool IsReady => _window.IsReady;
     protected override decimal ComputeNextValue(IndicatorDataPoint input)

--- a/skills/csharp/indicators/custom-indicator/SKILL.md
+++ b/skills/csharp/indicators/custom-indicator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: custom-indicator
 description: >
-  Creates a custom indicator class in QuantConnect/LEAN. Invoke for "create a custom indicator", "implement [name] indicator", "I need an indicator LEAN doesn't have", "PythonIndicator", "custom indicator class". Skip for LEAN built-ins (SMA, EMA, RSI).
+  Creates a custom indicator class in QuantConnect/LEAN. Invoke for "create a custom indicator", "implement [name] indicator", "I need an indicator LEAN doesn't have", `ComputeNextValue`, "custom indicator class". Skip for LEAN built-ins (SMA, EMA, RSI).
 ---
 
 # /custom-indicator -- QuantConnect Custom Indicator
@@ -14,7 +14,6 @@ Ask the user: (1) indicator name; (2) formula/logic; (3) input type -- `Indicato
 
 ## Step 2 -- Generate the Code
 
-Python: `from AlgorithmImports import *` only. Inherit `PythonIndicator`. File: `snake_case.py` in its own file.
 C#: inherit `Indicator` (or `BarIndicator` for OHLCV). Declare a `WarmUpPeriod` property (implement `IIndicatorWarmUpPeriodProvider`). File: `PascalCase.cs`.
 Manual warm-up (default): loop `History<TradeBar>(symbol, period + 1, Resolution.Daily)`, call `indicator.Update(bar)` before `RegisterIndicator`.
 Automatic warm-up: `Settings.AutomaticIndicatorWarmUp = true` in `Initialize`.
@@ -51,13 +50,12 @@ RegisterIndicator(symbol, _indicator);
 ```
 
 ### Universe integration
-C# mirrors Python: use `OnSecuritiesChanged`, `RegisterIndicator`, `DeregisterIndicator`, `Liquidate`. Gate reads on `_indicators[symbol].IsReady`.
+In `OnSecuritiesChanged`, create and warm the indicator for each added security, then `RegisterIndicator`; on removal, `DeregisterIndicator` and `Liquidate`. Track them in a `Dictionary<Symbol, CustomVolatility>` and gate reads on `_indicators[symbol].IsReady`.
 
 ## Step 3 -- Write Files via MCP
 
 1. `quantconnect:create_file` with the indicator class.
-2. `quantconnect:update_file_contents` for `main.py` / `Main.cs`.
-3. Python only: add `from custom_volatility import CustomVolatility` after `from AlgorithmImports import *`.
+2. `quantconnect:update_file_contents` for `Main.cs`.
 
 ## Step 4 -- Compile
 

--- a/skills/python/indicators/custom-indicator/SKILL.md
+++ b/skills/python/indicators/custom-indicator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: custom-indicator
 description: >
-  Creates a custom indicator class in QuantConnect/LEAN. Invoke for "create a custom indicator", "implement [name] indicator", "I need an indicator LEAN doesn't have", "PythonIndicator", "custom indicator class". Skip for LEAN built-ins (SMA, EMA, RSI).
+  Creates a custom indicator class in QuantConnect/LEAN. Invoke for "create a custom indicator", "implement [name] indicator", "I need an indicator LEAN doesn't have", `PythonIndicator`, "custom indicator class". Skip for LEAN built-ins (SMA, EMA, RSI).
 ---
 
 # /custom-indicator -- QuantConnect Custom Indicator
@@ -15,7 +15,6 @@ Ask the user: (1) indicator name; (2) formula/logic; (3) input type -- `Indicato
 ## Step 2 -- Generate the Code
 
 Python: `from AlgorithmImports import *` only. Inherit `PythonIndicator`. File: `snake_case.py` in its own file.
-C#: inherit `Indicator` (or `BarIndicator` for OHLCV). Declare a `WarmUpPeriod` property (implement `IIndicatorWarmUpPeriodProvider`). File: `PascalCase.cs`.
 Manual warm-up (default): loop `self.history[TradeBar](symbol, period + 1)`, call `indicator.update(bar)` before `self.register_indicator`.
 Automatic warm-up: `self.settings.automatic_indicator_warm_up = True` in `initialize`.
 
@@ -36,8 +35,6 @@ class CustomVolatility(PythonIndicator):
     def is_ready(self) -> bool:
         return self._window.is_ready
 ```
-For OHLCV in C#, inherit `BarIndicator` and use `IBaseDataBar` in `ComputeNextValue`.
-
 ### Single-symbol integration
 ```python
 def initialize(self):
@@ -59,12 +56,11 @@ def on_securities_changed(self, changes):
         self.deregister_indicator(security.indicator)
         self.liquidate(security)
 ```
-C# mirrors Python: use `OnSecuritiesChanged`, `RegisterIndicator`, `DeregisterIndicator`, `Liquidate`. Gate reads on `_indicators[symbol].IsReady`.
 
 ## Step 3 -- Write Files via MCP
 
 1. `quantconnect:create_file` with the indicator class.
-2. `quantconnect:update_file_contents` for `main.py` / `Main.cs`.
+2. `quantconnect:update_file_contents` for `main.py`.
 3. Python only: add `from custom_volatility import CustomVolatility` after `from AlgorithmImports import *`.
 
 ## Step 4 -- Compile

--- a/skills/python/indicators/custom-indicator/SKILL.md
+++ b/skills/python/indicators/custom-indicator/SKILL.md
@@ -15,7 +15,7 @@ Ask the user: (1) indicator name; (2) formula/logic; (3) input type -- `Indicato
 ## Step 2 -- Generate the Code
 
 Python: `from AlgorithmImports import *` only. Inherit `PythonIndicator`. File: `snake_case.py` in its own file.
-C#: inherit `Indicator` (or `BarIndicator` for OHLCV). Set `WarmUpPeriod` in constructor. File: `PascalCase.cs`.
+C#: inherit `Indicator` (or `BarIndicator` for OHLCV). Declare a `WarmUpPeriod` property (implement `IIndicatorWarmUpPeriodProvider`). File: `PascalCase.cs`.
 Manual warm-up (default): loop `self.history[TradeBar](symbol, period + 1)`, call `indicator.update(bar)` before `self.register_indicator`.
 Automatic warm-up: `self.settings.automatic_indicator_warm_up = True` in `initialize`.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The C# custom-indicator skill has a compile error in it.
The skill-template didn't properly gate the content of each language, so the python and C# version of the skill mentioned both languages.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The Indicator base class has no settable WarmUpPeriod member, so the CustomVolatility example failed to compile. Implement IIndicatorWarmUpPeriodProvider and declare WarmUpPeriod as a read-only property, matching the Custom Indicators documentation, so WarmUpIndicator and automatic indicator warm-up can use it.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
