### PR TITLE
Warn that the IB data provider undoes the benefit of FIX

### DIFF
--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/05 Data Providers.php
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/05 Data Providers.php
@@ -6,3 +6,10 @@ $missingAssets = "Index or Future Options";
 $affectedAssets = "Indices, Index Options, or Future Options";
 include(DOCS_RESOURCES."/brokerages/data-providers.php");
 ?>
+
+<p>
+  If you route orders through <a href='/docs/v2/cloud-platform/live-trading/brokerages/interactive-brokers#03-FIX-Integration'>FIX</a>, use the QuantConnect data provider on its own.
+  The IB data provider streams data through the IB API instead of your FIX session, so it brings back the weekly logins that FIX removes.
+  To trade <?=$affectedAssets?>, you need the IB data provider, so you have to accept those logins.
+</p>
+


### PR DESCRIPTION
## Summary

The FIX Integration page sells FIX partly on this: *"The QC-IBKR fix integration remains up forever, and prevents the need for weekly re-logins associated with the IB-Gateway technology."*

The Data Providers page then recommends combining the QuantConnect data provider with the IB data provider to trade Indices, Index Options and Future Options — without mentioning that the IB data provider does not ride the FIX session. It connects through the IB API, so a FIX user who follows that advice is back to logging in every week, and nothing on either page explains why.

Added a short note after the shared `data-providers.php` include stating the tradeoff. The existing recommendation stands; the note just prices it.

## Test plan

- [x] `php -l` passes on `05 Data Providers.php`.
- [x] The note is appended after the include rather than added to `Resources/brokerages/data-providers.php`, which is shared by every brokerage and would be wrong for the ones without FIX.
- [x] Reuses `$affectedAssets`, already set above the include, so the asset list stays consistent with the sentence the partial renders.
- [x] The `#03-FIX-Integration` anchor matches the convention used elsewhere in this folder.
