### PR TITLE
Add Algorithm Performance section to Key Concepts

### DIFF
--- a/01 Cloud Platform/04 Organizations/03 Resources/15 Add Nodes.html
+++ b/01 Cloud Platform/04 Organizations/03 Resources/15 Add Nodes.html
@@ -1,5 +1,7 @@
 <p>You need <a href='/docs/v2/cloud-platform/organizations/members#09-Permissions'>billing permissions</a> in the organization to add nodes.</p>
 
+<p>Adding a node renews your entire subscription period. We charge you the difference in price between your current subscription and the new one, which covers both the node and the extension of the subscription.</p>
+
 <p>Follow these steps to add nodes to your organization:</p>
 
 <ol>

--- a/01 Cloud Platform/04 Organizations/03 Resources/16 Remove Nodes.html
+++ b/01 Cloud Platform/04 Organizations/03 Resources/16 Remove Nodes.html
@@ -1,4 +1,4 @@
-<p>You need <a href="/docs/v2/cloud-platform/organizations/members#09-Permissions">billing permissions</a> in the organization to remove nodes. If you remove nodes during your billing period, your organization will receive a pro-rated credit on your account, which is applied to future invoices.</p>
+<p>You need <a href="/docs/v2/cloud-platform/organizations/members#09-Permissions">billing permissions</a> in the organization to remove nodes. Removing a node renews your entire subscription period. If you remove nodes during your billing period, your organization will receive a pro-rated credit on your account, which is applied to future invoices.</p>
 
 <p>Follow these steps to remove nodes from your organization:</p>
 

--- a/01 Cloud Platform/06 Projects/06 Debugging/04 Logging Statements.php
+++ b/01 Cloud Platform/06 Projects/06 Debugging/04 Logging Statements.php
@@ -11,3 +11,5 @@
 
 <h4>Quit</h4>
 <? include(DOCS_RESOURCES."/logging-statements/quit.php"); ?>
+
+<? include(DOCS_RESOURCES."/logging-statements/best-practices.php"); ?>

--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/01 Introduction.html
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/01 Introduction.html
@@ -1,0 +1,26 @@
+<p>
+  The time a backtest takes is mostly decided by how you write the algorithm, not by the machine that runs it.
+  LEAN's runtime scales with the number of data points your algorithm consumes and with the amount of work you do on each one, so the largest speed gains come from subscribing to less data and keeping your event handlers thin.
+</p>
+
+<p>The following list shows the order to work through when a backtest runs too slowly:</p>
+
+<ol>
+  <li>Measure the algorithm and name the dominant cost before you change any code.</li>
+  <li>Reduce the volume of data the algorithm consumes.</li>
+  <li>Remove history requests from the code paths that run repeatedly.</li>
+  <li>Move expensive work out of the data event handlers.</li>
+  <li>Choose the language that suits the event rate of the strategy.</li>
+  <li>Size the node, once the preceding steps are done.</li>
+</ol>
+
+<p>
+  The order matters.
+  A strategy that subscribes to minute data for 50 US Equities processes tens of millions of data points over a decade, so halving the resolution or the universe size saves more time than any node upgrade.
+  Node size is last on the list because a single backtest runs on a single node and cannot be split across several of them.
+</p>
+
+<p>
+  This section covers the performance of the algorithm you write.
+  For the throughput of the engine itself, see the <a href="/docs/v2/cloud-platform/backtesting/engine-performance">Engine Performance</a> page, which reports the results of the benchmark algorithms QuantConnect runs against LEAN.
+</p>

--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/02 Measure First.html
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/02 Measure First.html
@@ -1,0 +1,122 @@
+<p>
+  Profile the algorithm before you optimize it.
+  Guessing at the bottleneck usually leads to changes that alter the strategy without making it faster.
+</p>
+
+<h4>Reproduce the Slowdown on a Short Backtest</h4>
+
+<p>
+  Record the original start date, end date, and universe, then shrink both to the smallest backtest that still shows the slowdown.
+  One to three months and a handful of securities is usually enough.
+  A short backtest lets you re-run after each change and compare the same region of the chart.
+</p>
+
+<h4>Enable the Performance Chart</h4>
+
+<p>
+  The <a href="/docs/v2/cloud-platform/backtesting/results#05-Performance-Chart">Performance chart</a> reports CPU usage, RAM usage, and the execution time LEAN spends in each of its subsystems.
+  The chart is disabled by default.
+  To enable it, set the <span class="csharp"><code>Settings.PerformanceSamplePeriod</code> property</span><span class="python"><code>self.settings.performance_sample_period</code> attribute</span> to the sampling period you want:
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Sample the algorithm's resource usage and subsystem timings once a week.
+Settings.PerformanceSamplePeriod = TimeSpan.FromDays(7);</pre>
+    <pre class="python"># Sample the algorithm's resource usage and subsystem timings once a week.
+self.settings.performance_sample_period = timedelta(7)</pre>
+</div>
+
+<p>
+  Because the chart is off by default, a backtest you already ran has no Performance chart to inspect.
+  Enable the setting across your projects so the data is there when you need it.
+</p>
+
+<h4>Read the Dominant Series</h4>
+
+<p>
+  Find the series with the tallest spike, or the highest sustained plateau if there is no single spike, and fix the code path it points to.
+  The following table maps each series to the changes that reduce it:
+</p>
+
+<table class="qc-table table">
+    <thead>
+        <tr>
+            <th style="width: 25%">Series</th>
+            <th style="width: 75%">What To Change</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Subscriptions</td>
+            <td>Request a coarser resolution, subscribe to fewer securities, and drop resolutions the algorithm never reads.</td>
+        </tr>
+        <tr>
+            <td>Selection</td>
+            <td>Cap the size of the universe, move expensive queries out of the selection function, and cache results that hold across calls.</td>
+        </tr>
+        <tr>
+            <td>Slice</td>
+            <td>Reduce the subscription count, the resolution, and the number of custom data fields.</td>
+        </tr>
+        <tr>
+            <td>Consolidators</td>
+            <td>Consolidate fewer securities, consolidate to a coarser period, and share one consolidator across the subscribers that need the same bars.</td>
+        </tr>
+        <tr>
+            <td>OnData</td>
+            <td>Move heavy logic to a <a href="/docs/v2/writing-algorithms/scheduled-events">Scheduled Event</a> and replace hand-written series calculations with <a href="/docs/v2/writing-algorithms/indicators/key-concepts">indicators</a>.</td>
+        </tr>
+        <tr>
+            <td>Schedule</td>
+            <td>Lower the event frequency and cache the intermediate results the handler computes.</td>
+        </tr>
+        <tr>
+            <td>HistoryDataPoints</td>
+            <td>Remove <a href="/docs/v2/writing-algorithms/historical-data/history-requests">history requests</a> from repeated code paths, or request fewer securities, fields, and bars.</td>
+        </tr>
+        <tr>
+            <td>Securities</td>
+            <td>Reduce the number of active securities, which is the securities the universe selected plus the ones you hold or have open orders for.</td>
+        </tr>
+        <tr>
+            <td>ActiveSecurities</td>
+            <td>Liquidate stale positions and cancel stale orders so securities leave the universe when selection drops them.</td>
+        </tr>
+        <tr>
+            <td>Transactions</td>
+            <td>Rebalance less often and batch orders through <a href="/docs/v2/writing-algorithms/algorithm-framework/portfolio-construction/key-concepts">portfolio targets</a>.</td>
+        </tr>
+        <tr>
+            <td>SplitsDividendsDelisting</td>
+            <td>Reduce the universe size or move the corporate action logic out of the handler.</td>
+        </tr>
+        <tr>
+            <td>WallTime</td>
+            <td>Read this series to see the real time each sampling period cost, which tells you whether a change actually helped.</td>
+        </tr>
+    </tbody>
+</table>
+
+<p>
+  When several series spike together, start with the earliest one in the pipeline.
+  <code>Subscriptions</code> comes before <code>Consolidators</code>, <code>Consolidators</code> comes before <code>OnData</code>, and <code>Selection</code> comes before <code>Securities</code> and <code>Transactions</code>.
+  Treat the <code>CPU</code>, <code>ManagedRAM</code>, and <code>TotalRAM</code> series as symptoms until one of the timing series names the code path.
+</p>
+
+<h4 class="python">Profile the Python Code</h4>
+
+<p class="python">
+  When CPU or RAM is high and no timing series isolates the cost, add a <a rel="nofollow" target="_blank" href="https://docs.python.org/3/library/profile.html">Python profiler</a> to find the expensive function.
+  See <a href="/docs/v2/writing-algorithms/key-concepts/debugging-tools#06-Performance-Chart">Debugging Tools</a> for the full recipe.
+  Remove the profiler once you have the measurement.
+</p>
+
+<h4>Read the Resource Usage Outside the IDE</h4>
+
+<p>The following list shows the ways to collect resource usage across many backtests:</p>
+
+<ul>
+  <li>On the <b>Overview</b> tab of the backtest results, click <b>Download Results</b> to get the charts as JSON with UTC timestamps.</li>
+  <li>Call the <a href="/docs/v2/cloud-platform/api-reference/backtest-management/read-backtest/charts">Read Backtest Chart</a> endpoint with the chart name <code>Performance</code> to read one backtest's chart programmatically.</li>
+  <li>Read the <a href="/docs/v2/writing-algorithms/key-concepts/debugging-tools#07-Memory-Metrics"><code>OS</code> class members</a> from inside the algorithm for spot checks during a run.</li>
+</ul>

--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/03 Reduce Data Volume.html
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/03 Reduce Data Volume.html
@@ -1,0 +1,136 @@
+<p>
+  LEAN reads, decompresses, and dispatches every data point your algorithm subscribes to, so the runtime is roughly proportional to the number of data points processed.
+  Cutting the data volume is the change with the largest effect on backtest speed, and it is usually the cheapest one to make.
+</p>
+
+<h4>Request the Coarsest Resolution That Answers the Question</h4>
+
+<p>
+  A minute subscription delivers about 390 bars per US Equity per trading day and a daily subscription delivers one.
+  Tick subscriptions deliver several orders of magnitude more than minute.
+  Use daily or hourly data for strategies that make decisions once a day, and reserve tick data for strategies whose logic depends on individual trades and quotes.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Subscribe to daily data when the strategy only makes one decision a day.
+UniverseSettings.Resolution = Resolution.Daily;</pre>
+    <pre class="python"># Subscribe to daily data when the strategy only makes one decision a day.
+self.universe_settings.resolution = Resolution.DAILY</pre>
+</div>
+
+<h4>Warm Up at the Resolution You Need</h4>
+
+<p>
+  The <a href="/docs/v2/writing-algorithms/historical-data/warm-up-periods">warm-up period</a> streams data through the algorithm like any other period, so it counts toward the data volume.
+  When you set it with a time span alone, LEAN warms up at the resolution of your subscriptions.
+  A year of warm-up on a minute subscription is a year of minute data before the algorithm places its first trade.
+</p>
+
+<p>
+  Pass the resolution you actually need for the warm-up.
+  Daily indicators and a year of universe selection history, such as a trailing year of PE ratios, only need daily bars.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Warm up with a year of daily bars instead of a year of the subscription's resolution.
+SetWarmUp(TimeSpan.FromDays(365), Resolution.Daily);</pre>
+    <pre class="python"># Warm up with a year of daily bars instead of a year of the subscription's resolution.
+self.set_warm_up(timedelta(365), Resolution.DAILY)</pre>
+</div>
+
+<p>
+  If you registered indicators or consolidators for automatic updates, the warm-up resolution must be at or below the lowest resolution they use.
+</p>
+
+<p>
+  Universe selection runs during the warm-up period too.
+  When you only want to accumulate selection data and not trade yet, return <code class="csharp">Universe.Unchanged</code><code class="python">Universe.UNCHANGED</code> while the algorithm warms up.
+  The selection function still receives the data, so you collect what you need without adding and removing securities.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Record the selection data during warm-up, but leave the universe alone.
+private IEnumerable&lt;Symbol&gt; SelectSymbols(IEnumerable&lt;Fundamental&gt; fundamental)
+{
+    RecordPeRatios(fundamental);
+    if (IsWarmingUp) return Universe.Unchanged;
+    return fundamental.OrderBy(f =&gt; f.ValuationRatios.PERatio).Take(50).Select(f =&gt; f.Symbol);
+}</pre>
+    <pre class="python"># Record the selection data during warm-up, but leave the universe alone.
+def _select_symbols(self, fundamental):
+    self._record_pe_ratios(fundamental)
+    if self.is_warming_up:
+        return Universe.UNCHANGED
+    return [f.symbol for f in sorted(fundamental, key=lambda f: f.valuation_ratios.pe_ratio)[:50]]</pre>
+</div>
+
+<h4>Cap the Universe Size</h4>
+
+<p>
+  Give every <a href="/docs/v2/writing-algorithms/universes/key-concepts">universe</a> selection function an explicit limit on the number of securities it returns.
+  An unbounded selection function can return thousands of securities on a single day, which multiplies the subscription count, the <code>Slice</code> construction cost, and the memory footprint at once.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Return a fixed number of securities so the subscription count stays bounded.
+return fundamentals.OrderByDescending(f => f.DollarVolume).Take(50).Select(f => f.Symbol);</pre>
+    <pre class="python"># Return a fixed number of securities so the subscription count stays bounded.
+return [f.symbol for f in sorted(fundamentals, key=lambda f: f.dollar_volume, reverse=True)[:50]]</pre>
+</div>
+
+<h4>Filter Option Chains Tightly</h4>
+
+<p>
+  An unfiltered Option chain contains every strike and expiry that traded, so the contract count dwarfs the underlying subscription.
+  Narrow the <a href="/docs/v2/writing-algorithms/universes/equity-options">Option universe</a> to the contracts the strategy trades.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Select the contracts within 3 strikes of the underlying price that expire within 30 days.
+option.SetFilter(u => u.Strikes(-3, 3).Expiration(0, 30));</pre>
+    <pre class="python"># Select the contracts within 3 strikes of the underlying price that expire within 30 days.
+option.set_filter(lambda u: u.strikes(-3, 3).expiration(0, 30))</pre>
+</div>
+
+<p>
+  The arguments of the <code class="csharp">Strikes</code><code class="python">strikes</code> method are a <i>count of strikes</i> from the at-the-money strike, not a percentage of the underlying price.
+  <code class="csharp">Strikes(-3, 3)</code><code class="python">strikes(-3, 3)</code> selects three strikes below and three strikes above the underlying price.
+</p>
+
+<p>
+  The default filter selects standard <i>and</i> weekly contracts, so weeklys are in the chain unless you exclude them.
+  When the strategy only trades standard expiries, call the <code class="csharp">StandardsOnly</code><code class="python">standards_only</code> method to drop the rest.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Drop the weekly contracts when the strategy only trades standard expiries.
+option.SetFilter(u =&gt; u.Strikes(-3, 3).Expiration(0, 30).StandardsOnly());</pre>
+    <pre class="python"># Drop the weekly contracts when the strategy only trades standard expiries.
+option.set_filter(lambda u: u.strikes(-3, 3).expiration(0, 30).standards_only())</pre>
+</div>
+
+<p>
+  When you need end-of-day contract statistics rather than a live chain, read the <a href="/docs/v2/writing-algorithms/historical-data/universe-data">Option Universe data</a> instead of subscribing to the contracts.
+</p>
+
+<h4>Chain Universes Instead of Accumulating Subscriptions</h4>
+
+<p>
+  To trade Options on a dynamic Equity universe, <a href="/docs/v2/writing-algorithms/universes/equity/chained-universes">chain the universes</a> rather than adding contracts by hand.
+  A chained universe adds and removes the Option contracts as the underlying universe changes, so the subscription count tracks the current selection instead of growing with every security the algorithm has ever selected.
+</p>
+
+<h4>Remove Subscriptions You Finished With</h4>
+
+<p>
+  Each subscription costs memory and dispatch time for as long as it lives.
+  Call the <code class="csharp">RemoveSecurity</code><code class="python">remove_security</code> method to <a href="/docs/v2/writing-algorithms/securities/requesting-data#07-Remove-Subscriptions">remove one</a> when the strategy no longer needs it.
+  The method cancels your open orders for the security and liquidates your holdings, so only call it when you intend to exit the position.
+</p>
+
+<h4>Turn Off Data the Strategy Never Reads</h4>
+
+<p>
+  Extended market hours data roughly doubles the bar count for a US Equity subscription.
+  Leave <a href="/docs/v2/writing-algorithms/universes/settings#05-Extended-Market-Hours">extended market hours</a> off unless the strategy trades in the pre-market or post-market session, and drop any secondary resolution the algorithm subscribes to but never reads.
+</p>

--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/04 History Requests.html
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/04 History Requests.html
@@ -1,0 +1,61 @@
+<p>
+  A <a href="/docs/v2/writing-algorithms/historical-data/history-requests">history request</a> reads and decompresses data outside the streaming data feed.
+  The work is not shared with the subscriptions the algorithm already has, so every call pays the full cost of loading the data again.
+  A bulk history request in the <code class="csharp">Initialize</code><code class="python">initialize</code> method can allocate more memory than the node has, which stops the algorithm with a memory error or a timeout that no larger node fixes.
+</p>
+
+<h4>Let LEAN Warm Up Your Indicators</h4>
+
+<p>
+  Most history requests exist to fill a rolling calculation before the strategy starts trading.
+  LEAN does that for you.
+  The following list shows the options in order of preference:
+</p>
+
+<ol>
+  <li>An <a href="/docs/v2/writing-algorithms/indicators/key-concepts">indicator</a> with a <a href="/docs/v2/writing-algorithms/historical-data/warm-up-periods">warm-up period</a>, which LEAN feeds from the data it already loads.</li>
+  <li>An <a href="/docs/v2/writing-algorithms/indicators/combining-indicators">indicator extension</a>, when the value you need is a function of other indicators.</li>
+  <li>The <a href="/docs/v2/writing-algorithms/securities/handling-data#05-Market-Session"><code class="csharp">Security.Session</code><code class="python">Security.session</code></a> property, for open, high, low, close, and volume values LEAN already caches.</li>
+  <li>A <a href="/docs/v2/writing-algorithms/historical-data/rolling-window"><code>RollingWindow</code></a>, only when LEAN has no built-in equivalent.</li>
+</ol>
+
+<div class="section-example-container">
+    <pre class="csharp">// Warm up the indicators from the data feed instead of requesting history.
+Settings.AutomaticIndicatorWarmUp = true;
+_sma = SMA(_symbol, 200, Resolution.Daily);</pre>
+    <pre class="python"># Warm up the indicators from the data feed instead of requesting history.
+self.settings.automatic_indicator_warm_up = True
+self._sma = self.sma(self._symbol, 200, Resolution.DAILY)</pre>
+</div>
+
+<h4>Keep History Requests Out of Repeated Code Paths</h4>
+
+<p>
+  Never call the <code class="csharp">History</code><code class="python">history</code> method inside the <code class="csharp">OnData</code><code class="python">on_data</code> method, inside a loop over the securities in your universe, or inside a universe selection function.
+  Each of those runs on every time step, so one history request becomes millions over a backtest.
+  A large <code>HistoryDataPoints</code> series on the Performance chart is the signature of this pattern.
+</p>
+
+<h4>Batch the Requests You Cannot Remove</h4>
+
+<p>
+  When the strategy genuinely needs history, make one request for all the securities instead of one request per security.
+  Request only the bars and fields you use.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Request the history of every symbol in one call.
+var history = History&lt;TradeBar&gt;(_symbols, 30, Resolution.Daily);</pre>
+    <pre class="python"># Request the history of every symbol in one call.
+history = self.history[TradeBar](self._symbols, 30, Resolution.DAILY)</pre>
+</div>
+
+<p class="python">
+  Iterating the typed enumerable, as in the preceding example, avoids building a <code>DataFrame</code>.
+  The <code>DataFrame</code> conversion is a large part of the cost of a Python history request, so skip it when you only need to loop over the bars.
+</p>
+
+<p>
+  Cache the result in a member variable so later time steps reuse it.
+  For data you derive once and reuse across backtests, save it to the <a href="/docs/v2/writing-algorithms/object-store">Object Store</a> and load it at the start of the algorithm.
+</p>

--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/05 Thin Event Handlers.php
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/05 Thin Event Handlers.php
@@ -1,0 +1,132 @@
+<p>
+  The <code class="csharp">OnData</code><code class="python">on_data</code> method runs on every time step, so any cost inside it is multiplied by the number of time steps in the backtest.
+  Work that does not need to run that often belongs somewhere else.
+</p>
+
+<h4>Move Periodic Work to Scheduled Events</h4>
+
+<p>
+  A strategy that rebalances monthly does not need to evaluate its rebalancing logic on every minute bar.
+  Put that logic in a <a href="/docs/v2/writing-algorithms/scheduled-events">Scheduled Event</a> and leave the data event handler to the work that genuinely reacts to each bar.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Run the rebalancing logic once a month instead of on every data event.
+Schedule.On(DateRules.MonthStart(_symbol), TimeRules.AfterMarketOpen(_symbol, 30), Rebalance);</pre>
+    <pre class="python"># Run the rebalancing logic once a month instead of on every data event.
+self.schedule.on(self.date_rules.month_start(self._symbol), self.time_rules.after_market_open(self._symbol, 30), self._rebalance)</pre>
+</div>
+
+<h4>Schedule One Event Per Market, Not One Per Security</h4>
+
+<p>
+  The <code class="csharp">Symbol</code><code class="python">Symbol</code> you pass to a date rule or time rule only selects the trading calendar the rule follows.
+  Securities that share a market share that calendar, so every US Equity fires at the same moment.
+  Schedule one event against any symbol in the market and loop over your securities inside the handler.
+  Scheduling one event per security multiplies the <code>Schedule</code> series by the size of your universe and gains you nothing.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// One event serves every US Equity because they all follow the same market hours.
+Schedule.On(DateRules.EveryDay(_spy), TimeRules.BeforeMarketClose(_spy, 10), Rebalance);</pre>
+    <pre class="python"># One event serves every US Equity because they all follow the same market hours.
+self.schedule.on(self.date_rules.every_day(self._spy), self.time_rules.before_market_close(self._spy, 10), self._rebalance)</pre>
+</div>
+
+<p>
+  Add a second event only for securities on a different calendar, such as Futures, Crypto, or a foreign exchange.
+</p>
+
+<h4>Consolidate Only to a Coarser Period</h4>
+
+<p>
+  A <a href="/docs/v2/writing-algorithms/consolidating-data/getting-started">consolidator</a> that produces bars at the resolution you already subscribed to rebuilds a bar LEAN just gave you.
+  It costs an update for every bar of every security and returns data you already have.
+  Read the bar from the data event handler instead.
+  Consolidators earn their cost when the period you want is coarser than the subscription, such as minute data consolidated into hourly or daily bars.
+  A large <code>Consolidators</code> series on the Performance chart often points at this mistake.
+</p>
+
+<p>
+  A consolidator builds the open, high, low, close, and volume of the aggregated bar, so it only pays for itself when you use more than the close.
+  When your logic reads the closing value alone, schedule an event at the end of the period and read the price there.
+  The Scheduled Event costs one call per period, while the consolidator costs an update for every bar in the period.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Read the closing price once a day instead of consolidating minute bars into daily bars.
+Schedule.On(DateRules.EveryDay(_spy), TimeRules.BeforeMarketClose(_spy, 1), () => { var close = Securities[_spy].Price; });</pre>
+    <pre class="python"># Read the closing price once a day instead of consolidating minute bars into daily bars.
+self.schedule.on(self.date_rules.every_day(self._spy), self.time_rules.before_market_close(self._spy, 1), lambda: self._record(self.securities[self._spy].price))</pre>
+</div>
+
+<h4>Read the Greeks Instead of Recomputing Them</h4>
+
+<p>
+  LEAN evaluates the Option price model lazily and caches the result on the contract.
+  Read the Greeks from the Option chain in the current slice.
+  Calling the <code class="csharp">EvaluatePriceModel</code><code class="python">evaluate_price_model</code> method yourself repeats work LEAN already did and can dominate the runtime of an Options strategy.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Read the cached Greeks from the chain instead of re-evaluating the price model.
+foreach (var contract in chain) { var delta = contract.Greeks.Delta; }</pre>
+    <pre class="python"># Read the cached Greeks from the chain instead of re-evaluating the price model.
+for contract in chain:
+    delta = contract.greeks.delta</pre>
+</div>
+
+<h4>Batch Your Orders</h4>
+
+<p>
+  Every order produces order events that LEAN processes and that your handlers see.
+  Rebalance less often and express the target portfolio through <a href="/docs/v2/writing-algorithms/algorithm-framework/portfolio-construction/key-concepts">portfolio targets</a> so LEAN issues the smallest set of orders that reaches the target.
+  This shows up as a smaller <code>Transactions</code> series.
+</p>
+
+<h4>Don't Submit Orders That Get Rejected</h4>
+
+<p>
+  An invalid order is not free.
+  LEAN still creates the order, runs it through the pre-trade checks, raises the order event, and keeps the record for the rest of the backtest, so every rejection costs both time and memory that you never get back.
+  Algorithms that react to a rejection by resizing and resubmitting pay for it several times over.
+</p>
+
+<p>
+  Check the conditions before you place the order rather than after LEAN refuses it.
+  The <a href="/docs/v2/writing-algorithms/trading-and-orders/pre-trade-risk-control#02-Basic-Validation">Basic Validation</a> page lists what LEAN checks: the security is tradable, the market is open, the last known price is not zero, and the quantity is neither zero nor smaller than the lot size.
+  Size the position from the buying power you have and skip the order when the result rounds to nothing.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Size the order from the available buying power and skip it when there is nothing to trade.
+var quantity = CalculateOrderQuantity(symbol, weight);
+if (quantity != 0) MarketOrder(symbol, quantity);</pre>
+    <pre class="python"># Size the order from the available buying power and skip it when there is nothing to trade.
+quantity = self.calculate_order_quantity(symbol, weight)
+if quantity != 0:
+    self.market_order(symbol, quantity)</pre>
+</div>
+
+<p>
+  Orders placed while the algorithm is <a href="/docs/v2/writing-algorithms/historical-data/warm-up-periods">warming up</a> are rejected as well, so guard that code path with the <code class="csharp">IsWarmingUp</code><code class="python">is_warming_up</code> property.
+</p>
+
+<h4>Filter Tick Data at the Source</h4>
+
+<p>
+  Tick subscriptions deliver both trades and quotes.
+  When the strategy only reads trades, add a <a href="/docs/v2/writing-algorithms/securities/filtering-data">security data filter</a> that drops the rest before the data reaches your algorithm.
+  Filtering out quote ticks removes the bid and ask information that market order fill models use, so check that the fills still model your strategy correctly.
+</p>
+
+<h4>Train Machine Learning Models Outside the Time Step</h4>
+
+<p>
+  An algorithm must normally process each time step within 10 minutes.
+  Fit models in the <a href="/docs/v2/research-environment/key-concepts/getting-started">Research Environment</a>, save them to the <a href="/docs/v2/writing-algorithms/object-store">Object Store</a>, and load them at runtime.
+  You can go further and <a href="/docs/v2/writing-algorithms/machine-learning/key-concepts#10-Increase-Backtest-Speed">precompute the predictions themselves</a> so the algorithm streams them in as a custom universe dataset.
+  When you have to fit inside the algorithm, use the <a href="/docs/v2/writing-algorithms/machine-learning/training-models"><code class="csharp">Train</code><code class="python">train</code> method</a>, which raises that limit for the training session.
+</p>
+
+<? include(DOCS_RESOURCES."/logging-statements/best-practices.php"); ?>

--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/06 Language Choice.html
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/06 Language Choice.html
@@ -1,0 +1,69 @@
+<p>
+  LEAN runs on .NET.
+  A C# algorithm compiles into the engine and calls it directly.
+  A Python algorithm runs through <a href="/docs/v2/writing-algorithms/key-concepts/python-and-lean">Python.NET</a>, which marshals every call that crosses between the two runtimes.
+</p>
+
+<p>
+  The cost of that boundary is paid per call, not per backtest, so it scales with the event rate of the strategy.
+  A daily-resolution strategy on a few securities crosses the boundary a few thousand times and the overhead is not measurable next to the data loading.
+  A tick-resolution or large-universe strategy crosses it millions of times and the overhead becomes the dominant cost.
+  Write tick-resolution and other high-event-rate strategies in C#.
+  For everything else, choose the language you are most productive in and apply the practices below.
+</p>
+
+<h4 class="python">Cache the Objects You Read Repeatedly</h4>
+
+<p class="python">
+  Every read of a LEAN object from Python crosses the boundary, so fetching the same object again on every bar is pure overhead.
+  Resolve it once and read your own copy afterwards.
+  The <a href="/docs/v2/writing-algorithms/universes/key-concepts#06-Security-Changed-Events"><code class="python">on_securities_changed</code> event handler</a> is the natural place to do it.
+</p>
+
+<div class="python section-example-container">
+    <pre class="python"># Resolve the Security objects once, when the universe changes.
+def on_securities_changed(self, changes):
+    for security in changes.added_securities:
+        self._securities[security.symbol] = security
+    for security in changes.removed_securities:
+        self._securities.pop(security.symbol, None)
+
+# Read from the plain Python dictionary in the event handler.
+def on_data(self, data):
+    for symbol, security in self._securities.items():
+        price = security.price</pre>
+</div>
+
+<h4 class="python">Track Order State Instead of Querying It</h4>
+
+<p class="python">
+  The <code class="python">self.transactions.get_open_orders()</code> method rebuilds the list of open orders on every call, and it is usually called from the hottest loop in the algorithm.
+  A strategy that maintains several stop-loss and take-profit orders per security across a large universe pays this cost on every bar.
+  Maintain your own dictionary of open tickets and update it from the <a href="/docs/v2/writing-algorithms/trading-and-orders/order-events">order event handler</a>.
+</p>
+
+<div class="python section-example-container">
+    <pre class="python"># Update your own view of the open orders when their state changes.
+def on_order_event(self, order_event):
+    if order_event.status.is_closed():
+        self._open_tickets.pop(order_event.order_id, None)</pre>
+</div>
+
+<p class="python">
+  The same rule applies to any property you read more than once in a time step, including portfolio holdings, security prices, and symbol properties.
+  Read the value into a local variable at the top of the handler, then use the local variable.
+</p>
+
+<p class="csharp">
+  In C#, reading a <code>Security</code> object or querying the open orders is an ordinary in-process call with no marshalling cost, so you do not need to cache these values to avoid a boundary crossing.
+</p>
+
+<h4 class="python">Push the Arithmetic into Compiled Code</h4>
+
+<p class="python">The following list shows how to keep numerical work out of the Python interpreter:</p>
+
+<ul class="python">
+  <li>Use the <a href="/docs/v2/writing-algorithms/indicators/supported-indicators">built-in indicators</a>, which execute as C#, instead of computing the same values in Python.</li>
+  <li>Vectorize array work with NumPy rather than looping in Python.</li>
+  <li>Apply <a href="/docs/v2/writing-algorithms/key-concepts/debugging-tools#08-JIT-Compilation">just-in-time compilation and caching</a> to the pure-Python functions that remain hot.</li>
+</ul>

--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/07 Node Sizing.php
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/07 Node Sizing.php
@@ -1,0 +1,61 @@
+<p>
+  Change the node last.
+  A node upgrade is the only step in this list that costs money on every backtest, and it is the step with the smallest effect on a well-written algorithm.
+</p>
+
+<h4>Extra Cores Do Not Speed Up Your Strategy Logic</h4>
+
+<p>
+  LEAN is multi-threaded and loads data in parallel, but your algorithm's events fire synchronously in backtesting.
+  As the <a href="/docs/v2/writing-algorithms/key-concepts/algorithm-engine#04-Threads-in-LEAN">Threads in LEAN</a> page states, the primary bottleneck to LEAN execution is executing client code.
+</p>
+
+<p>
+  The cores beyond the first serve LEAN's data loading, not your strategy.
+  A backtest that leaves most of its cores idle is behaving normally, and it tells you the algorithm spends its time in your code rather than waiting on data.
+  You cannot split one backtest across several cores or several nodes by writing the algorithm differently.
+</p>
+
+<h4>Throughput Comes From More Nodes, Not Bigger Ones</h4>
+
+<p>
+  One backtest runs on one node.
+  To run more backtests at the same time, add nodes.
+  When your backtests use a fraction of the RAM and cores of the node they run on, several smaller nodes give your organization more total throughput than the same spend on fewer large ones.
+</p>
+
+<h4>Backtesting Node Specifications</h4>
+
+<p>The following table shows the specifications of the <a href="/docs/v2/cloud-platform/organizations/resources#02-Backtesting-Nodes">backtesting node</a> models:</p>
+
+<? include(DOCS_RESOURCES."/specs/backtest-nodes.html"); ?>
+
+<p>
+  The B2-8, B4-12, and B8-16 nodes run at the same clock speed, so single-threaded algorithm code runs at the same speed on all three.
+  What the larger nodes add is RAM headroom and cores for data loading.
+  The B-MICRO and B4-16-GPU nodes run at a lower clock speed, so they execute algorithm code more slowly.
+</p>
+
+<p>
+  Size the node on the <i>peak</i> memory your algorithm reaches, not the average.
+  LEAN stops an algorithm when its smoothed memory reading crosses the node's limit, as the <a href="/docs/v2/writing-algorithms/key-concepts/debugging-tools#07-Memory-Metrics">Memory Metrics</a> page describes.
+  Universe selection and Option chains are the usual sources of memory spikes, so avoid the smallest nodes for those strategies.
+</p>
+
+<p>
+  Choose a GPU node only when the algorithm offloads computation to the device, such as training a deep learning model with a framework that uses the GPU.
+  It takes time to transfer data to the GPU, and the GPU node runs at a lower clock speed than the standard nodes, so an algorithm that does not use the GPU runs more slowly on it.
+</p>
+
+<h4>Test a Node Before You Commit to It</h4>
+
+<p>
+  You don't have to reason about which node your algorithm needs.
+  You can <a href="/docs/v2/cloud-platform/organizations/resources#15-Add-Nodes">add</a> and <a href="/docs/v2/cloud-platform/organizations/resources#16-Remove-Nodes">remove</a> nodes at any time, so add the model you want to evaluate, run your heaviest strategy on it, and remove it if it doesn't earn its cost.
+</p>
+
+<p>
+  Adding or removing a node renews your entire subscription period.
+  When you add one, QuantConnect charges you the difference in price between your current subscription and the new one, which covers both the node and the extension of the subscription.
+  When you remove one, the period renews in the same way and your organization receives a pro-rated credit that is applied to your next invoice.
+</p>

--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/metadata.json
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/metadata.json
@@ -1,0 +1,12 @@
+{
+    "type": "metadata",
+    "values": {
+        "description": "Speed up a slow backtest by measuring the algorithm with the Performance chart, reducing the data it consumes, removing history requests, and keeping the event handlers thin before changing the node.",
+        "keywords": "algorithm performance, slow backtest, backtest speed, performance chart, profiling, bottleneck, cpu usage, ram usage, node size, c# vs python",
+        "og:description": "Speed up a slow backtest by measuring the algorithm with the Performance chart, reducing the data it consumes, removing history requests, and keeping the event handlers thin before changing the node.",
+        "og:title": "Algorithm Performance - Documentation QuantConnect.com",
+        "og:type": "website",
+        "og:site_name": "Algorithm Performance - QuantConnect.com",
+        "og:image": "https://cdn.quantconnect.com/docs/i/writing-algorithms/key-concepts/algorithm-performance.png"
+    }
+}

--- a/03 Writing Algorithms/38 Logging/06 Best Practices.php
+++ b/03 Writing Algorithms/38 Logging/06 Best Practices.php
@@ -1,0 +1,1 @@
+<? include(DOCS_RESOURCES."/logging-statements/best-practices.php"); ?>

--- a/Resources/backtesting/results/performance-chart.php
+++ b/Resources/backtesting/results/performance-chart.php
@@ -68,6 +68,10 @@
       <td>OnData</td>
       <td>The total execution time of <code class="csharp">OnData</code><code class="python">on_data</code> method call and <code class="csharp">Alpha.Update</code><code class="python">alpha.update</code>, measured in seconds, recorded since the last sampling event.</td>
     </tr>
+    <tr>
+      <td>WallTime</td>
+      <td>The real time that elapsed since the last sampling event, measured in seconds.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/Resources/logging-statements/best-practices.php
+++ b/Resources/logging-statements/best-practices.php
@@ -1,0 +1,72 @@
+<h4>Log Sparingly</h4>
+
+<p>
+  Every log statement costs execution time and counts against your <a href="/docs/v2/cloud-platform/organizations/resources#09-Log-Quotas">log quota</a>, so a statement in a handler that runs on every time step can slow an algorithm down and exhaust the quota in a single run.
+  Never log without a bound inside the <code class="csharp">OnData</code><code class="python">on_data</code> event handler or inside a Scheduled Event that fires often.
+  Log the condition you are investigating, not every pass through the handler.
+</p>
+
+<p>
+  Use the <code class="csharp">Log</code><code class="python">log</code> method rather than the <code class="csharp">Debug</code><code class="python">debug</code> method for routine records.
+  Debug messages go through the messaging system, which rate limits them to protect your browser and slows the algorithm.
+  Reserve debug statements for the few messages you want to stand out in the terminal.
+</p>
+
+<h4>Gate Diagnostics Behind a Verbosity Level</h4>
+
+<p>
+  Rather than adding and removing diagnostic statements each time you investigate something, route them through one method that checks a verbosity level.
+  You keep the statements in place and turn them off for the runs where you do not need them.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Log the message only when the algorithm runs at or above the given verbosity level.
+private void Trace(int level, string message)
+{
+    if (level &lt;= _logLevel) Log(message);
+}</pre>
+    <pre class="python"># Log the message only when the algorithm runs at or above the given verbosity level.
+def _trace(self, level, message):
+    if level &lt;= self._log_level:
+        self.log(message)</pre>
+</div>
+
+<p>
+  The caller builds the message before the method runs, so string formatting still costs you even when the method discards the result.
+  In the handlers that run on every time step, check the level at the call site so you skip the formatting too.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Skip building the message when the level is off.
+if (_logLevel &gt;= 2) Trace(2, $"{Time}: {symbol} at {price}");</pre>
+    <pre class="python"># Skip building the message when the level is off.
+if self._log_level &gt;= 2:
+    self._trace(2, f"{self.time}: {symbol} at {price}")</pre>
+</div>
+
+<h4>Don't Log Prices</h4>
+
+<p>
+  Logging dataset information is not permitted, and a price log writes one line per bar per security, which is the largest and least useful log a backtest can produce.
+  To see a series, <a href="/docs/v2/writing-algorithms/charting">plot it</a> instead.
+</p>
+
+<p>
+  If you suspect the data itself is wrong, don't hunt for it with log statements across a full backtest.
+  Confirm the values in the <a href="/docs/v2/research-environment/key-concepts/getting-started">Research Environment</a> with a <a href="/docs/v2/writing-algorithms/historical-data/history-requests">history request</a> for the symbol and period in question, then <a href="/datasets/report-issue">report the data issue</a>.
+  Attach the notebook, or a short algorithm that runs over the affected days and shows the problem.
+</p>
+
+<h4>Record Trade Information on the Order</h4>
+
+<p>
+  To record why a trade happened, pass a <code class="csharp">tag</code><code class="python">tag</code> argument to the order method instead of writing a log statement.
+  The tag travels with the <a href="/docs/v2/writing-algorithms/trading-and-orders/order-management/order-tickets">order</a> and appears in the results, so you keep the context of each trade without the cost of logging it.
+</p>
+
+<div class="section-example-container">
+    <pre class="csharp">// Record the reason for the trade on the order instead of in the log.
+StopMarketOrder(symbol, -quantity, stopPrice, tag: "stop loss");</pre>
+    <pre class="python"># Record the reason for the trade on the order instead of in the log.
+self.stop_market_order(symbol, -quantity, stop_price, tag="stop loss")</pre>
+</div>


### PR DESCRIPTION
## Summary

Adds `03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance`, a new section on making an algorithm run faster. There is currently no page that consolidates this advice, so it has to be stitched together from the Performance Chart, Memory Metrics, JIT Compilation, and node specification pages.

The section is ordered from the cheapest, highest-leverage change to the most expensive one:

| Page | Covers |
| --- | --- |
| Introduction | The order to work through, and why node size is last |
| Measure First | Short-backtest repro, enabling the Performance chart, a series-to-fix routing table, reading resource usage from the results page and the API |
| Reduce Data Volume | Resolution, warm-up resolution, universe caps, Option chain filters, chained universes, removing subscriptions, extended market hours |
| History Requests | Warm-up instead of history, keeping `History` out of repeated code paths, batching the requests you cannot remove |
| Thin Event Handlers | Scheduled Events, one event per market, redundant consolidators, cached Greeks, order batching, avoiding rejected orders, tick filters, ML training, logging |
| Language Choice | The Python.NET boundary cost, caching securities and order state, pushing arithmetic into compiled code |
| Node Sizing | Why extra cores do not speed up strategy logic, throughput from more nodes, peak-RAM sizing, testing a node before committing to it |

The section links to the existing pages rather than restating them.

### Also in this PR

- Extracts the logging guidance into `Resources/logging-statements/best-practices.php`, following the pattern of the other `logging-statements` resources, and includes it from the Logging section, the Cloud Platform debugging page, and the new section.
- Adds the missing `WallTime` row to the Performance chart series table. Lean emits the series in `Common/Util/PerformanceTrackingTool.cs`, but the table does not list it.
- Records on the Add Nodes and Remove Nodes pages that adding or removing a node renews the subscription period.

## Test Plan

- [x] `python code-generators/detect-language-mixing.py` reports 0 errors and 0 warnings for the new and edited files.
- [x] `php -l` passes on every new and edited `.php` file.
- [x] All 43 internal `/docs/v2/` links in the new section resolve to an existing page and, where an anchor is given, to an existing file in that section.
- [x] Every claim is verified against this repo, the Lean source, or the linked page. The C#-versus-Python section states the shape of the relationship without quoting a multiple, since nothing in the repo measures it.
- [x] New and edited files use CRLF, matching the repo.
