### PR TITLE
Fix broken Bloomberg BPIPE link in Terminal Link docs

### DIFF
--- a/05 Lean CLI/05 Datasets/13 Terminal Link/10 Live Trading.html
+++ b/05 Lean CLI/05 Datasets/13 Terminal Link/10 Live Trading.html
@@ -18,5 +18,5 @@
 
 <p>
   The preceding commands stream data through the Bloomberg&trade; SAPI or DAPI connection.
-  To stream live data through a dedicated Bloomberg&trade; BPIPE ticker plant that QuantConnect operates for your organization, see <a href='/docs/v2/cloud-platform/datasets/bloomberg-bpipe'>Bloomberg BPIPE</a>.
+  To stream live data through a dedicated Bloomberg&trade; BPIPE ticker plant that QuantConnect operates for your organization, see <a href='https://www.quantconnect.com/docs/v2/cloud-platform/datasets/bloomberg-bpipe'>Bloomberg BPIPE</a>.
 </p>


### PR DESCRIPTION
## Summary

Fixes #2638.

The Terminal Link "Live Trading" page under Lean CLI linked to the Bloomberg BPIPE dataset page with a relative URL. `url_check.py` also resolves relative links in `05 Lean CLI/` and `06 LEAN Engine/` against `www.lean.io`, which does not host the `cloud-platform` docs, so the link was reported as both a `soft_404` and a `leanio_nonexistence` error.

Changed the link to the absolute `https://www.quantconnect.com/docs/v2/cloud-platform/datasets/bloomberg-bpipe` URL, matching how every other cross-section link in the Lean CLI folder is written.

## Test Plan

- `grep` confirms no other relative `/docs/v2/{cloud-platform,local-platform,writing-algorithm,research-environment}` links remain under `05 Lean CLI/` or `06 LEAN Engine/`.
- Ran `url_check.py`'s extraction and checks scoped to the edited file: 28 URLs, no errors — the BPIPE link no longer produces a `www.lean.io` twin.
- `curl` confirms `https://www.quantconnect.com/docs/v2/cloud-platform/datasets/bloomberg-bpipe` returns 200 with the "Bloomberg BPIPE" page title.
