### PR TITLE
Add MarketOnOpen daily-resolution fill note to orders skill

### DIFF
--- a/skill-templates/orders/SKILL.md
+++ b/skill-templates/orders/SKILL.md
@@ -50,6 +50,9 @@ When a method enters or exits at the close, sample the signal and submit the MOC
 ## Market-on-close is for exchange-traded assets only — NOT crypto
 Market-on-close fills at an exchange's official closing auction. Cryptocurrencies trade 24/7 and have no closing auction, so py`market_on_close_order`cs`MarketOnCloseOrder` and its submission-buffer timing do NOT apply to crypto. For a daily crypto rebalance, fire a scheduled event at your chosen daily boundary (e.g. midnight UTC) and rebalance with py`set_holdings`cs`SetHoldings` / market orders. Do not deliberate market-on-close for crypto — it is not a thing there.
 
+## MarketOnOpen fills on daily resolution
+A market order submitted while the market is closed converts to MarketOnOpen; on daily resolution it is not processed until the session's daily bar arrives, and fills at that bar's open. Nothing can observe the fill before then — never schedule an event to check whether it filled, and never py`self.quit()`cs`Quit()` earlier: the order still reads `Submitted` with flat equity, which looks like a platform bug but is just a truncated run. Verify fills from the completed backtest's order records instead.
+
 ## Exiting / flattening
 - Market-order exit: py`self.liquidate()`cs`Liquidate()` closes ALL holdings, py`self.liquidate(symbol)`cs`Liquidate(symbol)` closes one.
 - Exit AT THE CLOSE: py`liquidate`cs`Liquidate` sends a market order, so for a close fill flatten with an MOC order for the negative of the current position:

--- a/skills/csharp/orders/SKILL.md
+++ b/skills/csharp/orders/SKILL.md
@@ -36,6 +36,9 @@ When a method enters or exits at the close, sample the signal and submit the MOC
 ## Market-on-close is for exchange-traded assets only — NOT crypto
 Market-on-close fills at an exchange's official closing auction. Cryptocurrencies trade 24/7 and have no closing auction, so `MarketOnCloseOrder` and its submission-buffer timing do NOT apply to crypto. For a daily crypto rebalance, fire a scheduled event at your chosen daily boundary (e.g. midnight UTC) and rebalance with `SetHoldings` / market orders. Do not deliberate market-on-close for crypto — it is not a thing there.
 
+## MarketOnOpen fills on daily resolution
+A market order submitted while the market is closed converts to MarketOnOpen; on daily resolution it is not processed until the session's daily bar arrives, and fills at that bar's open. Nothing can observe the fill before then — never schedule an event to check whether it filled, and never `Quit()` earlier: the order still reads `Submitted` with flat equity, which looks like a platform bug but is just a truncated run. Verify fills from the completed backtest's order records instead.
+
 ## Exiting / flattening
 - Market-order exit: `Liquidate()` closes ALL holdings, `Liquidate(symbol)` closes one.
 - Exit AT THE CLOSE: `Liquidate` sends a market order, so for a close fill flatten with an MOC order for the negative of the current position:

--- a/skills/python/orders/SKILL.md
+++ b/skills/python/orders/SKILL.md
@@ -36,6 +36,9 @@ When a method enters or exits at the close, sample the signal and submit the MOC
 ## Market-on-close is for exchange-traded assets only — NOT crypto
 Market-on-close fills at an exchange's official closing auction. Cryptocurrencies trade 24/7 and have no closing auction, so `market_on_close_order` and its submission-buffer timing do NOT apply to crypto. For a daily crypto rebalance, fire a scheduled event at your chosen daily boundary (e.g. midnight UTC) and rebalance with `set_holdings` / market orders. Do not deliberate market-on-close for crypto — it is not a thing there.
 
+## MarketOnOpen fills on daily resolution
+A market order submitted while the market is closed converts to MarketOnOpen; on daily resolution it is not processed until the session's daily bar arrives, and fills at that bar's open. Nothing can observe the fill before then — never schedule an event to check whether it filled, and never `self.quit()` earlier: the order still reads `Submitted` with flat equity, which looks like a platform bug but is just a truncated run. Verify fills from the completed backtest's order records instead.
+
 ## Exiting / flattening
 - Market-order exit: `self.liquidate()` closes ALL holdings, `self.liquidate(symbol)` closes one.
 - Exit AT THE CLOSE: `liquidate` sends a market order, so for a close fill flatten with an MOC order for the negative of the current position:


### PR DESCRIPTION
A market order submitted while the market is closed converts to MarketOnOpen; on daily resolution it is not processed until the session's daily bar arrives, so nothing can observe the fill before then.

Agents hit this repeatedly: they schedule an intraday event to check whether orders filled, or end the run early, and then read the resulting `Submitted`-with-flat-equity state as a platform fill failure — burning long debugging detours on a phantom bug.

Verified by probe backtest on daily-resolution US equities and equity options (regular sessions): pre-open orders fill at the daily bar's open, processed at the session end.

Edits `skill-templates/orders/SKILL.md` (the source); the generated `skills/python|csharp` copies come from the bundler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)