### PR TITLE
Add route and subscription-sizing guidance to equity-options skill

### DIFF
--- a/skill-templates/equity-options/SKILL.md
+++ b/skill-templates/equity-options/SKILL.md
@@ -20,6 +20,20 @@ There are two different option datasets behind the APIs (doc: "There is a daily,
 
 The operating rule that follows: **any intraday decision — entry sizing, delta hedging, IV-threshold checks, strike selection at a decision time — should read the slice's chain.** The py`option_chain()`cs`OptionChain()` method is for **daily contract discovery** (find which contracts exist, filter by prior-day delta/OI, then subscribe); using it for intraday sizing or greeks means every number is one day stale, and nothing errors to tell you. Greeks on slice contracts are computed lazily — accessing py`greeks`cs`Greeks` costs nothing; accessing py`greeks.delta`cs`Greeks.Delta` triggers the calculation — so only read the greeks you need.
 
+## Pick ONE route — and subscribe only what the strategy can trade
+
+Decide the route once, in py`initialize`cs`Initialize`. Mixing them is usually a smell:
+
+- **Universe route** (py`add_option`cs`AddOption` + filter): a universe's purpose is its slice chain. If all selection, pricing, and sizing happen through py`option_chain()`cs`OptionChain()` anyway, the minute-resolution subscriptions are pure cost — either read the slice for the decisions that need live data, or drop the universe and subscribe the picks directly.
+- **Discovery route** (py`option_chain()`cs`OptionChain()` + py`add_option_contract`cs`AddOptionContract`): the daily chain picks the contracts; subscribe each pick. Match the data to the decision: the py`option_chain()`cs`OptionChain()` rows are previous-close values — fine when daily-granularity data suits the strategy (screening, ranking, a daily-cadence rule that tolerates day-old marks), but when the strategy calls for decision-time values (intraday sizing, hedging, entry marks), read the subscribed picks' live quotes from the slice. Whichever you use, know which one you are using.
+- A subscription earns its cost by being **read** or being **held**: a contract you own needs its subscription (position pricing, fills, expiry processing) even if you never read a chain. What doesn't earn its cost is breadth — a wide py`add_option`cs`AddOption` universe where the algorithm neither reads the slice chain nor holds more than its few picks.
+
+Size the subscription to the trade, not to the chain:
+
+- Prefer a **strategy-shaped filter** when one matches the structure — py`u.iron_condor(30, 5, 10)`cs`u.IronCondor(30, 5, 10)`, py`u.straddle(30)`cs`u.Straddle(30)`, py`u.call_spread(30, 5)`cs`u.CallSpread(30, 5)`, and friends subscribe only the legs the strategy needs.
+- Otherwise derive the strike span and DTE window from the structure's own numbers (target deltas, wing widths, expiry rules), adding a delta-band filter (py`u.delta(0.05, 0.30)`cs`u.Delta(0.05m, 0.30m)`) where the structure is delta-targeted. The span should be the tightest one that always contains the tradable candidates — not a safety blanket.
+- py`strikes(-100, 100)`cs`Strikes(-100, 100)`, or an unfiltered py`expiration(0, 500)`cs`Expiration(0, 500)` window, subscribes thousands of minute-resolution contracts — a cost bug even when the algorithm is otherwise correct.
+
 ## Subscription route 1: py`add_option`cs`AddOption` — a filtered basket (universe)
 
 For strategies that pick contracts from a chain at decision time (spreads, condors, straddles, rolling structures), subscribe once in py`initialize`cs`Initialize`:
@@ -112,5 +126,7 @@ Because any option subscription forces the underlying Equity to RAW normalizatio
 - **Trading the canonical symbol**, or passing a contract symbol where the canonical is required (chain lookup, `OptionStrategies` factories).
 - **No py`if not chain:`cs`TryGetValue` guard** — the chain is legitimately absent before the first daily selection and whenever the filter turns over.
 - **Forgetting py`include_weeklys()`cs`IncludeWeeklys()`** when a spec's DTE window (e.g. 21–45 days, closest to 30) needs weekly expiries to hit its target.
+- **Carrying a wide universe you never read** — subscribing a broad chain while doing all selection, pricing, and sizing through py`option_chain()`cs`OptionChain()`: every subscription beyond the contracts actually held is pure cost. Read the universe's slice chain for the decisions that need live data, or drop the universe and use py`add_option_contract`cs`AddOptionContract` on the picks.
+- **Subscribing a huge chain as a tradability crutch** (±100 strikes, unbounded expiries) so any discovered contract can be ordered directly — subscribe the picks with py`add_option_contract`cs`AddOptionContract` instead, and let a strategy-shaped or structure-derived filter keep the universe minimal.
 - **Computing RV/returns on the force-RAW underlying** without an explicit adjusted-normalization history request.
 - Only American-style US equity options are supported; strikes in the filter API are **relative counts**, not dollar offsets — py`strikes(-1, 1)`cs`Strikes(-1, 1)` means one strike either side of the money.

--- a/skills/csharp/equity-options/SKILL.md
+++ b/skills/csharp/equity-options/SKILL.md
@@ -20,6 +20,20 @@ There are two different option datasets behind the APIs (doc: "There is a daily,
 
 The operating rule that follows: **any intraday decision — entry sizing, delta hedging, IV-threshold checks, strike selection at a decision time — should read the slice's chain.** The `OptionChain()` method is for **daily contract discovery** (find which contracts exist, filter by prior-day delta/OI, then subscribe); using it for intraday sizing or greeks means every number is one day stale, and nothing errors to tell you. Greeks on slice contracts are computed lazily — accessing `Greeks` costs nothing; accessing `Greeks.Delta` triggers the calculation — so only read the greeks you need.
 
+## Pick ONE route — and subscribe only what the strategy can trade
+
+Decide the route once, in `Initialize`. Mixing them is usually a smell:
+
+- **Universe route** (`AddOption` + filter): a universe's purpose is its slice chain. If all selection, pricing, and sizing happen through `OptionChain()` anyway, the minute-resolution subscriptions are pure cost — either read the slice for the decisions that need live data, or drop the universe and subscribe the picks directly.
+- **Discovery route** (`OptionChain()` + `AddOptionContract`): the daily chain picks the contracts; subscribe each pick. Match the data to the decision: the `OptionChain()` rows are previous-close values — fine when daily-granularity data suits the strategy (screening, ranking, a daily-cadence rule that tolerates day-old marks), but when the strategy calls for decision-time values (intraday sizing, hedging, entry marks), read the subscribed picks' live quotes from the slice. Whichever you use, know which one you are using.
+- A subscription earns its cost by being **read** or being **held**: a contract you own needs its subscription (position pricing, fills, expiry processing) even if you never read a chain. What doesn't earn its cost is breadth — a wide `AddOption` universe where the algorithm neither reads the slice chain nor holds more than its few picks.
+
+Size the subscription to the trade, not to the chain:
+
+- Prefer a **strategy-shaped filter** when one matches the structure — `u.IronCondor(30, 5, 10)`, `u.Straddle(30)`, `u.CallSpread(30, 5)`, and friends subscribe only the legs the strategy needs.
+- Otherwise derive the strike span and DTE window from the structure's own numbers (target deltas, wing widths, expiry rules), adding a delta-band filter (`u.Delta(0.05m, 0.30m)`) where the structure is delta-targeted. The span should be the tightest one that always contains the tradable candidates — not a safety blanket.
+- `Strikes(-100, 100)`, or an unfiltered `Expiration(0, 500)` window, subscribes thousands of minute-resolution contracts — a cost bug even when the algorithm is otherwise correct.
+
 ## Subscription route 1: `AddOption` — a filtered basket (universe)
 
 For strategies that pick contracts from a chain at decision time (spreads, condors, straddles, rolling structures), subscribe once in `Initialize`:
@@ -86,5 +100,7 @@ Because any option subscription forces the underlying Equity to RAW normalizatio
 - **Trading the canonical symbol**, or passing a contract symbol where the canonical is required (chain lookup, `OptionStrategies` factories).
 - **No `TryGetValue` guard** — the chain is legitimately absent before the first daily selection and whenever the filter turns over.
 - **Forgetting `IncludeWeeklys()`** when a spec's DTE window (e.g. 21–45 days, closest to 30) needs weekly expiries to hit its target.
+- **Carrying a wide universe you never read** — subscribing a broad chain while doing all selection, pricing, and sizing through `OptionChain()`: every subscription beyond the contracts actually held is pure cost. Read the universe's slice chain for the decisions that need live data, or drop the universe and use `AddOptionContract` on the picks.
+- **Subscribing a huge chain as a tradability crutch** (±100 strikes, unbounded expiries) so any discovered contract can be ordered directly — subscribe the picks with `AddOptionContract` instead, and let a strategy-shaped or structure-derived filter keep the universe minimal.
 - **Computing RV/returns on the force-RAW underlying** without an explicit adjusted-normalization history request.
 - Only American-style US equity options are supported; strikes in the filter API are **relative counts**, not dollar offsets — `Strikes(-1, 1)` means one strike either side of the money.

--- a/skills/python/equity-options/SKILL.md
+++ b/skills/python/equity-options/SKILL.md
@@ -20,6 +20,20 @@ There are two different option datasets behind the APIs (doc: "There is a daily,
 
 The operating rule that follows: **any intraday decision — entry sizing, delta hedging, IV-threshold checks, strike selection at a decision time — should read the slice's chain.** The `option_chain()` method is for **daily contract discovery** (find which contracts exist, filter by prior-day delta/OI, then subscribe); using it for intraday sizing or greeks means every number is one day stale, and nothing errors to tell you. Greeks on slice contracts are computed lazily — accessing `greeks` costs nothing; accessing `greeks.delta` triggers the calculation — so only read the greeks you need.
 
+## Pick ONE route — and subscribe only what the strategy can trade
+
+Decide the route once, in `initialize`. Mixing them is usually a smell:
+
+- **Universe route** (`add_option` + filter): a universe's purpose is its slice chain. If all selection, pricing, and sizing happen through `option_chain()` anyway, the minute-resolution subscriptions are pure cost — either read the slice for the decisions that need live data, or drop the universe and subscribe the picks directly.
+- **Discovery route** (`option_chain()` + `add_option_contract`): the daily chain picks the contracts; subscribe each pick. Match the data to the decision: the `option_chain()` rows are previous-close values — fine when daily-granularity data suits the strategy (screening, ranking, a daily-cadence rule that tolerates day-old marks), but when the strategy calls for decision-time values (intraday sizing, hedging, entry marks), read the subscribed picks' live quotes from the slice. Whichever you use, know which one you are using.
+- A subscription earns its cost by being **read** or being **held**: a contract you own needs its subscription (position pricing, fills, expiry processing) even if you never read a chain. What doesn't earn its cost is breadth — a wide `add_option` universe where the algorithm neither reads the slice chain nor holds more than its few picks.
+
+Size the subscription to the trade, not to the chain:
+
+- Prefer a **strategy-shaped filter** when one matches the structure — `u.iron_condor(30, 5, 10)`, `u.straddle(30)`, `u.call_spread(30, 5)`, and friends subscribe only the legs the strategy needs.
+- Otherwise derive the strike span and DTE window from the structure's own numbers (target deltas, wing widths, expiry rules), adding a delta-band filter (`u.delta(0.05, 0.30)`) where the structure is delta-targeted. The span should be the tightest one that always contains the tradable candidates — not a safety blanket.
+- `strikes(-100, 100)`, or an unfiltered `expiration(0, 500)` window, subscribes thousands of minute-resolution contracts — a cost bug even when the algorithm is otherwise correct.
+
 ## Subscription route 1: `add_option` — a filtered basket (universe)
 
 For strategies that pick contracts from a chain at decision time (spreads, condors, straddles, rolling structures), subscribe once in `initialize`:
@@ -82,5 +96,7 @@ Because any option subscription forces the underlying Equity to RAW normalizatio
 - **Trading the canonical symbol**, or passing a contract symbol where the canonical is required (chain lookup, `OptionStrategies` factories).
 - **No `if not chain:` guard** — the chain is legitimately absent before the first daily selection and whenever the filter turns over.
 - **Forgetting `include_weeklys()`** when a spec's DTE window (e.g. 21–45 days, closest to 30) needs weekly expiries to hit its target.
+- **Carrying a wide universe you never read** — subscribing a broad chain while doing all selection, pricing, and sizing through `option_chain()`: every subscription beyond the contracts actually held is pure cost. Read the universe's slice chain for the decisions that need live data, or drop the universe and use `add_option_contract` on the picks.
+- **Subscribing a huge chain as a tradability crutch** (±100 strikes, unbounded expiries) so any discovered contract can be ordered directly — subscribe the picks with `add_option_contract` instead, and let a strategy-shaped or structure-derived filter keep the universe minimal.
 - **Computing RV/returns on the force-RAW underlying** without an explicit adjusted-normalization history request.
 - Only American-style US equity options are supported; strikes in the filter API are **relative counts**, not dollar offsets — `strikes(-1, 1)` means one strike either side of the money.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Improve efficiency of AI-generated Option algorithms

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Observed in agent runs: an iron condor subscribing +/-100 strikes of weeklys at minute resolution, and a PMCC holding an entire unfiltered chain while selecting and sizing from option_chain()'s prior-close rows — thousands of subscribed contracts, two held, zero read.

New 'Pick ONE route - and subscribe only what the strategy can trade' section: choose the route in initialize (mixing is usually a smell); match the data source to the decision's freshness requirement - option_chain()'s prior-close rows are fine for screening, ranking, and daily-cadence rules, while intraday sizing, hedging, and entry marks read the subscribed contracts' live slice quotes; a subscription earns its cost by being read or being held, and breadth beyond the contracts actually used never earns it. Sizing guidance prefers strategy-shaped filters (iron_condor, straddle, call_spread - only the legs needed), else a span derived from the structure's own numbers; +/-100-strike or unbounded-expiration windows are called out as cost bugs. Two matching bullets added to common mistakes.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
