### PR TITLE
Document the IB FIX authentication flow in the deployment wizard

### DIFF
--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/03 FIX Integration.html
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/03 FIX Integration.html
@@ -2,7 +2,7 @@
 	If you already hold an IB account, you can subscribe to QuantConnect directly from the IB Client Portal to enable FIX order routing.</p>
 
 <p>
-	FIX integration is not supported for IB simulated accounts, which start with the letters 'DU'. You can trade multiple IB subaccounts, but all subaccounts must be linked to the same QuantConnect user Id.
+	FIX integration is not supported for IB simulated accounts, which start with the letters 'DU'. You can trade multiple IB subaccounts, but all subaccounts must be linked to the same QuantConnect account.
 </p>
 
 <p>
@@ -11,6 +11,11 @@
 </p>
 
 <p>Before you start, make sure you have an active IB account and access to the IB Client Portal.</p>
+
+<p>
+	Step 5 asks for the <span class='field-name'>Operator ID</span> that links your IB account to QuantConnect. QuantConnect generates this value, so get it first.
+	To get it, <a href='/docs/v2/cloud-platform/live-trading/brokerages/interactive-brokers#17-Deploy-Live-Algorithms-FIX'>open the live deployment wizard</a>, authenticate with your IB user name, and then select the account you want to trade.
+</p>
 
 <p>Follow these steps to add FIX support to your IB account:</p>
 
@@ -23,11 +28,11 @@
 	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-03.png'>
 	<li>On the <span class='page-section-name'>Service Account Configuration</span> screen, click the <span class='button-name'>Configure</span> gear next to QuantConnect.</li>
 	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-04.png'>
-	<li>In the <span class='page-section-name'>Service Account Configuration for QuantConnect</span> dialog, select the IB account(s) you want to link, enter your QuantConnect user Id in the <span class='field-name'>Quantconnect Username</span> field, and then click <span class='button-name'>Save</span>.</li>
+	<li>In the <span class='page-section-name'>Service Account Configuration for QuantConnect</span> dialog, select the IB account(s) you want to link, enter your <span class='field-name'>Operator ID</span> in the <span class='field-name'>QuantConnect UID</span> field, and then click <span class='button-name'>Save</span>.</li>
 	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-05-uid.png'>
 	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-06-uid0.png'>
-	<p>The user Id you enter is the default subscriber for the QuantConnect service. You can select multiple accounts here. When you later connect from QuantConnect to IB, you enter this same user Id to authenticate.</p>
-	<p>To get your QuantConnect user Id, <a href='https://www.quantconnect.com/docs/v2/cloud-platform/community/profile#09-Request-API-Token'>request an API token</a>. We email you your user Id and API token.</p>
+	<p>The <span class='field-name'>Operator ID</span> you enter is the default subscriber for the QuantConnect service. You can select multiple accounts here.</p>
+	<p>To get your <span class='field-name'>Operator ID</span>, see <a href='/docs/v2/cloud-platform/live-trading/brokerages/interactive-brokers#17-Deploy-Live-Algorithms-FIX'>Deploy Live Algorithms FIX</a>.</p>
 	<li>Back on the <span class='page-section-name'>Service Account Configuration</span> screen, click <span class='button-name'>Continue</span>.</li>
 	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-07.png'>
 	<li>Acknowledge and confirm the OMS Riders and Addendum.</li>

--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/17 Deploy Live Algorithms FIX.php
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/17 Deploy Live Algorithms FIX.php
@@ -3,7 +3,19 @@ $brokerageName = "<a rel='nofollow' target='_blank' href='https://qnt.co/interac
 $cashState = false;
 $holdingsState = false;
 $secondBullet = "";
-$authentication = "  <li>Enter your <a rel='nofollow' target='_blank' href='https://qnt.co/interactivebrokers'>IB</a> user name (see <a href='/docs/v2/cloud-platform/live-trading/brokerages/interactive-brokers#03-FIX-Integration'>FIX Integration</a>).</li>";
+$authentication = "
+    <li>In the <span class='page-section-name'>Interactive Brokers (FIX) Authentication</span> section, follow these steps:</li>
+    <ol>
+        <li>Click the <span class='field-name'>Account</span> field and then click your <a rel='nofollow' target='_blank' href='https://qnt.co/interactivebrokers'>IB</a> user name from the drop-down menu.</li>
+        <p>To use an IB user name you haven't linked yet, click <span class='button-name'>+ Add Account</span> and then enter it in the <span class='field-name'>IBKR User Name</span> field.</p>
+        <li>Click <span class='button-name'>Authenticate</span> and then log in to IB.</li>
+        <p>When you succeed, the <span class='field-name'>Authorization</span> row shows <span class='field-name'>Authorization Complete</span> and the wizard displays the <span class='field-name'>Account ID</span>, <span class='field-name'>Locator ID</span>, and <span class='field-name'>Operator ID</span> fields.</p>
+        <li>Click the <span class='field-name'>Account ID</span> field and then click the IB account you want to trade from the drop-down menu.</li>
+        <li>In the <span class='field-name'>Locator ID</span> field, enter the two-letter country code of your location (for example, US or CA).</li>
+        <p>IB uses the <span class='field-name'>Locator ID</span> to identify where the trading decision was made on Future and Future Option orders. If you trade Futures, set it. Otherwise, you can leave it blank.</p>
+        <li>Copy the value in the <span class='field-name'>Operator ID</span> field and then add it to your IB account.</li>
+        <p>QuantConnect generates the <span class='field-name'>Operator ID</span> from the account you select, so it stays empty until you select an <span class='field-name'>Account ID</span>. Your IB account only accepts orders from QuantConnect after you register this value, so add it before you continue. To register it, follow the steps in <a href='/docs/v2/cloud-platform/live-trading/brokerages/interactive-brokers#03-FIX-Integration'>FIX Integration</a> and then return to this page.</p>
+    </ol>";
 $dataProviderDetails =  "<p>In most cases, we suggest using <a href='/docs/v2/cloud-platform/datasets/interactive-brokers#06-Hybrid-Data-Provider'>both the QC and IB data providers</a>.</p>" . file_get_contents(DOCS_RESOURCES."/brokerages/interactive-brokers/paper-trading-data-feeds.html");
 $postDeploy = "<li>If your IB account has 2FA enabled, tap the notification on your IB Key device and then enter your pin.</li>";
 include(DOCS_RESOURCES."/live-trading/deploy-live-algorithm.php");


### PR DESCRIPTION
## Summary

The Interactive Brokers (FIX) authentication panel in the live deployment wizard has two states and five controls, but the docs described one field, and the FIX Integration page told users to register the wrong value with IB.

**`17 Deploy Live Algorithms FIX.php`** — the `$authentication` bullet was a single "enter your IB user name" step. It is now the full sequence: the `Account` drop-down (with `+ Add Account` revealing `IBKR User Name`), `Authenticate`, then the `Account ID`, `Locator ID` and `Operator ID` fields that appear after authorization completes. The bullets go in a nested `<ol>`, matching how the cash-state and holdings-state blocks nest inside the shared `<ol>` in `Resources/live-trading/deploy-live-algorithm.php`.

`Locator ID` is documented as Futures-specific. It is only read in `TrySetRequiredFuturesIdentification`, which sets the FIX `SenderLocationID` field ("identify location of decision maker or ALGO") and is called for `Future` and `FutureOption` only. It is read without the factory's error list, so a blank value never blocks a deployment.

**`03 FIX Integration.html`** — step 5 said to enter "your QuantConnect user Id" and to obtain it by requesting an API token. IB renamed that field to `QuantConnect UID`, and the value it takes is the Operator ID from the wizard. Corrected the field name and the value, replaced the API-token paragraph with a link to the wizard page, and added a note before the steps that the Operator ID comes from QuantConnect first — otherwise the page reads as a self-contained Client Portal walkthrough that stalls at step 5.

## Test plan

- [x] `php -l` passes on `17 Deploy Live Algorithms FIX.php`.
- [x] The new bullets are `<li>` elements inside a nested `<ol>` and do not open a list at the top level of the shared partial, so numbering in `deploy-live-algorithm.php` is unaffected.
- [x] `field-name`, `button-name` and `page-section-name` spans match the surrounding pages.
- [x] Both cross-links resolve: `#03-FIX-Integration` and `#17-Deploy-Live-Algorithms-FIX` follow the existing anchor convention used elsewhere for this folder.
- [x] The existing images already show `QuantConnect UID`; verified the CDN copies of `ib-fix-05-uid.png` and `ib-fix-06-uid0.png` are current, so only the prose was stale.
- [ ] Screenshots of the two wizard states are not included. They should be captured from a cloud session and added as `ib-fix-10.png` / `ib-fix-11.png`.
