### PR TITLE
Document the project file count quota

### DIFF
--- a/01 Cloud Platform/04 Organizations/03 Resources/11 File Quotas.php
+++ b/01 Cloud Platform/04 Organizations/03 Resources/11 File Quotas.php
@@ -1,0 +1,1 @@
+<?php include(DOCS_RESOURCES."/projects/files/quotas.html"); ?>

--- a/01 Cloud Platform/04 Organizations/03 Resources/11 File Size Quotas.php
+++ b/01 Cloud Platform/04 Organizations/03 Resources/11 File Size Quotas.php
@@ -1,1 +1,0 @@
-<?php include(DOCS_RESOURCES."/projects/files/size-quotas.html"); ?>

--- a/01 Cloud Platform/06 Projects/03 Files/10 Quotas.php
+++ b/01 Cloud Platform/06 Projects/03 Files/10 Quotas.php
@@ -1,0 +1,1 @@
+<?php include(DOCS_RESOURCES."/projects/files/quotas.html"); ?>

--- a/01 Cloud Platform/06 Projects/03 Files/10 Size Quotas.php
+++ b/01 Cloud Platform/06 Projects/03 Files/10 Size Quotas.php
@@ -1,1 +1,0 @@
-<?php include(DOCS_RESOURCES."/projects/files/size-quotas.html"); ?>

--- a/Resources/projects/files/quotas.html
+++ b/Resources/projects/files/quotas.html
@@ -1,38 +1,38 @@
-<p>The maximum file size and the maximum number of files you can have in a project depend on your organization's tier. The following table shows the quotas of each tier:</p>
+<p>The maximum number of files and the maximum file size you can have in a project depend on your organization's tier. The following table shows the quotas of each tier:</p>
 
 <table class="qc-table table" id='file-size-quota-table'>
    <thead>
       <tr>
          <th>Tier</th>
-         <th>Max File Size (KB)</th>
          <th>Max Files per Project</th>
+         <th>Max File Size (KB)</th>
       </tr>
    </thead>
    <tbody>
       <tr>
          <td>Free</td>
-         <td>32</td>
          <td>25</td>
+         <td>32</td>
       </tr>
       <tr>
          <td>Quant Researcher</td>
-         <td>64</td>
          <td>50</td>
+         <td>64</td>
       </tr>
       <tr>
          <td>Team</td>
-         <td>128</td>
          <td>75</td>
+         <td>128</td>
       </tr>
       <tr>
          <td>Trading Firm</td>
-         <td>256</td>
          <td>100</td>
+         <td>256</td>
       </tr>
       <tr>
          <td>Institution</td>
-         <td>256</td>
          <td>250</td>
+         <td>256</td>
       </tr>
    </tbody>
 </table>

--- a/Resources/projects/files/quotas.html
+++ b/Resources/projects/files/quotas.html
@@ -1,39 +1,45 @@
-<p>The maximum file size you can have in a project depends on your organization's tier. The following table shows the quota of each tier:</p>
+<p>The maximum file size and the maximum number of files you can have in a project depend on your organization's tier. The following table shows the quotas of each tier:</p>
 
 <table class="qc-table table" id='file-size-quota-table'>
    <thead>
       <tr>
          <th>Tier</th>
          <th>Max File Size (KB)</th>
+         <th>Max Files per Project</th>
       </tr>
    </thead>
    <tbody>
       <tr>
          <td>Free</td>
          <td>32</td>
+         <td>25</td>
       </tr>
       <tr>
          <td>Quant Researcher</td>
          <td>64</td>
+         <td>50</td>
       </tr>
       <tr>
          <td>Team</td>
          <td>128</td>
+         <td>75</td>
       </tr>
       <tr>
          <td>Trading Firm</td>
          <td>256</td>
+         <td>100</td>
       </tr>
       <tr>
          <td>Institution</td>
          <td>256</td>
+         <td>250</td>
       </tr>
    </tbody>
 </table>
 
 <style>
-#file-size-quota-table td:last-child, 
-#file-size-quota-table th:last-child {
+#file-size-quota-table td:not(:first-child), 
+#file-size-quota-table th:not(:first-child) {
     text-align: right;
 }
 </style>


### PR DESCRIPTION
Adds the per-project file count limit to the quota table and renames the pages, which no longer cover file size alone.

- `Resources/projects/files/size-quotas.html` -> `quotas.html`, with a new **Max Files per Project** column (25 / 50 / 75 / 100 / 250) and an updated intro sentence.
- `Projects > Files > Size Quotas` -> `Quotas`; `Organizations > Resources > File Size Quotas` -> `File Quotas`.

The Free tier value is the current backend limit of 20 rounded to the nearest 25, following the round-to-25s request. Please confirm it matches what was merged.

## Test plan

- Render both pages and check the table shows three columns with the numeric columns right aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)