### PR TITLE
Close the source list on the Crypto Sourcing pages

### DIFF
--- a/01 Cloud Platform/09 Datasets/07 QuantConnect/03 Crypto/02 Sourcing.php
+++ b/01 Cloud Platform/09 Datasets/07 QuantConnect/03 Crypto/02 Sourcing.php
@@ -5,6 +5,6 @@
     <li>Bybit</li>
     <li>Coinbase</li>
     <li>Kraken</li>
-<ul>
+</ul>
 
 <? include(DOCS_RESOURCES."/live-trading/europe-region.html"); ?>

--- a/01 Cloud Platform/09 Datasets/07 QuantConnect/04 Crypto Futures/02 Sourcing.php
+++ b/01 Cloud Platform/09 Datasets/07 QuantConnect/04 Crypto Futures/02 Sourcing.php
@@ -3,6 +3,6 @@
     <li>Binance</li>
     <li>Bybit</li>
     <li>dYdX</li>
-<ul>
+</ul>
 
 <? include(DOCS_RESOURCES."/live-trading/europe-region.html"); ?>


### PR DESCRIPTION
## Summary

The source lists on Crypto and Crypto Futures > Sourcing ended with an opening `<ul>` tag instead of `</ul>`. The unclosed nested list swallowed the Europe region note added in #2665, rendering it indented under the last bullet.

## Test plan

- Render Datasets > QuantConnect > Crypto > Sourcing and Crypto Futures > Sourcing and confirm the region note sits flush with the intro paragraph instead of indented inside the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)