### PR TITLE
Document the IB FIX Market Data permission and UID re-edit steps

### DIFF
--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/03 FIX Integration.html
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/03 FIX Integration.html
@@ -13,6 +13,15 @@
 <p>Before you start, make sure you have an active IB account and access to the IB Client Portal.</p>
 
 <p>
+	The IB user you log in with needs <span class='field-name'>Market Data</span> access to manage research subscriptions. If the <span class='page-section-name'>Research Subscriptions</span> section is missing or empty, open the user's access rights in the IB Client Portal and then enable <span class='field-name'>Market Data</span>. IB applies this permission immediately. <span class='field-name'>Subscriber Status</span> access alone is not enough.
+</p>
+<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-market-data.png'>
+
+<p>
+	Each IB account has its own <span class='field-name'>IBKR QC UID</span>, but a master user can only save one UID for all of the accounts it manages. To register a different UID for each subaccount, log in as the subaccount user and then follow these steps for that account.
+</p>
+
+<p>
 	Step 5 asks for the <span class='field-name'>IBKR QC UID</span> that links your IB account to QuantConnect. QuantConnect generates this value, so get it first.
 	To get it, <a href='/docs/v2/cloud-platform/live-trading/brokerages/interactive-brokers#17-Deploy-Live-Algorithms-FIX'>open the live deployment wizard</a>, authenticate with your IB user name, and then select the account you want to trade.
 </p>
@@ -40,4 +49,5 @@
 	<img class='docs-image' src='https://cdn.quantconnect.com/i/tu/ib-fix-09.png'>
 	<p>After you confirm, your subscription is complete and the selected information is added to the FIX connection for order validation.</p>
 	<p>You only need to complete these steps once for each <span class='field-name'>IBKR QC UID</span>, so repeat them when you trade an account you haven't registered yet. Wait about 5 minutes for IB to apply the change before you <a href='/docs/v2/cloud-platform/live-trading/brokerages/interactive-brokers#17-Deploy-Live-Algorithms-FIX'>deploy a live algorithm</a>.</p>
+	<p>After you subscribe, the <span class='page-section-name'>Service Account Configuration</span> screen no longer appears in your subscriptions. To edit an <span class='field-name'>IBKR QC UID</span> you already saved, click <span class='button-name'>Manage Subscriptions</span>, click <span class='button-name'>Continue</span> twice without changing any subscription, and then click the <span class='button-name'>Configure</span> gear next to QuantConnect.</p>
 </ol>


### PR DESCRIPTION
## Summary

Adds the missing setup details users hit when enabling the IBKR FIX integration, reported by a beta tester:

- The IB user needs **Market Data** access to manage research subscriptions. Without it the Research Subscriptions section is missing or empty. **Subscriber Status** access alone is not enough, which is what blocked the reporter.
- A master user can only save one `IBKR QC UID` for all the accounts it manages, so registering a different UID per subaccount requires logging in as the subaccount user.
- Once subscribed, the Service Account Configuration screen disappears from the subscriptions list. To edit a saved UID, reopen Manage Subscriptions and click Continue twice without changing any subscription.

## Test plan

- Render `Cloud Platform > Live Trading > Brokerages > Interactive Brokers > FIX Integration` and confirm the three new paragraphs read correctly and the numbered steps are unchanged.
- Confirm the new screenshot loads: https://cdn.quantconnect.com/i/tu/ib-fix-market-data.png (634x575, matching the width of the other images on the page).