### PR TITLE
Regenerate the Create Live Algorithm API reference page

### DIFF
--- a/01 Cloud Platform/99 API Reference/07 Live Management/01 Create Live Algorithm/02 Request.html
+++ b/01 Cloud Platform/99 API Reference/07 Live Management/01 Create Live Algorithm/02 Request.html
@@ -867,33 +867,6 @@ Project, compile, and brokerage login information for deploying a live algorithm
 </table><table class="table qc-table">
 <thead>
 <tr>
-<th colspan="2"><code>ClearStreetBrokerageSettings</code> Model - Settings for using Clear Street as the brokerage for a live algorithm.</th>
-</tr>
-</thead>
-<tr>
-<td width="20%">id</td> <td> <code>string Enum<br/><i><sub>required</sub></i></code> <br/> Id of the module. Options : ['ClearStreetBrokerage']</td>
-</tr>
-<tr>
-<td width="20%">clearstreet-access-token</td> <td> <code>string<br/><i><sub>required</sub></i></code> <br/> Your Clear Street API access token.</td>
-</tr>
-<tr>
-<td width="20%">clearstreet-account-id</td> <td> <code>string<br/><i><sub>required</sub></i></code> <br/> Your Clear Street account ID, the numeric ID of the account the algorithm trades.</td>
-</tr>
-<tr>
-<td width="20%">Example</td>
-<td>
-<div class="cli section-example-container"><pre>
-{
-  "id": "ClearStreetBrokerage",
-  "clearstreet-access-token": "string",
-  "clearstreet-account-id": "string"
-}</pre>
-</div>
-</td>
-</tr>
-</table><table class="table qc-table">
-<thead>
-<tr>
 <th colspan="2"><code>PublicBrokerageSettings</code> Model - Settings for using Public as the brokerage for a live algorithm.</th>
 </tr>
 </thead>
@@ -914,6 +887,33 @@ Project, compile, and brokerage login information for deploying a live algorithm
   "id": "PublicBrokerage",
   "public-secret-key": "string",
   "public-account-number": "string"
+}</pre>
+</div>
+</td>
+</tr>
+</table><table class="table qc-table">
+<thead>
+<tr>
+<th colspan="2"><code>ClearStreetBrokerageSettings</code> Model - Settings for using Clear Street as the brokerage for a live algorithm.</th>
+</tr>
+</thead>
+<tr>
+<td width="20%">id</td> <td> <code>string Enum<br/><i><sub>required</sub></i></code> <br/> Id of the module. Options : ['ClearStreetBrokerage']</td>
+</tr>
+<tr>
+<td width="20%">clearstreet-access-token</td> <td> <code>string<br/><i><sub>required</sub></i></code> <br/> Your Clear Street API access token.</td>
+</tr>
+<tr>
+<td width="20%">clearstreet-account-id</td> <td> <code>string<br/><i><sub>required</sub></i></code> <br/> Your Clear Street account ID, the numeric ID of the account the algorithm trades.</td>
+</tr>
+<tr>
+<td width="20%">Example</td>
+<td>
+<div class="cli section-example-container"><pre>
+{
+  "id": "ClearStreetBrokerage",
+  "clearstreet-access-token": "string",
+  "clearstreet-account-id": "string"
 }</pre>
 </div>
 </td>


### PR DESCRIPTION
## Summary

Re-runs `python code-generators/API-Reference-Code-Generator.py`. The only change is that the `ClearStreetBrokerageSettings` and `PublicBrokerageSettings` tables swap places on Create Live Algorithm > Request, so the page matches the order the models appear in `QuantConnect-Platform-2.0.0.yaml`. No content changes.

## Test plan

- `python code-generators/API-Reference-Code-Generator.py` reports no further diff after this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)