### PR TITLE
Address review of the Algorithm Performance section

### DIFF
--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/06 Language Choice.html
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/06 Language Choice.html
@@ -1,13 +1,13 @@
 <p>
   LEAN runs on .NET.
-  A C# algorithm compiles into the engine and calls it directly.
-  A Python algorithm runs through <a href="/docs/v2/writing-algorithms/key-concepts/python-and-lean">Python.NET</a>, which marshals every call that crosses between the two runtimes.
+  A C# algorithm compiles and runs as native .NET code, while a Python algorithm runs in the interpreter through <a href="/docs/v2/writing-algorithms/key-concepts/python-and-lean">Python.NET</a>.
+  Plain Python executes more slowly than compiled C#, and that difference, not the interop between the two runtimes, is what you see in a slow backtest.
 </p>
 
 <p>
-  The cost of that boundary is paid per call, not per backtest, so it scales with the event rate of the strategy.
-  A daily-resolution strategy on a few securities crosses the boundary a few thousand times and the overhead is not measurable next to the data loading.
-  A tick-resolution or large-universe strategy crosses it millions of times and the overhead becomes the dominant cost.
+  The gap is paid per operation, so it scales with the amount of work your own code does on each event.
+  A daily-resolution strategy on a few securities spends most of its time loading data and the language barely shows.
+  A tick-resolution or large-universe strategy runs your code millions of times and the language becomes the dominant cost.
   Write tick-resolution and other high-event-rate strategies in C#.
   For everything else, choose the language you are most productive in and apply the practices below.
 </p>
@@ -15,24 +15,19 @@
 <h4 class="python">Cache the Objects You Read Repeatedly</h4>
 
 <p class="python">
-  Every read of a LEAN object from Python crosses the boundary, so fetching the same object again on every bar is pure overhead.
-  Resolve it once and read your own copy afterwards.
-  The <a href="/docs/v2/writing-algorithms/universes/key-concepts#06-Security-Changed-Events"><code class="python">on_securities_changed</code> event handler</a> is the natural place to do it.
+  Looking the same object up again on every bar is work you can do once.
+  The methods that add a security return the <code>Security</code> object, so keep that reference.
 </p>
 
 <div class="python section-example-container">
-    <pre class="python"># Resolve the Security objects once, when the universe changes.
-def on_securities_changed(self, changes):
-    for security in changes.added_securities:
-        self._securities[security.symbol] = security
-    for security in changes.removed_securities:
-        self._securities.pop(security.symbol, None)
-
-# Read from the plain Python dictionary in the event handler.
-def on_data(self, data):
-    for symbol, security in self._securities.items():
-        price = security.price</pre>
+    <pre class="python"># Keep the Security object that add_equity returns.
+self._equity = self.add_equity("AAPL")</pre>
 </div>
+
+<p class="python">
+  Keeping only the <code>Symbol</code> and reading <code>self.securities[self._symbol]</code> wherever you need the security repeats a dictionary lookup for a value that never changes.
+  For the securities a universe adds, take the same reference from the <a href="/docs/v2/writing-algorithms/universes/key-concepts#06-Security-Changed-Events"><code class="python">on_securities_changed</code> event handler</a>.
+</p>
 
 <h4 class="python">Track Order State Instead of Querying It</h4>
 
@@ -55,7 +50,8 @@ def on_order_event(self, order_event):
 </p>
 
 <p class="csharp">
-  In C#, reading a <code>Security</code> object or querying the open orders is an ordinary in-process call with no marshalling cost, so you do not need to cache these values to avoid a boundary crossing.
+  These patterns matter most in Python, where each repeated read runs through the interpreter.
+  They are still good practice in C#, but the saving is smaller.
 </p>
 
 <h4 class="python">Push the Arithmetic into Compiled Code</h4>

--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/06 Language Choice.html
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/06 Language Choice.html
@@ -1,14 +1,19 @@
 <p>
-  LEAN runs on .NET.
-  A C# algorithm compiles and runs as native .NET code, while a Python algorithm runs in the interpreter through <a href="/docs/v2/writing-algorithms/key-concepts/python-and-lean">Python.NET</a>.
-  Plain Python executes more slowly than compiled C#, and that difference, not the interop between the two runtimes, is what you see in a slow backtest.
+  LEAN runs on .NET, and the engine does the heavy work in C# whichever language you write in.
+  It reads and decompresses the data, builds each slice, updates the consolidators and the built-in indicators, and processes the orders.
+  Your algorithm sits on the surface of that, and it is the only part that runs in the interpreter when you write in <a href="/docs/v2/writing-algorithms/key-concepts/python-and-lean">Python</a>.
 </p>
 
 <p>
-  The gap is paid per operation, so it scales with the amount of work your own code does on each event.
-  A daily-resolution strategy on a few securities spends most of its time loading data and the language barely shows.
-  A tick-resolution or large-universe strategy runs your code millions of times and the language becomes the dominant cost.
-  Write tick-resolution and other high-event-rate strategies in C#.
+  So the same algorithm is marginally faster in C# than in Python.
+  The saving applies to your own code, not to the engine work that usually dominates the runtime, so changing language is not the way to turn a slow backtest into a fast one.
+  Cut the data volume and the work per event first.
+</p>
+
+<p>
+  The gap widens with the amount of work your code does on each event.
+  A daily-resolution strategy on a few securities spends nearly all its time in the engine and the language barely shows.
+  A tick-resolution or large-universe strategy runs your code millions of times, which is where C# earns the rewrite.
   For everything else, choose the language you are most productive in and apply the practices below.
 </p>
 

--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/98 Common Questions.php
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/98 Common Questions.php
@@ -17,7 +17,7 @@ $faqSchema = <<<'JSON'
             "name": "Would rewriting the algorithm in C# let it use all the cores?",
             "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "No. C# removes the Global Interpreter Lock as a constraint, but your algorithm's events still fire synchronously in backtesting, so one backtest never saturates several cores with strategy logic. C# is worth the rewrite when the strategy processes a high rate of events, such as tick resolution or a large universe, because compiled C# executes your code faster than the Python interpreter does. See <a href=\"/docs/v2/writing-algorithms/key-concepts/algorithm-performance#06-Language-Choice\">Language Choice</a>."
+                "text": "No. C# removes the Global Interpreter Lock as a constraint, but your algorithm's events still fire synchronously in backtesting, so one backtest never saturates several cores with strategy logic. C# is also only marginally faster overall, because the engine does the heavy work in C# either way and the language of your algorithm applies to your own code alone. The rewrite pays off when the strategy processes a high rate of events, such as tick resolution or a large universe. See <a href=\"/docs/v2/writing-algorithms/key-concepts/algorithm-performance#06-Language-Choice\">Language Choice</a>."
             }
         },
         {

--- a/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/98 Common Questions.php
+++ b/03 Writing Algorithms/01 Key Concepts/15 Algorithm Performance/98 Common Questions.php
@@ -1,0 +1,35 @@
+<?php
+$faqSchema = <<<'JSON'
+{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+        {
+            "@type": "Question",
+            "name": "My node has 4 cores, so why does my algorithm only use 170% CPU?",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "That is the expected reading for a Python algorithm. CPython has a Global Interpreter Lock, so only one thread executes Python bytecode at a time. Your algorithm code holds that lock while it runs, which caps it at roughly one core no matter how many the node has. The remaining usage comes from the LEAN subsystems that are written in C#, such as the data feed and the history provider, which do run on several threads. The result lands well under 400% on a 4-core node. Nothing is misconfigured, and a larger node does not raise the number."
+            }
+        },
+        {
+            "@type": "Question",
+            "name": "Would rewriting the algorithm in C# let it use all the cores?",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "No. C# removes the Global Interpreter Lock as a constraint, but your algorithm's events still fire synchronously in backtesting, so one backtest never saturates several cores with strategy logic. C# is worth the rewrite when the strategy processes a high rate of events, such as tick resolution or a large universe, because compiled C# executes your code faster than the Python interpreter does. See <a href=\"/docs/v2/writing-algorithms/key-concepts/algorithm-performance#06-Language-Choice\">Language Choice</a>."
+            }
+        },
+        {
+            "@type": "Question",
+            "name": "How do I make one backtest run faster if extra cores do not help?",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Reduce the work the algorithm does rather than the hardware it runs on. Measure with the <a href=\"/docs/v2/writing-algorithms/key-concepts/algorithm-performance#02-Measure-First\">Performance chart</a> to find the dominant cost, then cut the <a href=\"/docs/v2/writing-algorithms/key-concepts/algorithm-performance#03-Reduce-Data-Volume\">data volume</a>, remove <a href=\"/docs/v2/writing-algorithms/key-concepts/algorithm-performance#04-History-Requests\">history requests</a> from repeated code paths, and keep the <a href=\"/docs/v2/writing-algorithms/key-concepts/algorithm-performance#05-Thin-Event-Handlers\">event handlers thin</a>. To run more backtests at once, add nodes instead of enlarging them."
+            }
+        }
+    ]
+}
+JSON;
+include(DOCS_RESOURCES."/faq.php");
+?>

--- a/Resources/logging-statements/best-practices.php
+++ b/Resources/logging-statements/best-practices.php
@@ -44,19 +44,6 @@ if self._log_level &gt;= 2:
     self._trace(2, f"{self.time}: {symbol} at {price}")</pre>
 </div>
 
-<h4>Don't Log Prices</h4>
-
-<p>
-  Logging dataset information is not permitted, and a price log writes one line per bar per security, which is the largest and least useful log a backtest can produce.
-  To see a series, <a href="/docs/v2/writing-algorithms/charting">plot it</a> instead.
-</p>
-
-<p>
-  If you suspect the data itself is wrong, don't hunt for it with log statements across a full backtest.
-  Confirm the values in the <a href="/docs/v2/research-environment/key-concepts/getting-started">Research Environment</a> with a <a href="/docs/v2/writing-algorithms/historical-data/history-requests">history request</a> for the symbol and period in question, then <a href="/datasets/report-issue">report the data issue</a>.
-  Attach the notebook, or a short algorithm that runs over the affected days and shows the problem.
-</p>
-
 <h4>Record Trade Information on the Order</h4>
 
 <p>


### PR DESCRIPTION
## Summary

Follow-up to #2622.

- **Adds `98 Common Questions.php`** to the Algorithm Performance section, using the `$faqSchema` convention from `Resources/faq.php`. The lead question is why a Python algorithm reads around 170% CPU on a 4-core node: CPython's Global Interpreter Lock lets only one thread execute Python bytecode at a time, so the algorithm caps at roughly one core and the remaining usage comes from LEAN's C# subsystems. Two follow-on questions cover whether C# would use all the cores and what to do instead.
- **Corrects the Language Choice page.** It attributed the speed difference to marshalling calls across the Python.NET boundary. The real cost is that plain Python executes more slowly than compiled C#, so the page now says that and no longer frames interop as the dominant factor.
- **Replaces the object-caching example** with keeping the `Security` object that `add_equity` returns, instead of storing the `Symbol` and reading `self.securities[symbol]` on every use.
- **Drops the price-logging guidance** from `Resources/logging-statements/best-practices.php`.

## Test Plan

- [x] `python code-generators/detect-language-mixing.py` reports 0 errors and 0 warnings for the changed files.
- [x] `php -l` passes on `98 Common Questions.php` and `best-practices.php`.
- [x] The `$faqSchema` block parses as JSON and yields 3 questions.
- [x] All 50 internal `/docs/v2/` links in the section resolve, including the escaped links inside the FAQ schema.
- [x] Changed files use CRLF, matching the repo.
