### PR TITLE
Document Local Platform project synchronization modes

### DIFF
--- a/02 Local Platform/04 Development Environment/05 Configuration/02 Extension Settings.html
+++ b/02 Local Platform/04 Development Environment/05 Configuration/02 Extension Settings.html
@@ -30,7 +30,13 @@
         </tr>
         <tr>
             <td>Sync: Local And Cloud Projects</td>
-            <td><span class="button-name">Yes</span> to synchronize cloud and local projects. Otherwise, <span class="button-name">No</span>. <span class="button-name">No</span> is only available for Institution organizations.</td>
+            <td>The synchronization mode for your local and cloud projects.
+                <ul>
+                    <li><span class="button-name">Synchronize All Projects</span> (default): While the extension runs, it synchronizes all your cloud and local projects in the background.</li>
+                    <li><span class="button-name">Synchronize Open Project Only</span>: The extension only synchronizes the project you currently have open.</li>
+                    <li><span class="button-name">Disable Synchronization</span>: The extension doesn't synchronize any projects. This mode is best when local agents edit your project files and you want to avoid conflicts with the cloud versions of your projects.</li>
+                </ul>
+            </td>
         </tr>
         <tr>
             <td>User: Preferred Language</td>

--- a/02 Local Platform/04 Development Environment/09 Synchronization/01 Introduction.html
+++ b/02 Local Platform/04 Development Environment/09 Synchronization/01 Introduction.html
@@ -1,1 +1,3 @@
 <p>Unless you are working on an anonymous project, Local Platform automatically syncs your local project files with QuantConnect Cloud. Every time you save a file, Local Platform saves the changes in your local project and in the cloud version of the project.</p>
+
+<p>To synchronize only the project you currently have open, or to disable synchronization entirely, adjust the <span class="button-name">Sync: Local And Cloud Projects</span> <a href="/docs/v2/local-platform/development-environment/configuration#02-Extension-Settings">extension setting</a>. Disabling synchronization is best when local agents edit your project files and you want to avoid conflicts with the cloud versions of your projects.</p>


### PR DESCRIPTION
## Summary

The `Sync: Local And Cloud Projects` extension setting changed from a Yes/No toggle to a dropdown with three modes: `Synchronize All Projects` (default), `Synchronize Open Project Only`, and `Disable Synchronization`.

- Update the extension settings table in Local Platform > Development Environment > Configuration to describe the three modes.
- Add a paragraph to Local Platform > Development Environment > Synchronization pointing to the setting and noting that disabling synchronization avoids conflicts when local agents edit project files.

## Test Plan

- Verified the anchor link `/docs/v2/local-platform/development-environment/configuration#02-Extension-Settings` matches the pattern used elsewhere in the Local Platform docs.
- Verified the nested-list markup follows the same structure as other multi-option settings tables in the docs.