### PR TITLE
Fix FIX order properties table overflow

### DIFF
--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/97 FIX Connections/03 Order Properties.html
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/97 FIX Connections/03 Order Properties.html
@@ -1,12 +1,12 @@
 <p>FIX connections support custom order properties. The following table describes the members of the <code>FixOrderProperties</code> object that you can set to customize order execution:</p>
 
-<table class="table qc-table">
+<table class="table qc-table" id="fix-order-properties-table">
     <thead>
         <tr>
-         <th>Property</th>
-         <th>Data Type</th>
-         <th>Description</th>
-         <th>Default Value</th>
+         <th style="width: 18%">Property</th>
+         <th style="width: 17%">Data Type</th>
+         <th style="width: 45%">Description</th>
+         <th style="width: 20%">Default Value</th>
         </tr>
     </thead>
     <tbody>
@@ -42,6 +42,18 @@
         </tr>
     </tbody>
 </table>
+
+<style>
+#fix-order-properties-table {
+    table-layout: fixed;
+}
+
+#fix-order-properties-table td,
+#fix-order-properties-table code {
+    white-space: normal;
+    overflow-wrap: break-word;
+}
+</style>
 
 <p>Each FIX connection provides an order properties class that inherits the <code>FixOrderProperties</code> class. For example, the Bloomberg FIX connection provides the <code>BloombergFixOrderProperties</code> class.</p>
 

--- a/Resources/brokerages/bloomberg-fix/orders.php
+++ b/Resources/brokerages/bloomberg-fix/orders.php
@@ -72,13 +72,13 @@
 <h4>Order Properties</h4>
 <p><?= $writingAlgorithms ? "The <code>BloombergFixBrokerageModel</code> supports custom order properties." : "We model custom order properties from the Bloomberg&trade; FIX connection." ?> The <code>BloombergFixOrderProperties</code> class inherits the <code>FixOrderProperties</code> class that every <a href='/docs/v2/cloud-platform/live-trading/brokerages/fix-connections'>FIX connection</a> shares. The following table describes the members of the <code>BloombergFixOrderProperties</code> object that you can set to customize order execution:</p>
 
-<table class="table qc-table">
+<table class="table qc-table" id="bloomberg-fix-order-properties-table">
     <thead>
         <tr>
-         <th>Property</th>
-         <th>Data Type</th>
-         <th>Description</th>
-         <th>Default Value</th>
+         <th style="width: 18%">Property</th>
+         <th style="width: 17%">Data Type</th>
+         <th style="width: 45%">Description</th>
+         <th style="width: 20%">Default Value</th>
         </tr>
     </thead>
     <tbody>
@@ -126,6 +126,18 @@
         </tr>
     </tbody>
 </table>
+
+<style>
+#bloomberg-fix-order-properties-table {
+    table-layout: fixed;
+}
+
+#bloomberg-fix-order-properties-table td,
+#bloomberg-fix-order-properties-table code {
+    white-space: normal;
+    overflow-wrap: break-word;
+}
+</style>
 
 <? if ($writingAlgorithms) { ?>
 <div class="section-example-container">

--- a/Resources/brokerages/terminal-link/orders.php
+++ b/Resources/brokerages/terminal-link/orders.php
@@ -62,13 +62,13 @@
 <h4>Order Properties</h4>
 <p>We model custom order properties from the Bloomberg EMSX API. The following table describes the members of the <code>TerminalLinkOrderProperties</code> object that you can set to customize order execution:</p>
 
-<table class="table qc-table" class='order-properties-table'>
+<table class="table qc-table" id="terminal-link-order-properties-table">
     <thead>
         <tr>
-         <th>Property</th>
-         <th>Data Type</th>
-         <th>Description</th>
-         <th>Default Value</th>
+         <th style="width: 18%">Property</th>
+         <th style="width: 17%">Data Type</th>
+         <th style="width: 45%">Description</th>
+         <th style="width: 20%">Default Value</th>
         </tr>
     </thead>
     <tbody>
@@ -212,6 +212,18 @@
         </tr>
     </tbody>
 </table>
+
+<style>
+#terminal-link-order-properties-table {
+    table-layout: fixed;
+}
+
+#terminal-link-order-properties-table td,
+#terminal-link-order-properties-table code {
+    white-space: normal;
+    overflow-wrap: break-word;
+}
+</style>
 
 <? if ($writingAlgorithms) { ?>
 <div class="section-example-container">


### PR DESCRIPTION
## Summary

The order properties tables on the Bloomberg and FIX pages ran past the content area and under the "In This Page" navigation, cutting off the Default Value column. Long unbreakable code tokens such as `FixOrderProperties.AUTOMATED_EXECUTION_ORDER_PRIVATE` and `BaseExtendedDictionary[str, str]` forced the tables wider than their container.

- Gives each column an explicit width and sets `table-layout: fixed`, so a table can never exceed its container.
- Lets the code tokens wrap with `white-space: normal` and `overflow-wrap: break-word`.

Applied to all three tables that carry this content:

- `Resources/brokerages/bloomberg-fix/orders.php`
- `Resources/brokerages/terminal-link/orders.php`
- `01 Cloud Platform/10 Live Trading/02 Brokerages/97 FIX Connections/03 Order Properties.html`

The Terminal Link table also carried a duplicate `class` attribute, which the browser ignored. That is replaced with the id the new rules need.

## Test plan

- Column widths sum to 100% in all three tables.
- The three tables use distinct element ids, so the rules stay scoped when the single-page build concatenates these pages.

## Note

The `Strategy` row of the Terminal Link table is missing its Default Value cell, so that row has three cells instead of four. It renders fine and is left as is.
