### PR TITLE
Add Index Options to Terminal Link supported asset classes

### DIFF
--- a/05 Lean CLI/09 Live Trading/01 Brokerages/16 Bloomberg EMSX/02 Asset Classes.php
+++ b/05 Lean CLI/09 Live Trading/01 Brokerages/16 Bloomberg EMSX/02 Asset Classes.php
@@ -3,5 +3,6 @@
 <ul>
     <li><a href='https://www.quantconnect.com/docs/v2/writing-algorithms/securities/asset-classes/us-equity'>Equities</a></li>
     <li><a href='https://www.quantconnect.com/docs/v2/writing-algorithms/securities/asset-classes/equity-options'>Equity Options</a></li>
+    <li><a href='https://www.quantconnect.com/docs/v2/writing-algorithms/securities/asset-classes/index-options'>Index Options</a></li>
     <li><a href='https://www.quantconnect.com/docs/v2/writing-algorithms/securities/asset-classes/futures'>Futures</a></li>
 </ul>

--- a/Resources/brokerages/terminal-link/asset-classes.html
+++ b/Resources/brokerages/terminal-link/asset-classes.html
@@ -3,5 +3,6 @@
 <ul>
     <li><a href='/docs/v2/writing-algorithms/securities/asset-classes/us-equity'>Equities</a></li>
     <li><a href='/docs/v2/writing-algorithms/securities/asset-classes/equity-options'>Equity Options</a></li>
+    <li><a href='/docs/v2/writing-algorithms/securities/asset-classes/index-options'>Index Options</a></li>
     <li><a href='/docs/v2/writing-algorithms/securities/asset-classes/futures'>Futures</a></li>
 </ul>

--- a/Resources/brokerages/terminal-link/orders.php
+++ b/Resources/brokerages/terminal-link/orders.php
@@ -9,6 +9,7 @@
         <th>Order Type</th>
         <th>Equity</th>
         <th>Equity Options</th>
+        <th>Index Options</th>
         <th>Futures</th>
       </tr>
    </thead>
@@ -18,15 +19,18 @@
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+        <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
       </tr>
       <tr>
         <td><a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/market-on-open-orders">Market on open</a></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td></td>
         <td></td>
+        <td></td>
       </tr>
       <tr>
         <td><a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/limit-orders">Limit</a></td>
+        <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
@@ -36,9 +40,11 @@
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
+        <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
       </tr>
       <tr>
         <td><a href="/docs/v2/writing-algorithms/trading-and-orders/order-types/stop-limit-orders">Stop limit</a></td>
+        <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>
         <td><img src="https://cdn.quantconnect.com/i/tu/check.png" alt="green check" width="15px;"></td>

--- a/Resources/brokerages/terminal-link/terminallink.json
+++ b/Resources/brokerages/terminal-link/terminallink.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"order-types": ["Market", "Market On Open", "Limit", "Stop Market",  "Stop Limit"],
-	"assets": ["Equity", "Equity Options", "Futures", "Forex"], 
+	"assets": ["Equity", "Equity Options", "Index Options", "Futures", "Forex"],
 	"brokerage-url": "https://www.lean.io/terminal-link",
 	"documentation": "/docs/v2/cloud-platform/live-trading/brokerages/bloomberg-emsx",
 	"module-specification": {
@@ -30,6 +30,7 @@
 			"security-types": [
 				"Equity",
 				"Option",
+				"IndexOption",
 				"Future",
 				"Forex"
 			],


### PR DESCRIPTION
## Summary

Documents Index Options support in the Terminal Link (Bloomberg EMSX) brokerage integration:

- QuantConnect/Lean#9633 adds `SecurityType.IndexOption` to the supported security types of `TerminalLinkBrokerageModel`.
- QuantConnect/Lean.Brokerages.TerminalLink#131 (merged) maps `IndexOption` contracts to the Bloomberg `Index` yellow key on the EMSX order-routing and market-data paths, and enables market-data subscriptions and option-chain lookups.

Changes:
- `Resources/brokerages/terminal-link/asset-classes.html`: add Index Options to the tradable asset classes (rendered on the Cloud Platform Bloomberg EMSX and Writing Algorithms Terminal Link pages).
- `05 Lean CLI/09 Live Trading/01 Brokerages/16 Bloomberg EMSX/02 Asset Classes.php`: same addition for the CLI page.
- `Resources/brokerages/terminal-link/orders.php`: add an Index Options column to the order-types table (Market, Limit, Stop Market, Stop Limit — same as Equity Options).
- `Resources/brokerages/terminal-link/terminallink.json`: add Index Options to `assets` and `IndexOption` to the download `security-types`.

The LEAN CLI Datasets page for Terminal Link already lists US Index Options as a supported dataset, so no change was needed there.

## Test plan

- Verified the supported security types against `TerminalLinkBrokerageModel` in the LEAN PR and the merged symbol-mapper/data-queue changes in Lean.Brokerages.TerminalLink.
- Order-type support mirrors the existing Equity Options column; the brokerage model applies the same order-type set to all supported asset classes (Market on Open remains documented as Equity-only).
- JSON validated for syntax.