### PR TITLE
Label second-resolution Option data as live-trading only

### DIFF
--- a/Resources/securities/resolutions/cfd.html
+++ b/Resources/securities/resolutions/cfd.html
@@ -20,28 +20,28 @@
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-	    <td><br></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="supported"><span class="sr-only">Supported</span>✓</td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-	    <td><br></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="supported"><span class="sr-only">Supported</span>✓</td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-	    <td><br></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="supported"><span class="sr-only">Supported</span>✓</td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-	    <td><br></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="supported"><span class="sr-only">Supported</span>✓</td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>

--- a/Resources/securities/resolutions/equity-options.html
+++ b/Resources/securities/resolutions/equity-options.html
@@ -15,13 +15,13 @@
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
 	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
-            <td><br></td>
-            <td><br></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-	    <td><br></td>
-            <td><br></td>
+	    <td class="supported" style="color: #d97706;"><span class="sr-only">Supported in live trading only</span>&#9888;&#xFE0E;</td>
+            <td class="supported" style="color: #d97706;"><span class="sr-only">Supported in live trading only</span>&#9888;&#xFE0E;</td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
@@ -48,3 +48,5 @@
         </tr>
     </tbody>
 </table>
+
+<p><span style="color: #d97706;">&#9888;&#xFE0E;</span> Supported in live trading only.</p>

--- a/Resources/securities/resolutions/forex.html
+++ b/Resources/securities/resolutions/forex.html
@@ -20,28 +20,28 @@
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-	    <td><br></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="supported"><span class="sr-only">Supported</span>✓</td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
-	    <td><br></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="supported"><span class="sr-only">Supported</span>✓</td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Hour</code><code class="python">HOUR</code></td>
-	    <td><br></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="supported"><span class="sr-only">Supported</span>✓</td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Daily</code><code class="python">DAILY</code></td>
-	    <td><br></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="supported"><span class="sr-only">Supported</span>✓</td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>

--- a/Resources/securities/resolutions/future-options.html
+++ b/Resources/securities/resolutions/future-options.html
@@ -15,13 +15,13 @@
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
 	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
-            <td><br></td>
-            <td><br></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-	    <td><br></td>
-            <td><br></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>

--- a/Resources/securities/resolutions/index-options.html
+++ b/Resources/securities/resolutions/index-options.html
@@ -15,13 +15,13 @@
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
 	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
-            <td><br></td>
-            <td><br></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-	    <td><br></td>
-            <td><br></td>
+	    <td class="supported" style="color: #d97706;"><span class="sr-only">Supported in live trading only</span>&#9888;&#xFE0E;</td>
+            <td class="supported" style="color: #d97706;"><span class="sr-only">Supported in live trading only</span>&#9888;&#xFE0E;</td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
@@ -48,3 +48,5 @@
         </tr>
     </tbody>
 </table>
+
+<p><span style="color: #d97706;">&#9888;&#xFE0E;</span> Supported in live trading only.</p>

--- a/Resources/securities/resolutions/index.html
+++ b/Resources/securities/resolutions/index.html
@@ -16,19 +16,19 @@
 	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
-            <td><br></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
 	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
-            <td><br></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
 	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
-            <td><br></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>

--- a/Resources/securities/resolutions/india-equity.html
+++ b/Resources/securities/resolutions/india-equity.html
@@ -15,20 +15,20 @@
             <td><code class="csharp">Tick</code><code class="python">TICK</code></td>
 	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
-            <td><br></td>
-            <td><br></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Second</code><code class="python">SECOND</code></td>
-	    <td><br></td>
-            <td><br></td>
+	    <td class="unsupported"><span class="sr-only">Not supported</span></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>
         <tr>
             <td><code class="csharp">Minute</code><code class="python">MINUTE</code></td>
 	    <td class="supported"><span class="sr-only">Supported</span>✓</td>
-            <td><br></td>
+            <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
             <td class="unsupported"><span class="sr-only">Not supported</span></td>
         </tr>


### PR DESCRIPTION
## Summary

The Equity Option and Index Option resolution tables left the Second row's TradeBar and QuoteBar cells blank, which reads as "not supported" even though those subscriptions work in live trading and only lack historical data. Those cells now show an amber warning sign with an `sr-only` "Supported in live trading only" label, plus a legend line under each table.

While there, every remaining blank cell in `Resources/securities/resolutions/` gets the `unsupported` class and its `sr-only` "Not supported" label. These tables are read by screen readers and AI agents, both of which see nothing at all in an empty cell. Each cell now states its own value rather than leaving the reader to infer meaning from blank space, which matters because a retrieval chunk may contain a single row with no legend attached.

Future Options is deliberately unchanged in meaning: there is no live Future Options data feed, so its Second row stays "not supported".

## Test plan

- [x] `grep -c "<td><br></td>" Resources/securities/resolutions/*.html` returns no matches
- [x] Every table has all 20 cells (5 resolutions x 4 data formats) carrying either the `supported` or `unsupported` class and an `sr-only` label
- [ ] Render the Equity Option and Index Option resolution pages and confirm the Second row shows a centered amber warning sign, the legend line appears under the table, and every other table looks unchanged