### PR TITLE
Update live results docs to reference Live Dashboard page

### DIFF
--- a/01 Cloud Platform/10 Live Trading/07 Results/02 View Live Results.html
+++ b/01 Cloud Platform/10 Live Trading/07 Results/02 View Live Results.html
@@ -2,4 +2,4 @@
 
 <img class="docs-image" src="https://cdn.quantconnect.com/i/tu/view-live-results-1.png" alt="Live result interface">
 
-<p>The content in the live results page updates as your algorithm executes. You can close or refresh the window without interrupting the algorithm because the live trading node processes on our servers. If you close the page, you can <a href="/docs/v2/cloud-platform/live-trading/results#14-View-All-Live-Projects">view all of your live projects</a> to open the page again.</p>
+<p>The content in the live results page updates as your algorithm executes. You can close or refresh the window without interrupting the algorithm because the live trading node processes on our servers. If you close the page, you can <a href="/docs/v2/cloud-platform/live-trading/results#14-View-All-Live-Projects">view all of your live projects</a>, open the project, and then click the yellow lightning bolt icon at the top of the IDE to open the page again.</p>

--- a/01 Cloud Platform/10 Live Trading/07 Results/14 View All Live Projects.html
+++ b/01 Cloud Platform/10 Live Trading/07 Results/14 View All Live Projects.html
@@ -1,4 +1,3 @@
-<p>The <span class='page-section-name'>Your Strategies</span> section of the <a href='/explore'>Strategy Explorer</a> page displays the status of all the live algorithms in your organizations. To view the page, log in to the Algorithm Lab and then, in the left navigation bar, click <span class='menu-name'>Strategy Explorer</span>.</p>
+<p>The <a href='/live'>Live Dashboard</a> page displays the status of all the live algorithms in your organizations. To view the page, log in to the Algorithm Lab and then, in the left navigation bar, click the lightning bolt icon.</p>
 
-<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/strategy-explorer-card.png' alt="View live project in algorithm lab">
-
+<p>To view the results of one of the algorithms, click its row in the table. The project opens in the Algorithm Lab. To see the live results page, click the yellow lightning bolt icon at the top of the IDE.</p>


### PR DESCRIPTION
## Summary
- Replace the outdated Strategy Explorer instructions with the Live Dashboard page (`/live`), reached via the lightning bolt icon in the left navigation bar; remove the stale screenshot
- Explain that clicking a row opens the project and the yellow lightning bolt icon at the top of the IDE opens the live results page
- Extend the View Live Results page with the same instruction for reopening a closed results page

## Test Plan
- Verified the HTML fragments render valid markup and the `/live` link and existing anchor `#14-View-All-Live-Projects` are unchanged