### PR TITLE
Add equity-options and option-strategies skills

### DIFF
--- a/skill-templates/equity-options/SKILL.md
+++ b/skill-templates/equity-options/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: equity-options
+description: Use when an algorithm trades options on a SINGLE named underlying Equity — subscribing (py`add_option`cs`AddOption` vs py`add_option_contract`cs`AddOptionContract`), reading the chain (the slice's py`option_chains`cs`OptionChains` vs the py`option_chain()`cs`OptionChain()` method), greeks/IV data freshness, strike/expiry filters, price seeding, and warm-up. Triggers — code calling any of those four APIs; questions like "why are my deltas/IV stale", "why can't I trade the contract I just added", "why is the chain empty", "which API gives decision-time greeks". Skip when — options on a DYNAMIC equity universe (see chained-universes-options), historical/backfilled option data for past dates (see historical-data-equity-options), or multi-leg order placement and assignment/exercise handling (see option-strategies).
+---
+
+# Equity Options: subscriptions and chain data — QuantConnect / LEAN
+
+Two decisions shape every equity-options algorithm, and each has two answers that look interchangeable but carry different data: **how you subscribe** (py`add_option`cs`AddOption` vs py`add_option_contract`cs`AddOptionContract`) and **how you read the chain** (the slice's py`option_chains`cs`OptionChains` vs the py`option_chain()`cs`OptionChain()` method). Picking the wrong member of either pair produces algorithms that trade on day-old numbers without any error.
+
+## Greeks/IV freshness — the core rule
+
+There are two different option datasets behind the APIs (doc: "There is a daily, pre-calculated dataset based on the end of the previous trading day. There is also a stream of values that are calculated on-the-fly as your algorithm runs."):
+
+| Access path | Data you get |
+|---|---|
+| py`option.set_filter(...)`cs`option.SetFilter(...)` filter function (incl. py`.delta()/.iv()`cs`.Delta()/.IV()` filters) | "daily, pre-calculated values based on the end of the **previous trading day**" — not customizable |
+| py`self.option_chain(symbol)`cs`OptionChain(symbol)` method | same prior-day EOD pre-calculated values; returns **all tradable contracts**, not just your filter's picks |
+| py`self.history[OptionUniverse](...)`cs`History<OptionUniverse>(...)` | same prior-day EOD values, one full chain per trading day |
+| the slice: py`data.option_chains`cs`data.OptionChains` (or py`self.current_slice.option_chains`cs`CurrentSlice.OptionChains`) | **current values from the Option price model**, computed on request against live data — customizable via py`option.price_model`cs`option.PriceModel` |
+
+The operating rule that follows: **any intraday decision — entry sizing, delta hedging, IV-threshold checks, strike selection at a decision time — should read the slice's chain.** The py`option_chain()`cs`OptionChain()` method is for **daily contract discovery** (find which contracts exist, filter by prior-day delta/OI, then subscribe); using it for intraday sizing or greeks means every number is one day stale, and nothing errors to tell you. Greeks on slice contracts are computed lazily — accessing py`greeks`cs`Greeks` costs nothing; accessing py`greeks.delta`cs`Greeks.Delta` triggers the calculation — so only read the greeks you need.
+
+## Subscription route 1: py`add_option`cs`AddOption` — a filtered basket (universe)
+
+For strategies that pick contracts from a chain at decision time (spreads, condors, straddles, rolling structures), subscribe once in py`initialize`cs`Initialize`:
+
+```python
+self.universe_settings.asynchronous = True
+option = self.add_option("SPY")                 # underlying auto-subscribed RAW
+option.set_filter(lambda u: u.include_weeklys().strikes(-3, 3).expiration(15, 60))
+self._symbol = option.symbol                    # canonical Symbol — save it
+```
+```csharp
+UniverseSettings.Asynchronous = true;
+var option = AddOption("SPY");                  // underlying auto-subscribed RAW
+option.SetFilter(u => u.IncludeWeeklys().Strikes(-3, 3).Expiration(15, 60));
+_symbol = option.Symbol;                        // canonical Symbol — save it
+```
+
+- **The canonical py`option.symbol`cs`option.Symbol` is not tradable** — it is the key into py`data.option_chains`cs`data.OptionChains` and the first argument of every `OptionStrategies` factory.
+- **Filter timing**: selection "usually runs at the first bar of every day"; a newly selected contract's data arrives "in the next `Slice`". So the chain can be absent on any given event — always guard: py`chain = data.option_chains.get(self._symbol); if not chain: return`cs`if (!data.OptionChains.TryGetValue(_symbol, out var chain)) return;`.
+- **Default filter** if you never call py`set_filter`cs`SetFilter`: standards + weeklys, within 1 strike of the underlying price, expiring within 35 days — almost never what a spec wants; set the filter explicitly.
+- Filter building blocks: py`strikes(min, max)`cs`Strikes(min, max)` (relative strike counts around the money, not dollars), py`expiration(min_days, max_days)`cs`Expiration(minDays, maxDays)`, py`calls_only()/puts_only()`cs`CallsOnly()/PutsOnly()`, py`weeklys_only()/standards_only()/include_weeklys()`cs`WeeklysOnly()/StandardsOnly()/IncludeWeeklys()`, py`front_month()/back_month()`cs`FrontMonth()/BackMonth()`, greek/OI filters py`delta(min, max)`cs`Delta(min, max)`, py`iv(min, max)`cs`IV(min, max)`, py`open_interest(min, max)`cs`OpenInterest(min, max)` (these compare **prior-day EOD** values — use them for coarse pre-selection, then pick precisely from live slice greeks), and strategy-shaped helpers (py`u.straddle(30)`cs`u.Straddle(30)`, py`u.iron_condor(30, 5, 10)`cs`u.IronCondor(30, 5, 10)`) that narrow the universe to exactly the legs a named strategy needs.
+- **Resolution rule**: the option resolution must be ≥ the underlying Equity's resolution (minute equity → minute/hour/daily options). Contract subscriptions support minute, hour, and daily; minute is the default.
+
+Reading the chain at a decision time:
+
+```python
+def on_data(self, data: Slice) -> None:
+    chain = data.option_chains.get(self._symbol)
+    if not chain:
+        return
+    spot = chain.underlying.price
+    atm_call = min((c for c in chain if c.right == OptionRight.CALL),
+                   key=lambda c: abs(c.strike - spot))
+    delta = atm_call.greeks.delta        # live price-model value, computed on request
+    mid = (atm_call.bid_price + atm_call.ask_price) / 2
+```
+```csharp
+public override void OnData(Slice data)
+{
+    if (!data.OptionChains.TryGetValue(_symbol, out var chain)) return;
+    var spot = chain.Underlying.Price;
+    var atmCall = chain.Where(c => c.Right == OptionRight.Call)
+        .OrderBy(c => Math.Abs(c.Strike - spot)).First();
+    var delta = atmCall.Greeks.Delta;    // live price-model value, computed on request
+    var mid = (atmCall.BidPrice + atmCall.AskPrice) / 2;
+}
+```
+
+In a Scheduled Event there is no slice parameter — read the same object through py`self.current_slice.option_chains`cs`CurrentSlice.OptionChains`.
+
+## Subscription route 2: py`add_option_contract`cs`AddOptionContract` — individual known contracts
+
+For strategies that hold a few specific contracts found by daily screening, discover with the py`option_chain()`cs`OptionChain()` method, then subscribe each pick:
+
+```python
+# In a scheduled event — option_chain() carries PRIOR-DAY EOD greeks: fine for
+# discovering contracts, wrong for intraday sizing or hedging.
+chain = self.option_chain(self._underlying, flatten=True).data_frame
+expiry = chain.expiry.min()
+symbol = chain[(chain.expiry == expiry) & (chain.right == OptionRight.CALL) &
+               (chain.delta > 0.3)].sort_values("openinterest").index[-1]
+self.add_option_contract(symbol)
+```
+```csharp
+// In a scheduled event — OptionChain() carries PRIOR-DAY EOD greeks: fine for
+// discovering contracts, wrong for intraday sizing or hedging.
+var chain = OptionChain(_underlying);
+var expiry = chain.Min(c => c.Expiry);
+var symbol = chain
+    .Where(c => c.Expiry == expiry && c.Right == OptionRight.Call && c.Greeks.Delta > 0.3m)
+    .OrderBy(c => c.OpenInterest).Last().Symbol;
+AddOptionContract(symbol);
+```
+
+The three idioms that must accompany this route:
+
+1. **Seed prices** — a contract subscribed this time step has no data until the next slice ("you'll need to wait until the next `Slice` to receive data and trade the contract"). Set py`self.settings.seed_initial_prices = True`cs`Settings.SeedInitialPrices = true;` in py`initialize`cs`Initialize` to trade it immediately.
+2. **RAW underlying** — subscribe the underlying with py`self.add_equity("SPY", data_normalization_mode=DataNormalizationMode.RAW)`cs`AddEquity("SPY", dataNormalizationMode: DataNormalizationMode.Raw)` so strike-vs-price comparisons share a scale. If you skip this, LEAN auto-subscribes (or force-switches an existing subscription) to RAW anyway — see the history caveat below.
+3. **Volatility warm-up** — py`set_warm_up`cs`SetWarmUp` in py`initialize`cs`Initialize` cannot anticipate contracts added later; warm the underlying's volatility model in a security initializer (feed ~30 daily bars through py`security.volatility_model.update(...)`cs`security.VolatilityModel.Update(...)`) so slice-chain IV/greeks are sane from the first read. On the py`add_option`cs`AddOption` route the simple py`self.set_warm_up(31, Resolution.DAILY)`cs`SetWarmUp(31, Resolution.Daily)` suffices (default volatility model needs 30+1 daily bars).
+
+To read a subscribed contract from the slice, index the chain with the **canonical**: py`data.option_chains.get(self._contract_symbol.canonical)`cs`data.OptionChains.TryGetValue(_contractSymbol.Canonical, out var chain)`. py`remove_option_contract(symbol)`cs`RemoveOptionContract(symbol)` cancels its open orders and liquidates the position.
+
+## The RAW-underlying history caveat
+
+Because any option subscription forces the underlying Equity to RAW normalization, a py`history()`cs`History()` call on that underlying now returns **raw closes** — dividend gaps included. Any realized-volatility, daily-return, or overnight-gap calculation on an option underlying must request adjusted data explicitly: py`self.history(self._underlying, 22, Resolution.DAILY, data_normalization_mode=DataNormalizationMode.ADJUSTED)`cs`History(_underlying, 22, Resolution.Daily, dataNormalizationMode: DataNormalizationMode.Adjusted)`. Do not "fix" this by subscribing the underlying ADJUSTED — LEAN silently switches it back to RAW.
+
+## Common mistakes
+
+- **Sizing or hedging from py`option_chain()`cs`OptionChain()` intraday.** Its marks and greeks are the previous close; position sizes computed from them are provably off versus decision-time quotes. Decision-time numbers come from the slice's chain.
+- **Trading the canonical symbol**, or passing a contract symbol where the canonical is required (chain lookup, `OptionStrategies` factories).
+- **No py`if not chain:`cs`TryGetValue` guard** — the chain is legitimately absent before the first daily selection and whenever the filter turns over.
+- **Forgetting py`include_weeklys()`cs`IncludeWeeklys()`** when a spec's DTE window (e.g. 21–45 days, closest to 30) needs weekly expiries to hit its target.
+- **Computing RV/returns on the force-RAW underlying** without an explicit adjusted-normalization history request.
+- Only American-style US equity options are supported; strikes in the filter API are **relative counts**, not dollar offsets — py`strikes(-1, 1)`cs`Strikes(-1, 1)` means one strike either side of the money.

--- a/skill-templates/option-strategies/SKILL.md
+++ b/skill-templates/option-strategies/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: option-strategies
+description: Use when placing or managing MULTI-LEG option positions and the option lifecycle in QuantConnect/LEAN — the `OptionStrategies` factory + py`buy/sell`cs`Buy/Sell` route, combo orders (py`combo_market_order`cs`ComboMarketOrder`, py`combo_limit_order`cs`ComboLimitOrder`, py`combo_leg_limit_order`cs`ComboLegLimitOrder`), position-group margin, early assignment, exercise, and expiry cleanup. Triggers — iron condor / straddle / strangle / spread / butterfly / calendar / collar / covered-call code; questions like "how do I place all four legs at once", "why was my short option assigned", "what happens to my position at expiry", "why did my algorithm stop trading after expiry". Skip when — chain subscriptions and greeks freshness (see equity-options), single-leg orders (see orders), historical option data (see historical-data-equity-options).
+---
+
+# Option strategies and the option lifecycle — QuantConnect / LEAN
+
+## Placing multi-leg positions: two documented routes, no third
+
+**Route A — `OptionStrategies` factory + py`buy`cs`Buy`.** One call builds the whole structure from the **canonical** option symbol (saved from py`option = self.add_option(...); self._symbol = option.symbol`cs`var option = AddOption(...); _symbol = option.Symbol;`) plus strikes/expiries — no contract symbols needed, all legs placed atomically:
+
+```python
+strategy = OptionStrategies.iron_condor(self._symbol, far_put, near_put, near_call, far_call, expiry)
+self.buy(strategy, 2)     # 2 condors; sell(strategy, q) inverts every leg
+```
+```csharp
+var strategy = OptionStrategies.IronCondor(_symbol, farPut, nearPut, nearCall, farCall, expiry);
+Buy(strategy, 2);         // 2 condors; Sell(strategy, q) inverts every leg
+```
+
+Both directions of every structure have their own factory (py`straddle`cs`Straddle` / py`short_straddle`cs`ShortStraddle`, py`iron_condor`cs`IronCondor` / py`short_iron_condor`cs`ShortIronCondor`) and a "short_" factory is still placed with py`buy`cs`Buy`. The catalogue (py`snake_case`cs`PascalCase` members of `OptionStrategies`): bear/bull call/put spreads; long/short call/put butterflies (strike order **higher, ATM, lower**); long/short call/put calendar spreads (py`(strike, near_expiry, far_expiry)`cs`(strike, nearExpiry, farExpiry)`); covered/naked/protective calls and puts; protective collar; conversion/reverse conversion; long/short straddles and strangles; long/short iron butterflies and iron condors (strikes ascending); long/short box spreads; long/short jelly rolls; bear/bull call/put ladders; long/short call/put backspreads. Covered/protective/conversion structures embed the underlying — buying one unit of py`covered_call`cs`CoveredCall` is long 100 shares + short 1 call.
+
+**Route B — combo orders.** Build py`Leg.create(symbol, ratio)`cs`Leg.Create(symbol, ratio)` lists from actual contract symbols when you need custom ratios, a leg set no factory matches, or limit pricing:
+
+```python
+legs = [Leg.create(short_call.symbol, -1), Leg.create(long_call.symbol, 1)]
+tickets = self.combo_market_order(legs, quantity)      # one ticket per leg
+```
+```csharp
+var legs = new List<Leg> { Leg.Create(shortCall.Symbol, -1), Leg.Create(longCall.Symbol, 1) };
+var tickets = ComboMarketOrder(legs, quantity);        // one ticket per leg
+```
+
+- Leg quantities set the **ratio**; the order's `quantity` argument is a global multiplier and sets the combo's direction. At least one positive and one negative leg; each leg a unique contract.
+- py`combo_limit_order(legs, quantity, limit_price)`cs`ComboLimitOrder(legs, quantity, limitPrice)` — one **net** price for the package, legs fill together when the combined price crosses it; the only combo type documented to also accept an underlying-equity leg. py`combo_leg_limit_order`cs`ComboLegLimitOrder` — per-leg limits via the third argument of py`Leg.create`cs`Leg.Create`; each leg fills on its own limit. Both are updatable through the leg tickets until filled.
+- Combo orders are synchronous by default with a 5-second wait (extend via py`self.transactions.market_order_fill_timeout`cs`Transactions.MarketOrderFillTimeout`); pass py`asynchronous=True`cs`asynchronous: true` to fire-and-continue. Marketable combos on illiquid OTM contracts "may take a few minutes to fill".
+
+**There is no route C.** Legging into a multi-leg structure with sequential single market orders is not a documented pattern: it carries leg risk (partial structures during fills) and the interim one-sided position can fail margin that the complete structure would pass. Single-leg strategies (naked call/put) are the one case where a plain py`market_order`cs`MarketOrder` is the documented approach.
+
+## Margin: recognized structures are cheaper
+
+LEAN groups positions that compose a recognized strategy and margins the **group**, not the legs — the docs' example: an ITM long call ($29,150) plus an OTM short call ($101,499) margin at $130,649 separately but **$0 as a bull call spread**. Defined-risk structures (spreads, condors, butterflies) are therefore dramatically cheaper than their leg-sums; don't pre-reject a trade by summing per-leg requirements. For a pre-trade check, wrap the strategy in py`OptionStrategyPositionGroupBuyingPowerModel(strategy)`cs`new OptionStrategyPositionGroupBuyingPowerModel(strategy)` and query py`get_initial_margin_requirement(...)`cs`GetInitialMarginRequirement(...)` against py`self.portfolio.margin_remaining`cs`Portfolio.MarginRemaining` (the result is per one unit — multiply by your quantity).
+
+## Early assignment: an hourly simulation you must expect
+
+Short American options in a backtest can be assigned **before** expiry. The default py`DefaultOptionAssignmentModel`cs`DefaultOptionAssignmentModel` scans hourly and assigns a short option that is within 4 days of expiry, at least 5% in the money, and profitable to exercise after fees (European style: expiry day only). Any strategy holding short legs into that window (covered calls, short condors near expiry, diagonals) must handle assignment — or, when the strategy's rules exit before the window (e.g. manage-at-21-DTE), assignment simply never triggers. To disable the simulation deliberately: py`security.set_option_assignment_model(NullOptionAssignmentModel())`cs`(security as Option).SetOptionAssignmentModel(new NullOptionAssignmentModel());` in a security initializer.
+
+**Handle assignment in py`on_assignment_order_event`cs`OnAssignmentOrderEvent` — not by sniffing py`is_assignment`cs`IsAssignment` in the generic order-event handler.** The docs' working examples read the just-delivered share position inside the dedicated handler (holdings are current there) and clean up immediately:
+
+```python
+def on_assignment_order_event(self, assignment_event: OrderEvent) -> None:
+    shares = assignment_event.quantity * self._option.symbol_properties.contract_multiplier
+    self.market_order(assignment_event.symbol.underlying, -shares, tag="Assignment cleanup")
+```
+```csharp
+public override void OnAssignmentOrderEvent(OrderEvent assignmentEvent)
+{
+    var shares = assignmentEvent.Quantity * _option.SymbolProperties.ContractMultiplier;
+    MarketOrder(assignmentEvent.Symbol.Underlying, -shares, tag: "Assignment cleanup");
+}
+```
+
+Reacting from the generic py`on_order_event`cs`OnOrderEvent` instead has been observed to fire before the delivered shares are booked, so a holdings-based cleanup silently does nothing until a later event. Note the delivered shares appear at the **strike** price via a fill event, simultaneous with a zero-price fill that removes the option contract; assignment after the close cannot be flattened until the next session's open regardless of handler.
+
+## Expiry: LEAN acts on the contracts, not on your state
+
+At expiration LEAN auto-exercises long ITM positions ("Automatic Exercise": zero-price fill removing the contract + a strike-price fill delivering the underlying for physical settlement) and removes OTM contracts worthless. **None of your exit logic runs.** Any strategy that tracks its own open position (a `self._position` object, leg symbol fields) must clear that state when contracts expire — otherwise the algorithm believes a position is still open, its management checks keep early-returning on missing data, and it silently never trades again. If the strategy's rules are supposed to exit before expiry, treat reaching expiry as a bug signal, but still write the state-cleanup path. Manual exercise: py`self.exercise_option(contract_symbol, quantity)`cs`ExerciseOption(contractSymbol, quantity)` — long positions only, American any time, European only at expiry, rejected on insufficient capital.
+
+## Common mistakes
+
+- Selling a `short_*` factory (double inversion) — short factories are **bought**; py`sell`cs`Sell` on the long factory is the other spelling of the same trade.
+- Butterfly strike order: all four butterfly factories take **(higher, ATM, lower)** — the doc examples' variable names disagree with their own math; follow the order, not the names.
+- Passing the underlying Equity symbol or a contract symbol as a factory's first argument — it must be the **canonical** option symbol.
+- Summing per-leg margin to pre-check a defined-risk structure (position grouping makes the real requirement far lower).
+- Assignment cleanup in the generic order-event handler reading holdings that aren't updated yet — use py`on_assignment_order_event`cs`OnAssignmentOrderEvent`.
+- No expiry-slip state cleanup: position-tracking fields never cleared when contracts expire, permanently halting re-entry.
+- Pairing route A with per-leg limit prices — factories place market executions; limit pricing needs route B.

--- a/skills/csharp/equity-options/SKILL.md
+++ b/skills/csharp/equity-options/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: equity-options
+description: Use when an algorithm trades options on a SINGLE named underlying Equity — subscribing (`AddOption` vs `AddOptionContract`), reading the chain (the slice's `OptionChains` vs the `OptionChain()` method), greeks/IV data freshness, strike/expiry filters, price seeding, and warm-up. Triggers — code calling any of those four APIs; questions like "why are my deltas/IV stale", "why can't I trade the contract I just added", "why is the chain empty", "which API gives decision-time greeks". Skip when — options on a DYNAMIC equity universe (see chained-universes-options), historical/backfilled option data for past dates (see historical-data-equity-options), or multi-leg order placement and assignment/exercise handling (see option-strategies).
+---
+
+# Equity Options: subscriptions and chain data — QuantConnect / LEAN
+
+Two decisions shape every equity-options algorithm, and each has two answers that look interchangeable but carry different data: **how you subscribe** (`AddOption` vs `AddOptionContract`) and **how you read the chain** (the slice's `OptionChains` vs the `OptionChain()` method). Picking the wrong member of either pair produces algorithms that trade on day-old numbers without any error.
+
+## Greeks/IV freshness — the core rule
+
+There are two different option datasets behind the APIs (doc: "There is a daily, pre-calculated dataset based on the end of the previous trading day. There is also a stream of values that are calculated on-the-fly as your algorithm runs."):
+
+| Access path | Data you get |
+|---|---|
+| `option.SetFilter(...)` filter function (incl. `.Delta()/.IV()` filters) | "daily, pre-calculated values based on the end of the **previous trading day**" — not customizable |
+| `OptionChain(symbol)` method | same prior-day EOD pre-calculated values; returns **all tradable contracts**, not just your filter's picks |
+| `History<OptionUniverse>(...)` | same prior-day EOD values, one full chain per trading day |
+| the slice: `data.OptionChains` (or `CurrentSlice.OptionChains`) | **current values from the Option price model**, computed on request against live data — customizable via `option.PriceModel` |
+
+The operating rule that follows: **any intraday decision — entry sizing, delta hedging, IV-threshold checks, strike selection at a decision time — should read the slice's chain.** The `OptionChain()` method is for **daily contract discovery** (find which contracts exist, filter by prior-day delta/OI, then subscribe); using it for intraday sizing or greeks means every number is one day stale, and nothing errors to tell you. Greeks on slice contracts are computed lazily — accessing `Greeks` costs nothing; accessing `Greeks.Delta` triggers the calculation — so only read the greeks you need.
+
+## Subscription route 1: `AddOption` — a filtered basket (universe)
+
+For strategies that pick contracts from a chain at decision time (spreads, condors, straddles, rolling structures), subscribe once in `Initialize`:
+
+```csharp
+UniverseSettings.Asynchronous = true;
+var option = AddOption("SPY");                  // underlying auto-subscribed RAW
+option.SetFilter(u => u.IncludeWeeklys().Strikes(-3, 3).Expiration(15, 60));
+_symbol = option.Symbol;                        // canonical Symbol — save it
+```
+
+- **The canonical `option.Symbol` is not tradable** — it is the key into `data.OptionChains` and the first argument of every `OptionStrategies` factory.
+- **Filter timing**: selection "usually runs at the first bar of every day"; a newly selected contract's data arrives "in the next `Slice`". So the chain can be absent on any given event — always guard: `if (!data.OptionChains.TryGetValue(_symbol, out var chain)) return;`.
+- **Default filter** if you never call `SetFilter`: standards + weeklys, within 1 strike of the underlying price, expiring within 35 days — almost never what a spec wants; set the filter explicitly.
+- Filter building blocks: `Strikes(min, max)` (relative strike counts around the money, not dollars), `Expiration(minDays, maxDays)`, `CallsOnly()/PutsOnly()`, `WeeklysOnly()/StandardsOnly()/IncludeWeeklys()`, `FrontMonth()/BackMonth()`, greek/OI filters `Delta(min, max)`, `IV(min, max)`, `OpenInterest(min, max)` (these compare **prior-day EOD** values — use them for coarse pre-selection, then pick precisely from live slice greeks), and strategy-shaped helpers (`u.Straddle(30)`, `u.IronCondor(30, 5, 10)`) that narrow the universe to exactly the legs a named strategy needs.
+- **Resolution rule**: the option resolution must be ≥ the underlying Equity's resolution (minute equity → minute/hour/daily options). Contract subscriptions support minute, hour, and daily; minute is the default.
+
+Reading the chain at a decision time:
+
+```csharp
+public override void OnData(Slice data)
+{
+    if (!data.OptionChains.TryGetValue(_symbol, out var chain)) return;
+    var spot = chain.Underlying.Price;
+    var atmCall = chain.Where(c => c.Right == OptionRight.Call)
+        .OrderBy(c => Math.Abs(c.Strike - spot)).First();
+    var delta = atmCall.Greeks.Delta;    // live price-model value, computed on request
+    var mid = (atmCall.BidPrice + atmCall.AskPrice) / 2;
+}
+```
+
+In a Scheduled Event there is no slice parameter — read the same object through `CurrentSlice.OptionChains`.
+
+## Subscription route 2: `AddOptionContract` — individual known contracts
+
+For strategies that hold a few specific contracts found by daily screening, discover with the `OptionChain()` method, then subscribe each pick:
+
+```csharp
+// In a scheduled event — OptionChain() carries PRIOR-DAY EOD greeks: fine for
+// discovering contracts, wrong for intraday sizing or hedging.
+var chain = OptionChain(_underlying);
+var expiry = chain.Min(c => c.Expiry);
+var symbol = chain
+    .Where(c => c.Expiry == expiry && c.Right == OptionRight.Call && c.Greeks.Delta > 0.3m)
+    .OrderBy(c => c.OpenInterest).Last().Symbol;
+AddOptionContract(symbol);
+```
+
+The three idioms that must accompany this route:
+
+1. **Seed prices** — a contract subscribed this time step has no data until the next slice ("you'll need to wait until the next `Slice` to receive data and trade the contract"). Set `Settings.SeedInitialPrices = true;` in `Initialize` to trade it immediately.
+2. **RAW underlying** — subscribe the underlying with `AddEquity("SPY", dataNormalizationMode: DataNormalizationMode.Raw)` so strike-vs-price comparisons share a scale. If you skip this, LEAN auto-subscribes (or force-switches an existing subscription) to RAW anyway — see the history caveat below.
+3. **Volatility warm-up** — `SetWarmUp` in `Initialize` cannot anticipate contracts added later; warm the underlying's volatility model in a security initializer (feed ~30 daily bars through `security.VolatilityModel.Update(...)`) so slice-chain IV/greeks are sane from the first read. On the `AddOption` route the simple `SetWarmUp(31, Resolution.Daily)` suffices (default volatility model needs 30+1 daily bars).
+
+To read a subscribed contract from the slice, index the chain with the **canonical**: `data.OptionChains.TryGetValue(_contractSymbol.Canonical, out var chain)`. `RemoveOptionContract(symbol)` cancels its open orders and liquidates the position.
+
+## The RAW-underlying history caveat
+
+Because any option subscription forces the underlying Equity to RAW normalization, a `History()` call on that underlying now returns **raw closes** — dividend gaps included. Any realized-volatility, daily-return, or overnight-gap calculation on an option underlying must request adjusted data explicitly: `History(_underlying, 22, Resolution.Daily, dataNormalizationMode: DataNormalizationMode.Adjusted)`. Do not "fix" this by subscribing the underlying ADJUSTED — LEAN silently switches it back to RAW.
+
+## Common mistakes
+
+- **Sizing or hedging from `OptionChain()` intraday.** Its marks and greeks are the previous close; position sizes computed from them are provably off versus decision-time quotes. Decision-time numbers come from the slice's chain.
+- **Trading the canonical symbol**, or passing a contract symbol where the canonical is required (chain lookup, `OptionStrategies` factories).
+- **No `TryGetValue` guard** — the chain is legitimately absent before the first daily selection and whenever the filter turns over.
+- **Forgetting `IncludeWeeklys()`** when a spec's DTE window (e.g. 21–45 days, closest to 30) needs weekly expiries to hit its target.
+- **Computing RV/returns on the force-RAW underlying** without an explicit adjusted-normalization history request.
+- Only American-style US equity options are supported; strikes in the filter API are **relative counts**, not dollar offsets — `Strikes(-1, 1)` means one strike either side of the money.

--- a/skills/csharp/option-strategies/SKILL.md
+++ b/skills/csharp/option-strategies/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: option-strategies
+description: Use when placing or managing MULTI-LEG option positions and the option lifecycle in QuantConnect/LEAN — the `OptionStrategies` factory + `Buy/Sell` route, combo orders (`ComboMarketOrder`, `ComboLimitOrder`, `ComboLegLimitOrder`), position-group margin, early assignment, exercise, and expiry cleanup. Triggers — iron condor / straddle / strangle / spread / butterfly / calendar / collar / covered-call code; questions like "how do I place all four legs at once", "why was my short option assigned", "what happens to my position at expiry", "why did my algorithm stop trading after expiry". Skip when — chain subscriptions and greeks freshness (see equity-options), single-leg orders (see orders), historical option data (see historical-data-equity-options).
+---
+
+# Option strategies and the option lifecycle — QuantConnect / LEAN
+
+## Placing multi-leg positions: two documented routes, no third
+
+**Route A — `OptionStrategies` factory + `Buy`.** One call builds the whole structure from the **canonical** option symbol (saved from `var option = AddOption(...); _symbol = option.Symbol;`) plus strikes/expiries — no contract symbols needed, all legs placed atomically:
+
+```csharp
+var strategy = OptionStrategies.IronCondor(_symbol, farPut, nearPut, nearCall, farCall, expiry);
+Buy(strategy, 2);         // 2 condors; Sell(strategy, q) inverts every leg
+```
+
+Both directions of every structure have their own factory (`Straddle` / `ShortStraddle`, `IronCondor` / `ShortIronCondor`) and a "short_" factory is still placed with `Buy`. The catalogue (`PascalCase` members of `OptionStrategies`): bear/bull call/put spreads; long/short call/put butterflies (strike order **higher, ATM, lower**); long/short call/put calendar spreads (`(strike, nearExpiry, farExpiry)`); covered/naked/protective calls and puts; protective collar; conversion/reverse conversion; long/short straddles and strangles; long/short iron butterflies and iron condors (strikes ascending); long/short box spreads; long/short jelly rolls; bear/bull call/put ladders; long/short call/put backspreads. Covered/protective/conversion structures embed the underlying — buying one unit of `CoveredCall` is long 100 shares + short 1 call.
+
+**Route B — combo orders.** Build `Leg.Create(symbol, ratio)` lists from actual contract symbols when you need custom ratios, a leg set no factory matches, or limit pricing:
+
+```csharp
+var legs = new List<Leg> { Leg.Create(shortCall.Symbol, -1), Leg.Create(longCall.Symbol, 1) };
+var tickets = ComboMarketOrder(legs, quantity);        // one ticket per leg
+```
+
+- Leg quantities set the **ratio**; the order's `quantity` argument is a global multiplier and sets the combo's direction. At least one positive and one negative leg; each leg a unique contract.
+- `ComboLimitOrder(legs, quantity, limitPrice)` — one **net** price for the package, legs fill together when the combined price crosses it; the only combo type documented to also accept an underlying-equity leg. `ComboLegLimitOrder` — per-leg limits via the third argument of `Leg.Create`; each leg fills on its own limit. Both are updatable through the leg tickets until filled.
+- Combo orders are synchronous by default with a 5-second wait (extend via `Transactions.MarketOrderFillTimeout`); pass `asynchronous: true` to fire-and-continue. Marketable combos on illiquid OTM contracts "may take a few minutes to fill".
+
+**There is no route C.** Legging into a multi-leg structure with sequential single market orders is not a documented pattern: it carries leg risk (partial structures during fills) and the interim one-sided position can fail margin that the complete structure would pass. Single-leg strategies (naked call/put) are the one case where a plain `MarketOrder` is the documented approach.
+
+## Margin: recognized structures are cheaper
+
+LEAN groups positions that compose a recognized strategy and margins the **group**, not the legs — the docs' example: an ITM long call ($29,150) plus an OTM short call ($101,499) margin at $130,649 separately but **$0 as a bull call spread**. Defined-risk structures (spreads, condors, butterflies) are therefore dramatically cheaper than their leg-sums; don't pre-reject a trade by summing per-leg requirements. For a pre-trade check, wrap the strategy in `new OptionStrategyPositionGroupBuyingPowerModel(strategy)` and query `GetInitialMarginRequirement(...)` against `Portfolio.MarginRemaining` (the result is per one unit — multiply by your quantity).
+
+## Early assignment: an hourly simulation you must expect
+
+Short American options in a backtest can be assigned **before** expiry. The default `DefaultOptionAssignmentModel` scans hourly and assigns a short option that is within 4 days of expiry, at least 5% in the money, and profitable to exercise after fees (European style: expiry day only). Any strategy holding short legs into that window (covered calls, short condors near expiry, diagonals) must handle assignment — or, when the strategy's rules exit before the window (e.g. manage-at-21-DTE), assignment simply never triggers. To disable the simulation deliberately: `(security as Option).SetOptionAssignmentModel(new NullOptionAssignmentModel());` in a security initializer.
+
+**Handle assignment in `OnAssignmentOrderEvent` — not by sniffing `IsAssignment` in the generic order-event handler.** The docs' working examples read the just-delivered share position inside the dedicated handler (holdings are current there) and clean up immediately:
+
+```csharp
+public override void OnAssignmentOrderEvent(OrderEvent assignmentEvent)
+{
+    var shares = assignmentEvent.Quantity * _option.SymbolProperties.ContractMultiplier;
+    MarketOrder(assignmentEvent.Symbol.Underlying, -shares, tag: "Assignment cleanup");
+}
+```
+
+Reacting from the generic `OnOrderEvent` instead has been observed to fire before the delivered shares are booked, so a holdings-based cleanup silently does nothing until a later event. Note the delivered shares appear at the **strike** price via a fill event, simultaneous with a zero-price fill that removes the option contract; assignment after the close cannot be flattened until the next session's open regardless of handler.
+
+## Expiry: LEAN acts on the contracts, not on your state
+
+At expiration LEAN auto-exercises long ITM positions ("Automatic Exercise": zero-price fill removing the contract + a strike-price fill delivering the underlying for physical settlement) and removes OTM contracts worthless. **None of your exit logic runs.** Any strategy that tracks its own open position (a `self._position` object, leg symbol fields) must clear that state when contracts expire — otherwise the algorithm believes a position is still open, its management checks keep early-returning on missing data, and it silently never trades again. If the strategy's rules are supposed to exit before expiry, treat reaching expiry as a bug signal, but still write the state-cleanup path. Manual exercise: `ExerciseOption(contractSymbol, quantity)` — long positions only, American any time, European only at expiry, rejected on insufficient capital.
+
+## Common mistakes
+
+- Selling a `short_*` factory (double inversion) — short factories are **bought**; `Sell` on the long factory is the other spelling of the same trade.
+- Butterfly strike order: all four butterfly factories take **(higher, ATM, lower)** — the doc examples' variable names disagree with their own math; follow the order, not the names.
+- Passing the underlying Equity symbol or a contract symbol as a factory's first argument — it must be the **canonical** option symbol.
+- Summing per-leg margin to pre-check a defined-risk structure (position grouping makes the real requirement far lower).
+- Assignment cleanup in the generic order-event handler reading holdings that aren't updated yet — use `OnAssignmentOrderEvent`.
+- No expiry-slip state cleanup: position-tracking fields never cleared when contracts expire, permanently halting re-entry.
+- Pairing route A with per-leg limit prices — factories place market executions; limit pricing needs route B.

--- a/skills/python/equity-options/SKILL.md
+++ b/skills/python/equity-options/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: equity-options
+description: Use when an algorithm trades options on a SINGLE named underlying Equity — subscribing (`add_option` vs `add_option_contract`), reading the chain (the slice's `option_chains` vs the `option_chain()` method), greeks/IV data freshness, strike/expiry filters, price seeding, and warm-up. Triggers — code calling any of those four APIs; questions like "why are my deltas/IV stale", "why can't I trade the contract I just added", "why is the chain empty", "which API gives decision-time greeks". Skip when — options on a DYNAMIC equity universe (see chained-universes-options), historical/backfilled option data for past dates (see historical-data-equity-options), or multi-leg order placement and assignment/exercise handling (see option-strategies).
+---
+
+# Equity Options: subscriptions and chain data — QuantConnect / LEAN
+
+Two decisions shape every equity-options algorithm, and each has two answers that look interchangeable but carry different data: **how you subscribe** (`add_option` vs `add_option_contract`) and **how you read the chain** (the slice's `option_chains` vs the `option_chain()` method). Picking the wrong member of either pair produces algorithms that trade on day-old numbers without any error.
+
+## Greeks/IV freshness — the core rule
+
+There are two different option datasets behind the APIs (doc: "There is a daily, pre-calculated dataset based on the end of the previous trading day. There is also a stream of values that are calculated on-the-fly as your algorithm runs."):
+
+| Access path | Data you get |
+|---|---|
+| `option.set_filter(...)` filter function (incl. `.delta()/.iv()` filters) | "daily, pre-calculated values based on the end of the **previous trading day**" — not customizable |
+| `self.option_chain(symbol)` method | same prior-day EOD pre-calculated values; returns **all tradable contracts**, not just your filter's picks |
+| `self.history[OptionUniverse](...)` | same prior-day EOD values, one full chain per trading day |
+| the slice: `data.option_chains` (or `self.current_slice.option_chains`) | **current values from the Option price model**, computed on request against live data — customizable via `option.price_model` |
+
+The operating rule that follows: **any intraday decision — entry sizing, delta hedging, IV-threshold checks, strike selection at a decision time — should read the slice's chain.** The `option_chain()` method is for **daily contract discovery** (find which contracts exist, filter by prior-day delta/OI, then subscribe); using it for intraday sizing or greeks means every number is one day stale, and nothing errors to tell you. Greeks on slice contracts are computed lazily — accessing `greeks` costs nothing; accessing `greeks.delta` triggers the calculation — so only read the greeks you need.
+
+## Subscription route 1: `add_option` — a filtered basket (universe)
+
+For strategies that pick contracts from a chain at decision time (spreads, condors, straddles, rolling structures), subscribe once in `initialize`:
+
+```python
+self.universe_settings.asynchronous = True
+option = self.add_option("SPY")                 # underlying auto-subscribed RAW
+option.set_filter(lambda u: u.include_weeklys().strikes(-3, 3).expiration(15, 60))
+self._symbol = option.symbol                    # canonical Symbol — save it
+```
+- **The canonical `option.symbol` is not tradable** — it is the key into `data.option_chains` and the first argument of every `OptionStrategies` factory.
+- **Filter timing**: selection "usually runs at the first bar of every day"; a newly selected contract's data arrives "in the next `Slice`". So the chain can be absent on any given event — always guard: `chain = data.option_chains.get(self._symbol); if not chain: return`.
+- **Default filter** if you never call `set_filter`: standards + weeklys, within 1 strike of the underlying price, expiring within 35 days — almost never what a spec wants; set the filter explicitly.
+- Filter building blocks: `strikes(min, max)` (relative strike counts around the money, not dollars), `expiration(min_days, max_days)`, `calls_only()/puts_only()`, `weeklys_only()/standards_only()/include_weeklys()`, `front_month()/back_month()`, greek/OI filters `delta(min, max)`, `iv(min, max)`, `open_interest(min, max)` (these compare **prior-day EOD** values — use them for coarse pre-selection, then pick precisely from live slice greeks), and strategy-shaped helpers (`u.straddle(30)`, `u.iron_condor(30, 5, 10)`) that narrow the universe to exactly the legs a named strategy needs.
+- **Resolution rule**: the option resolution must be ≥ the underlying Equity's resolution (minute equity → minute/hour/daily options). Contract subscriptions support minute, hour, and daily; minute is the default.
+
+Reading the chain at a decision time:
+
+```python
+def on_data(self, data: Slice) -> None:
+    chain = data.option_chains.get(self._symbol)
+    if not chain:
+        return
+    spot = chain.underlying.price
+    atm_call = min((c for c in chain if c.right == OptionRight.CALL),
+                   key=lambda c: abs(c.strike - spot))
+    delta = atm_call.greeks.delta        # live price-model value, computed on request
+    mid = (atm_call.bid_price + atm_call.ask_price) / 2
+```
+In a Scheduled Event there is no slice parameter — read the same object through `self.current_slice.option_chains`.
+
+## Subscription route 2: `add_option_contract` — individual known contracts
+
+For strategies that hold a few specific contracts found by daily screening, discover with the `option_chain()` method, then subscribe each pick:
+
+```python
+# In a scheduled event — option_chain() carries PRIOR-DAY EOD greeks: fine for
+# discovering contracts, wrong for intraday sizing or hedging.
+chain = self.option_chain(self._underlying, flatten=True).data_frame
+expiry = chain.expiry.min()
+symbol = chain[(chain.expiry == expiry) & (chain.right == OptionRight.CALL) &
+               (chain.delta > 0.3)].sort_values("openinterest").index[-1]
+self.add_option_contract(symbol)
+```
+The three idioms that must accompany this route:
+
+1. **Seed prices** — a contract subscribed this time step has no data until the next slice ("you'll need to wait until the next `Slice` to receive data and trade the contract"). Set `self.settings.seed_initial_prices = True` in `initialize` to trade it immediately.
+2. **RAW underlying** — subscribe the underlying with `self.add_equity("SPY", data_normalization_mode=DataNormalizationMode.RAW)` so strike-vs-price comparisons share a scale. If you skip this, LEAN auto-subscribes (or force-switches an existing subscription) to RAW anyway — see the history caveat below.
+3. **Volatility warm-up** — `set_warm_up` in `initialize` cannot anticipate contracts added later; warm the underlying's volatility model in a security initializer (feed ~30 daily bars through `security.volatility_model.update(...)`) so slice-chain IV/greeks are sane from the first read. On the `add_option` route the simple `self.set_warm_up(31, Resolution.DAILY)` suffices (default volatility model needs 30+1 daily bars).
+
+To read a subscribed contract from the slice, index the chain with the **canonical**: `data.option_chains.get(self._contract_symbol.canonical)`. `remove_option_contract(symbol)` cancels its open orders and liquidates the position.
+
+## The RAW-underlying history caveat
+
+Because any option subscription forces the underlying Equity to RAW normalization, a `history()` call on that underlying now returns **raw closes** — dividend gaps included. Any realized-volatility, daily-return, or overnight-gap calculation on an option underlying must request adjusted data explicitly: `self.history(self._underlying, 22, Resolution.DAILY, data_normalization_mode=DataNormalizationMode.ADJUSTED)`. Do not "fix" this by subscribing the underlying ADJUSTED — LEAN silently switches it back to RAW.
+
+## Common mistakes
+
+- **Sizing or hedging from `option_chain()` intraday.** Its marks and greeks are the previous close; position sizes computed from them are provably off versus decision-time quotes. Decision-time numbers come from the slice's chain.
+- **Trading the canonical symbol**, or passing a contract symbol where the canonical is required (chain lookup, `OptionStrategies` factories).
+- **No `if not chain:` guard** — the chain is legitimately absent before the first daily selection and whenever the filter turns over.
+- **Forgetting `include_weeklys()`** when a spec's DTE window (e.g. 21–45 days, closest to 30) needs weekly expiries to hit its target.
+- **Computing RV/returns on the force-RAW underlying** without an explicit adjusted-normalization history request.
+- Only American-style US equity options are supported; strikes in the filter API are **relative counts**, not dollar offsets — `strikes(-1, 1)` means one strike either side of the money.

--- a/skills/python/option-strategies/SKILL.md
+++ b/skills/python/option-strategies/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: option-strategies
+description: Use when placing or managing MULTI-LEG option positions and the option lifecycle in QuantConnect/LEAN — the `OptionStrategies` factory + `buy/sell` route, combo orders (`combo_market_order`, `combo_limit_order`, `combo_leg_limit_order`), position-group margin, early assignment, exercise, and expiry cleanup. Triggers — iron condor / straddle / strangle / spread / butterfly / calendar / collar / covered-call code; questions like "how do I place all four legs at once", "why was my short option assigned", "what happens to my position at expiry", "why did my algorithm stop trading after expiry". Skip when — chain subscriptions and greeks freshness (see equity-options), single-leg orders (see orders), historical option data (see historical-data-equity-options).
+---
+
+# Option strategies and the option lifecycle — QuantConnect / LEAN
+
+## Placing multi-leg positions: two documented routes, no third
+
+**Route A — `OptionStrategies` factory + `buy`.** One call builds the whole structure from the **canonical** option symbol (saved from `option = self.add_option(...); self._symbol = option.symbol`) plus strikes/expiries — no contract symbols needed, all legs placed atomically:
+
+```python
+strategy = OptionStrategies.iron_condor(self._symbol, far_put, near_put, near_call, far_call, expiry)
+self.buy(strategy, 2)     # 2 condors; sell(strategy, q) inverts every leg
+```
+Both directions of every structure have their own factory (`straddle` / `short_straddle`, `iron_condor` / `short_iron_condor`) and a "short_" factory is still placed with `buy`. The catalogue (`snake_case` members of `OptionStrategies`): bear/bull call/put spreads; long/short call/put butterflies (strike order **higher, ATM, lower**); long/short call/put calendar spreads (`(strike, near_expiry, far_expiry)`); covered/naked/protective calls and puts; protective collar; conversion/reverse conversion; long/short straddles and strangles; long/short iron butterflies and iron condors (strikes ascending); long/short box spreads; long/short jelly rolls; bear/bull call/put ladders; long/short call/put backspreads. Covered/protective/conversion structures embed the underlying — buying one unit of `covered_call` is long 100 shares + short 1 call.
+
+**Route B — combo orders.** Build `Leg.create(symbol, ratio)` lists from actual contract symbols when you need custom ratios, a leg set no factory matches, or limit pricing:
+
+```python
+legs = [Leg.create(short_call.symbol, -1), Leg.create(long_call.symbol, 1)]
+tickets = self.combo_market_order(legs, quantity)      # one ticket per leg
+```
+- Leg quantities set the **ratio**; the order's `quantity` argument is a global multiplier and sets the combo's direction. At least one positive and one negative leg; each leg a unique contract.
+- `combo_limit_order(legs, quantity, limit_price)` — one **net** price for the package, legs fill together when the combined price crosses it; the only combo type documented to also accept an underlying-equity leg. `combo_leg_limit_order` — per-leg limits via the third argument of `Leg.create`; each leg fills on its own limit. Both are updatable through the leg tickets until filled.
+- Combo orders are synchronous by default with a 5-second wait (extend via `self.transactions.market_order_fill_timeout`); pass `asynchronous=True` to fire-and-continue. Marketable combos on illiquid OTM contracts "may take a few minutes to fill".
+
+**There is no route C.** Legging into a multi-leg structure with sequential single market orders is not a documented pattern: it carries leg risk (partial structures during fills) and the interim one-sided position can fail margin that the complete structure would pass. Single-leg strategies (naked call/put) are the one case where a plain `market_order` is the documented approach.
+
+## Margin: recognized structures are cheaper
+
+LEAN groups positions that compose a recognized strategy and margins the **group**, not the legs — the docs' example: an ITM long call ($29,150) plus an OTM short call ($101,499) margin at $130,649 separately but **$0 as a bull call spread**. Defined-risk structures (spreads, condors, butterflies) are therefore dramatically cheaper than their leg-sums; don't pre-reject a trade by summing per-leg requirements. For a pre-trade check, wrap the strategy in `OptionStrategyPositionGroupBuyingPowerModel(strategy)` and query `get_initial_margin_requirement(...)` against `self.portfolio.margin_remaining` (the result is per one unit — multiply by your quantity).
+
+## Early assignment: an hourly simulation you must expect
+
+Short American options in a backtest can be assigned **before** expiry. The default `DefaultOptionAssignmentModel` scans hourly and assigns a short option that is within 4 days of expiry, at least 5% in the money, and profitable to exercise after fees (European style: expiry day only). Any strategy holding short legs into that window (covered calls, short condors near expiry, diagonals) must handle assignment — or, when the strategy's rules exit before the window (e.g. manage-at-21-DTE), assignment simply never triggers. To disable the simulation deliberately: `security.set_option_assignment_model(NullOptionAssignmentModel())` in a security initializer.
+
+**Handle assignment in `on_assignment_order_event` — not by sniffing `is_assignment` in the generic order-event handler.** The docs' working examples read the just-delivered share position inside the dedicated handler (holdings are current there) and clean up immediately:
+
+```python
+def on_assignment_order_event(self, assignment_event: OrderEvent) -> None:
+    shares = assignment_event.quantity * self._option.symbol_properties.contract_multiplier
+    self.market_order(assignment_event.symbol.underlying, -shares, tag="Assignment cleanup")
+```
+Reacting from the generic `on_order_event` instead has been observed to fire before the delivered shares are booked, so a holdings-based cleanup silently does nothing until a later event. Note the delivered shares appear at the **strike** price via a fill event, simultaneous with a zero-price fill that removes the option contract; assignment after the close cannot be flattened until the next session's open regardless of handler.
+
+## Expiry: LEAN acts on the contracts, not on your state
+
+At expiration LEAN auto-exercises long ITM positions ("Automatic Exercise": zero-price fill removing the contract + a strike-price fill delivering the underlying for physical settlement) and removes OTM contracts worthless. **None of your exit logic runs.** Any strategy that tracks its own open position (a `self._position` object, leg symbol fields) must clear that state when contracts expire — otherwise the algorithm believes a position is still open, its management checks keep early-returning on missing data, and it silently never trades again. If the strategy's rules are supposed to exit before expiry, treat reaching expiry as a bug signal, but still write the state-cleanup path. Manual exercise: `self.exercise_option(contract_symbol, quantity)` — long positions only, American any time, European only at expiry, rejected on insufficient capital.
+
+## Common mistakes
+
+- Selling a `short_*` factory (double inversion) — short factories are **bought**; `sell` on the long factory is the other spelling of the same trade.
+- Butterfly strike order: all four butterfly factories take **(higher, ATM, lower)** — the doc examples' variable names disagree with their own math; follow the order, not the names.
+- Passing the underlying Equity symbol or a contract symbol as a factory's first argument — it must be the **canonical** option symbol.
+- Summing per-leg margin to pre-check a defined-risk structure (position grouping makes the real requirement far lower).
+- Assignment cleanup in the generic order-event handler reading holdings that aren't updated yet — use `on_assignment_order_event`.
+- No expiry-slip state cleanup: position-tracking fields never cleared when contracts expire, permanently halting re-entry.
+- Pairing route A with per-leg limit prices — factories place market executions; limit pricing needs route B.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Two new skills covering the equity-options lifecycle for the QC Assistants, distilled from the Securities/Equity Options, Universes/ Equity Options, Trading and Orders/Option Strategies, and Reality Modeling/Options Models doc sections.

equity-options: the two subscription routes (add_option filtered basket vs add_option_contract individual contracts, with the seeding / RAW-underlying / volatility-warm-up idioms the contract route needs) and the two chain reads with their data freshness — the universe filter, the option_chain() method, and OptionUniverse history all carry daily pre-calculated prior-close greeks/IV, while the slice's option_chains carries current price-model values, so intraday sizing, hedging, and strike selection should read the slice. Also covers the forced-RAW underlying history caveat for return/volatility math.

option-strategies: OptionStrategies factories vs combo orders (and why sequential legging is neither), position-group margin, the early- assignment simulation, handling assignment in on_assignment_order_event (holdings are current there, unlike the generic order-event handler), and clearing algorithm position state at expiry so strategies don't silently halt.

Both cross-reference chained-universes-options and historical-data-equity-options rather than duplicating them.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve Mia's ability to generate Option strategies

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
