### PR TITLE
Update orders skill so assistants aren't distracted by liquidation orders

### DIFF
--- a/skill-templates/orders/SKILL.md
+++ b/skill-templates/orders/SKILL.md
@@ -55,6 +55,9 @@ Market-on-close fills at an exchange's official closing auction. Cryptocurrencie
 - Exit AT THE CLOSE: py`liquidate`cs`Liquidate` sends a market order, so for a close fill flatten with an MOC order for the negative of the current position:
   py`self.market_on_close_order(symbol, -self.portfolio[symbol].quantity)`cs`MarketOnCloseOrder(symbol, -Portfolio[symbol].Quantity)`.
 
+## Engine-generated delisting liquidations in the order records
+When a held security delists, LEAN automatically closes the position with a market order tagged `Liquidate from delisting` — outside the strategy's own schedule. These are platform processing, not strategy orders: expect a few in any long backtest that holds many names. When verifying order records against the strategy's timing invariants ("orders only at rebalances", "flat by close", ...), count these engine liquidations as compliant platform behavior, not violations — and do not add special delisting handling unless the method explicitly requires it.
+
 ## Reversing a position
 A reversal needs only ONE order, not a py`liquidate`cs`Liquidate` then a separate entry. With py`set_holdings`cs`SetHoldings` this is automatic — py`set_holdings(symbol, new_weight)`cs`SetHoldings(symbol, newWeight)` (e.g. the opposite sign) computes and places the single net order for you, so prefer it and write nothing extra. Manage it by hand ONLY when the spec mandates a manual share count; then place one order for the NET delta:
 ```python

--- a/skills/csharp/orders/SKILL.md
+++ b/skills/csharp/orders/SKILL.md
@@ -41,6 +41,9 @@ Market-on-close fills at an exchange's official closing auction. Cryptocurrencie
 - Exit AT THE CLOSE: `Liquidate` sends a market order, so for a close fill flatten with an MOC order for the negative of the current position:
   `MarketOnCloseOrder(symbol, -Portfolio[symbol].Quantity)`.
 
+## Engine-generated delisting liquidations in the order records
+When a held security delists, LEAN automatically closes the position with a market order tagged `Liquidate from delisting` — outside the strategy's own schedule. These are platform processing, not strategy orders: expect a few in any long backtest that holds many names. When verifying order records against the strategy's timing invariants ("orders only at rebalances", "flat by close", ...), count these engine liquidations as compliant platform behavior, not violations — and do not add special delisting handling unless the method explicitly requires it.
+
 ## Reversing a position
 A reversal needs only ONE order, not a `Liquidate` then a separate entry. With `SetHoldings` this is automatic — `SetHoldings(symbol, newWeight)` (e.g. the opposite sign) computes and places the single net order for you, so prefer it and write nothing extra. Manage it by hand ONLY when the spec mandates a manual share count; then place one order for the NET delta:
 ```csharp

--- a/skills/python/orders/SKILL.md
+++ b/skills/python/orders/SKILL.md
@@ -41,6 +41,9 @@ Market-on-close fills at an exchange's official closing auction. Cryptocurrencie
 - Exit AT THE CLOSE: `liquidate` sends a market order, so for a close fill flatten with an MOC order for the negative of the current position:
   `self.market_on_close_order(symbol, -self.portfolio[symbol].quantity)`.
 
+## Engine-generated delisting liquidations in the order records
+When a held security delists, LEAN automatically closes the position with a market order tagged `Liquidate from delisting` — outside the strategy's own schedule. These are platform processing, not strategy orders: expect a few in any long backtest that holds many names. When verifying order records against the strategy's timing invariants ("orders only at rebalances", "flat by close", ...), count these engine liquidations as compliant platform behavior, not violations — and do not add special delisting handling unless the method explicitly requires it.
+
 ## Reversing a position
 A reversal needs only ONE order, not a `liquidate` then a separate entry. With `set_holdings` this is automatic — `set_holdings(symbol, new_weight)` (e.g. the opposite sign) computes and places the single net order for you, so prefer it and write nothing extra. Manage it by hand ONLY when the spec mandates a manual share count; then place one order for the NET delta:
 ```python


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Update orders skill so agents aren't distracted by liquidation orders

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When the strategy description given to the assistants defines the rebalancing frequency or order conditions, the agents review the orders and find liquidation events but can find liquidation orders. In this case, they waste resources thinking about / discussing if something is wrong with the algorithm implementation, but it's unnecessary. 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
