### PR TITLE
Fix broken documentation links

### DIFF
--- a/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/02 Account Types.php
+++ b/01 Cloud Platform/10 Live Trading/02 Brokerages/02 Interactive Brokers/02 Account Types.php
@@ -12,7 +12,7 @@
 <p>You need to activate IBKR Mobile Authentication (IB Key) to deploy live algorithms with your brokerage account. After you open your account, follow the <a rel="nofollow" target="_blank" href="https://ibkr.info/node/2260">installation and activation instructions</a> on the IB website.</p>
 
 <h4>Paper Trading</h4>
-<p>IB supports paper trading. Follow the <a rel="nofollow" target="_blank" href="https://www.interactivebrokers.com/en/software/ptgstl/topics/papertrader.htm">Opening a Paper Trading Account</a> page in the IB documentation to set up your paper trading account.</p>
+<p>IB supports paper trading. Follow the <a rel="nofollow" target="_blank" href="https://www.ibkrguides.com/clientportal/papertradingaccount.htm">Paper Trading Account</a> page in the IB documentation to set up your paper trading account.</p>
 
 <? include(DOCS_RESOURCES."/data-feeds/ib-share-data-with-paper-trading.html"); ?>
 

--- a/05 Lean CLI/09 Live Trading/01 Brokerages/02 Interactive Brokers/03 Deploy Local Algorithms.php
+++ b/05 Lean CLI/09 Live Trading/01 Brokerages/02 Interactive Brokers/03 Deploy Local Algorithms.php
@@ -48,4 +48,4 @@ $requiresSubscription = true;
 include(DOCS_RESOURCES."/brokerages/cli-deployment/deploy-local-algorithms.php");
 ?>
 
-<p>To connect LEAN to an IB Gateway instance that runs on your desktop instead of the instance inside the LEAN container, see <a href="/docs/v2/lean-cli/live-trading/brokerages/interactive-brokers#04-Connect-to-an-External-IB-Gateway">Connect to an External IB Gateway</a>.</p>
+<p>To connect LEAN to an IB Gateway instance that runs on your desktop instead of the instance inside the LEAN container, see <a href="/docs/v2/lean-cli/live-trading/brokerages/interactive-brokers#04-Deploy-with-External-IB-Gateway">Deploy with External IB Gateway</a>.</p>

--- a/doc_anchors.py
+++ b/doc_anchors.py
@@ -48,6 +48,7 @@ SECTION_REPLACEMENTS = [
     ("Multi Alpha",  "Multi-Alpha"),
     ("Self Managed", "Self-Managed"),
     ("Sub Assistant", "Sub-Assistant"),
+    ("Sub Agent",     "Sub-Agent"),
     ("Margin3F",     "Margin%3F"),
     ("Greeks3F",     "Greeks%3F"),
     ("Smile3F",      "Smile%3F"),


### PR DESCRIPTION
## Summary

- IB **Account Types**: the paper trading guide at `interactivebrokers.com/en/software/ptgstl/topics/papertrader.htm` is gone. It now points to the `ibkrguides.com` Paper Trading Account page, the same host as the other IB guide links on that page.
- CLI **Deploy Local Algorithms**: the IB Gateway section was renamed, so the anchor and link text now match `04 Deploy with External IB Gateway`. This covers both the quantconnect.com and lean.io reports.
- `doc_anchors.py`: the `#08-Sub-Agent-Orchestration` report is a false positive — that id exists on the live page. The checker de-hyphenates a fragment before matching, so it looked for "08 Sub Agent Orchestration". Added `("Sub Agent", "Sub-Agent")` to `SECTION_REPLACEMENTS`, next to the existing `Sub Assistant` entry.

Resolves #2655

## Test plan

- [x] `python url_check.py` passes: 0 errors, 16 pre-existing warnings (bot-blocked 403s and flaky hosts).
- [ ] Confirm the IB paper trading and IB Gateway links resolve on the rendered pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)