### PR TITLE
Document Free tier downgrade data loss and the Quant Researcher alternative

### DIFF
--- a/01 Cloud Platform/04 Organizations/08 Billing/07 Change Organization Tiers.php
+++ b/01 Cloud Platform/04 Organizations/08 Billing/07 Change Organization Tiers.php
@@ -38,9 +38,33 @@
 
 
 <h4>Free Tier</h4>
+
+<div class="highlight">
+    <p>Downgrading to the Free tier deletes data. If your goal is to lower your bill instead of leaving the platform, downgrade to the <a href="/docs/v2/cloud-platform/organizations/tier-features#03-Quant-Researcher-Tier">Quant Researcher</a> tier and remove every subscription except the seat. It's the lowest-cost paid tier, so your projects, backtest results, logs, and <a href="/docs/v2/cloud-platform/object-store">Object Store</a> data are preserved. If you only need a short break, <a href="/docs/v2/cloud-platform/organizations/billing#08-Pause-and-Resume-Subscriptions">pause your subscriptions</a> instead, which keeps your organization as it is.</p>
+</div>
+
 <p>Follow these steps to downgrade to the Free tier:</p>
 
 <ol>
     <li>On the <a href="/downgrade" class="menu-name">Downgrade</a> page, click <span class='button-name'>Cancel My Plan</span>.</li>
+    <li>Read the list of consequences the page shows and confirm you accept all of them. Cancelling your subscription means the following:
+
+        <ul>
+            <li>You lose access to node scaling and return to shared micro instances.</li>
+            <li>You can no longer collaborate with others.</li>
+            <li>Your backtest results and logs are deleted.</li>
+            <li>Projects that exceed the Free tier limits are deleted.</li>
+            <li>Your existing Object Store data is deleted.</li>
+            <li>Your live algorithms are stopped and their logs are deleted.</li>
+        </ul>
+
+        <p>These deletions are permanent, so save what you want to keep before you continue:</p>
+
+        <ul>
+            <li>To keep your projects, install the <a href="/docs/v2/lean-cli">LEAN CLI</a> and run <a href="/docs/v2/lean-cli/api-reference/lean-cloud-pull"><code>lean cloud pull</code></a> to copy them to your local drive.</li>
+            <li>To keep your results, call the <a href="/docs/v2/cloud-platform/api-reference/backtest-management/read-backtest">Read Backtest</a> and <a href="/docs/v2/cloud-platform/api-reference/live-management/read-live-algorithm">Read Live Algorithm</a> endpoints and store the responses.</li>
+            <li>You can't export your Object Store data. <a href="/docs/v2/lean-cli/object-store#04-Download-Files">Downloading files from the Object Store</a> is only available to permissioned <a href="/docs/v2/cloud-platform/organizations/tier-features#06-Institution-Tier">Institution</a> tier organizations, so unless your organization has that permission, treat the deletion as final.</li>
+        </ul>
+    </li>
     <li>Click the <span class='button-name'>I understand that my subscription will be terminated at the end of the current billing cycle</span> check box and then click <span class='button-name'>Cancel My Subscription</span>.</li>
 </ol>


### PR DESCRIPTION
## What

Document what downgrading to the Free tier actually does, and point users who
just want a smaller bill at the Quant Researcher tier instead.

Two changes to `01 Cloud Platform/04 Organizations/08 Billing/07 Change Organization Tiers.php`:

1. **A callout above the Free tier steps** recommending a downgrade to the
   **Quant Researcher** tier with every subscription except the seat removed.
   That is the lowest-cost paid plan, and it preserves projects, backtest
   results, logs, and Object Store data. It also links the pause/resume section
   for users who only need a short break.
2. **A new step between "Cancel My Plan" and the confirmation checkbox** that
   enumerates the consequences the Downgrade page itself lists, so a reader can
   see them before starting the flow rather than only in the middle of it:
   - You lose access to node scaling and return to shared micro instances.
   - You can no longer collaborate with others.
   - Your backtest results and logs are deleted.
   - Projects that exceed the Free tier limits are deleted.
   - Your existing Object Store data is deleted.
   - Your live algorithms are stopped and their logs are deleted.

   The step then says how to save each kind of data first: `lean cloud pull` for
   projects, the Read Backtest / Read Live Algorithm endpoints for results, and
   an explicit statement that Object Store data cannot be exported at all
   outside the Institution tier, so that deletion is final.

## Why

The page currently documents the downgrade as two clicks with no indication that
it is destructive. Two consequences in particular are not documented anywhere in
the docs:

- **Object Store data is deleted.** Since the Free tier no longer includes
  Object Store access, downgrading removes the organization's stored files, it
  does not merely lock them behind the paywall. `Resources/object-store/storage-sizes.html`
  states that the Object Store is available to paid organizations, but nothing
  connects that to what happens to existing data on a downgrade.
- **Backtest results and logs are deleted.** The only 90-day retention statement
  in the docs is on
  `01 Cloud Platform/14 Community/04 Profile/16 Deactivate Account.html`, which
  is about account deactivation, not tier changes, so it is easy to read the two
  as the same policy.

Support fields this repeatedly: customers ask to pause for longer than the
2-month cap, get pointed at the Free downgrade as the alternative, and are not
told what they are about to lose. Surfacing the Quant Researcher path in the
docs also gives that conversation a documented answer instead of a verbal one.

The wording of the consequences list mirrors the Downgrade page's own
"By cancelling my subscription I agree that" panel, so the docs and the product
stay consistent.

## Notes

- Content-only change to one `.php` file; no PHP added, only HTML.
- Uses the repo's existing `<div class="highlight">` callout convention.
- Internal links used, all already referenced elsewhere in the repo:
  `/docs/v2/cloud-platform/organizations/tier-features#03-Quant-Researcher-Tier`,
  `/docs/v2/cloud-platform/object-store`,
  `/docs/v2/cloud-platform/organizations/billing#08-Pause-and-Resume-Subscriptions`,
  `/docs/v2/lean-cli`, `/docs/v2/lean-cli/api-reference/lean-cloud-pull`,
  `/docs/v2/cloud-platform/api-reference/backtest-management/read-backtest`,
  `/docs/v2/cloud-platform/api-reference/live-management/read-live-algorithm`,
  `/docs/v2/lean-cli/object-store#04-Download-Files`,
  `/docs/v2/cloud-platform/organizations/tier-features#06-Institution-Tier`.
- Raised from Intercom conversation 215475562212707.
